### PR TITLE
feat: 온보딩 관심사 등록 api 구현

### DIFF
--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/interest/controller/InterestController.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/interest/controller/InterestController.java
@@ -1,0 +1,39 @@
+package com.solif.backend.domain.interest.controller;
+
+import com.solif.backend.domain.interest.dto.InterestRequest;
+import com.solif.backend.domain.interest.dto.InterestResponse;
+import com.solif.backend.domain.interest.dto.InterestSuccessCode;
+import com.solif.backend.domain.interest.service.InterestService;
+import com.solif.backend.global.common.response.ResponseFactory;
+import com.solif.backend.global.common.response.SuccessResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "관심사", description = "관심사 등록 API")
+@RestController
+@RequestMapping("/api/interests")
+@RequiredArgsConstructor
+public class InterestController {
+
+    private final InterestService interestService;
+
+    @Operation(
+            summary = "관심사 등록",
+            description = "사용자의 관심사를 등록합니다. 최소 2개 이상 선택해야 합니다.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @PostMapping
+    public ResponseEntity<SuccessResponse<InterestResponse>> registerInterests(
+            @AuthenticationPrincipal Long userId,
+            @Valid @RequestBody InterestRequest request
+    ) {
+        InterestResponse response = interestService.registerInterests(userId, request);
+        return ResponseFactory.success(InterestSuccessCode.INTEREST_REGISTER_SUCCESS, response);
+    }
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/interest/controller/InterestController.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/interest/controller/InterestController.java
@@ -1,9 +1,11 @@
 package com.solif.backend.domain.interest.controller;
 
+import com.solif.backend.domain.auth.exception.AuthErrorCode;
 import com.solif.backend.domain.interest.dto.InterestRequest;
 import com.solif.backend.domain.interest.dto.InterestResponse;
 import com.solif.backend.domain.interest.dto.InterestSuccessCode;
 import com.solif.backend.domain.interest.service.InterestService;
+import com.solif.backend.global.common.exception.CustomException;
 import com.solif.backend.global.common.response.ResponseFactory;
 import com.solif.backend.global.common.response.SuccessResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -33,6 +35,11 @@ public class InterestController {
             @AuthenticationPrincipal Long userId,
             @Valid @RequestBody InterestRequest request
     ) {
+        // userId NULL 체크 추가
+        if (userId == null) {
+            throw new CustomException(AuthErrorCode.UNAUTHORIZED);
+        }
+
         InterestResponse response = interestService.registerInterests(userId, request);
         return ResponseFactory.success(InterestSuccessCode.INTEREST_REGISTER_SUCCESS, response);
     }

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/interest/dto/InterestRequest.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/interest/dto/InterestRequest.java
@@ -1,0 +1,20 @@
+package com.solif.backend.domain.interest.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@Schema(description = "관심사 등록 요청")
+public class InterestRequest {
+
+    @NotEmpty(message = "관심사를 선택해주세요.")
+    @Size(min = 2, message = "관심사는 최소 2개 이상 선택해야 합니다.")
+    @Schema(description = "관심사 카테고리 목록", example = "[\"봉사활동\", \"독서\", \"금융\"]")
+    private List<String> categoryNames;
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/interest/dto/InterestResponse.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/interest/dto/InterestResponse.java
@@ -1,0 +1,26 @@
+package com.solif.backend.domain.interest.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+@Schema(description = "관심사 등록 응답")
+public class InterestResponse {
+
+    @Schema(description = "등록된 관심사 개수", example = "3")
+    private int count;
+
+    @Schema(description = "등록된 관심사 목록", example = "[\"봉사활동\", \"독서\", \"금융\"]")
+    private List<String> categoryNames;
+
+    public static InterestResponse of(int count, List<String> categoryNames) {
+        return InterestResponse.builder()
+                .count(count)
+                .categoryNames(categoryNames)
+                .build();
+    }
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/interest/dto/InterestSuccessCode.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/interest/dto/InterestSuccessCode.java
@@ -9,7 +9,7 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum InterestSuccessCode implements SuccessCode {
 
-    INTEREST_REGISTER_SUCCESS(HttpStatus.OK, "INTEREST_001", "관심사 등록에 성공했습니다.");
+    INTEREST_REGISTER_SUCCESS(HttpStatus.OK, "INTEREST_S001", "관심사 등록에 성공했습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/interest/dto/InterestSuccessCode.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/interest/dto/InterestSuccessCode.java
@@ -1,0 +1,17 @@
+package com.solif.backend.domain.interest.dto;
+
+import com.solif.backend.global.common.response.SuccessCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum InterestSuccessCode implements SuccessCode {
+
+    INTEREST_REGISTER_SUCCESS(HttpStatus.OK, "INTEREST_001", "관심사 등록에 성공했습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/interest/entity/UserInterest.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/interest/entity/UserInterest.java
@@ -1,0 +1,33 @@
+package com.solif.backend.domain.interest.entity;
+
+import com.solif.backend.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "user_interest")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserInterest {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "interest_id")
+    private Long interestId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(name = "category_name", nullable = false, length = 50)
+    private String categoryName;
+
+    @Builder
+    public UserInterest(User user, String categoryName) {
+        this.user = user;
+        this.categoryName = categoryName;
+    }
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/interest/exception/InterestErrorCode.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/interest/exception/InterestErrorCode.java
@@ -1,0 +1,18 @@
+package com.solif.backend.domain.interest.exception;
+
+import com.solif.backend.global.common.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum InterestErrorCode implements ErrorCode {
+
+    INVALID_CATEGORY(HttpStatus.BAD_REQUEST, "INTEREST_001", "유효하지 않은 관심사 카테고리입니다."),
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "INTEREST_002", "사용자를 찾을 수 없습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/interest/repository/UserInterestRepository.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/interest/repository/UserInterestRepository.java
@@ -1,0 +1,15 @@
+package com.solif.backend.domain.interest.repository;
+
+import com.solif.backend.domain.interest.entity.UserInterest;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface UserInterestRepository extends JpaRepository<UserInterest, Long> {
+    
+    // 사용자의 기존 관심사 삭제 (덮어쓰기용)
+    void deleteAllByUser_UserId(Long userId);
+    
+    // 사용자의 관심사 조회
+    List<UserInterest> findAllByUser_UserId(Long userId);
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/interest/service/InterestService.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/interest/service/InterestService.java
@@ -1,0 +1,65 @@
+package com.solif.backend.domain.interest.service;
+
+import com.solif.backend.domain.interest.dto.InterestRequest;
+import com.solif.backend.domain.interest.dto.InterestResponse;
+import com.solif.backend.domain.interest.entity.UserInterest;
+import com.solif.backend.domain.interest.exception.InterestErrorCode;
+import com.solif.backend.domain.interest.repository.UserInterestRepository;
+import com.solif.backend.domain.user.entity.User;
+import com.solif.backend.domain.user.repository.UserRepository;
+import com.solif.backend.global.common.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Set;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class InterestService {
+
+    private final UserInterestRepository userInterestRepository;
+    private final UserRepository userRepository;
+
+    // 유효한 카테고리 목록
+    private static final Set<String> VALID_CATEGORIES = Set.of(
+            "봉사활동", "여행", "축구", "농구", "야구",
+            "문화생활", "독서", "스터디", "금융"
+    );
+
+    @Transactional
+    public InterestResponse registerInterests(Long userId, InterestRequest request) {
+        // 1. 사용자 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(InterestErrorCode.USER_NOT_FOUND));
+
+        // 2. 카테고리 유효성 검증
+        validateCategories(request.getCategoryNames());
+
+        // 3. 기존 관심사 삭제 (덮어쓰기)
+        userInterestRepository.deleteAllByUser_UserId(userId);
+
+        // 4. 새 관심사 저장
+        List<UserInterest> interests = request.getCategoryNames().stream()
+                .map(categoryName -> UserInterest.builder()
+                        .user(user)
+                        .categoryName(categoryName)
+                        .build())
+                .toList();
+
+        userInterestRepository.saveAll(interests);
+
+        // 5. 응답 반환
+        return InterestResponse.of(interests.size(), request.getCategoryNames());
+    }
+
+    private void validateCategories(List<String> categoryNames) {
+        for (String category : categoryNames) {
+            if (!VALID_CATEGORIES.contains(category)) {
+                throw new CustomException(InterestErrorCode.INVALID_CATEGORY);
+            }
+        }
+    }
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/interest/service/InterestService.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/interest/service/InterestService.java
@@ -35,13 +35,18 @@ public class InterestService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(InterestErrorCode.USER_NOT_FOUND));
 
-        // 2. 카테고리 유효성 검증
+        // 2. 중복 제거 후 카테고리 목록 생성
+        List<String> uniqueCategories = request.getCategoryNames().stream()
+                .distinct()
+                .toList();
+
+        // 3. 카테고리 유효성 검증
         validateCategories(request.getCategoryNames());
 
-        // 3. 기존 관심사 삭제 (덮어쓰기)
+        // 4. 기존 관심사 삭제 (덮어쓰기)
         userInterestRepository.deleteAllByUser_UserId(userId);
 
-        // 4. 새 관심사 저장
+        // 5. 새 관심사 저장
         List<UserInterest> interests = request.getCategoryNames().stream()
                 .map(categoryName -> UserInterest.builder()
                         .user(user)
@@ -51,8 +56,8 @@ public class InterestService {
 
         userInterestRepository.saveAll(interests);
 
-        // 5. 응답 반환
-        return InterestResponse.of(interests.size(), request.getCategoryNames());
+        // 6. 응답 반환
+        return InterestResponse.of(interests.size(), uniqueCategories);
     }
 
     private void validateCategories(List<String> categoryNames) {


### PR DESCRIPTION
## 🔍 개요
온보딩 첫 단계에서 사용자의 관심사를 등록하는 API를 구현

## ✨ 변경 사항
- 'POST /api/interests' - 관심사 등록 API
- 최소 2개 이상 선택 검증
- 유효한 카테고리만 허용 (봉사활동, 여행, 축구, 농구, 야구, 문화생활, 독서, 스터디, 금융)
- 기존 관심사 있으면 덮어쓰기 처리

## 🧪 테스트
- [x] 로컬 테스트 완료
- [x] API 테스트 완료
- [ ] 테스트 코드 작성 (해당 시)

## 📎 관련 이슈
Closes: #26 

## ⚠️ 참고 사항
- 인증 필요 (Bearer Token)
- 관심사 최소 2개 이상 선택 필수


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 사용자 관심사 등록 기능 추가
  * POST /api/interests로 관심사 카테고리 선택 및 등록 가능
  * 최소 2개 이상 관심사 선택 필수(입력 검증 포함)
  * 기존 관심사는 등록 시 덮어써 자동 업데이트됨
  * 등록 성공 시 카운트 및 선택한 카테고리 목록 반환
  * 유효하지 않은 카테고리/사용자 미존재 시 명확한 에러 코드 제공

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->