### PR TITLE
feat: H2 DB 의존성 추가 (로컬 개발용)

### DIFF
--- a/blue-sol-backend/build.gradle
+++ b/blue-sol-backend/build.gradle
@@ -34,6 +34,8 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.15'
+
+	runtimeOnly 'com.h2database:h2'
 }
 
 tasks.named('test') {


### PR DESCRIPTION
## 🔍 개요
실제 DB 연결 전 단계에서 Spring Boot 애플리케이션이
정상적으로 기동되지 않는 문제를 해결하기 위해
로컬 개발 환경 전용으로 H2 DB 설정을 추가했다.

## ✨ 변경 사항
- H2 DB 의존성 추가
- 로컬 개발 환경에서 H2를 사용하도록 설정
- JPA 설정을 통해 애플리케이션 정상 기동 확인
- H2 Console 접근 가능 여부 확인

## 🧪 테스트
- [x] 로컬 테스트 완료
- [ ] API 테스트 완료
- [ ] 테스트 코드 작성 (해당 시)

## 📎 관련 이슈
Closes: #6

## ⚠️ 참고 사항
- 해당 설정은 로컬 개발 환경 전용임
- 운영 환경에는 영향 없음
- 실제 DB 연결 완료 후 제거 또는 비활성화 예정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 백엔드 인프라 개선으로 인메모리 및 임베디드 데이터베이스 지원 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->