### PR TITLE
feat: 통합 게시글 조회 API 구현 (목록 + 상세)

### DIFF
--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/board/code/BoardErrorCode.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/board/code/BoardErrorCode.java
@@ -1,0 +1,18 @@
+package com.solif.backend.domain.board.code;
+
+import com.solif.backend.global.common.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum BoardErrorCode implements ErrorCode {
+
+    BOARD_NOT_FOUND(HttpStatus.NOT_FOUND, "BOARD_001", "게시판을 찾을 수 없습니다."),
+    INVALID_BOARD_TYPE(HttpStatus.BAD_REQUEST, "BOARD_002", "유효하지 않은 게시판 타입입니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/comment/dto/PostCommentCount.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/comment/dto/PostCommentCount.java
@@ -1,0 +1,11 @@
+package com.solif.backend.domain.comment.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class PostCommentCount {
+    private Long postId;
+    private Long commentCount;
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/comment/repository/CommentRepository.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/comment/repository/CommentRepository.java
@@ -9,4 +9,7 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     // 게시글별 댓글 목록 조회
     List<Comment> findByPost_PostIdOrderByCreatedAtAsc(Long postId);
+
+    // 게시글별 댓글 수 조회
+    Integer countByPost_PostId(Long postId);
 }

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/comment/repository/CommentRepository.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/comment/repository/CommentRepository.java
@@ -11,5 +11,5 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     List<Comment> findByPost_PostIdOrderByCreatedAtAsc(Long postId);
 
     // 게시글별 댓글 수 조회
-    Integer countByPost_PostId(Long postId);
+    Long countByPost_PostId(Long postId);
 }

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/comment/repository/CommentRepository.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/comment/repository/CommentRepository.java
@@ -2,8 +2,11 @@ package com.solif.backend.domain.comment.repository;
 
 import com.solif.backend.domain.comment.entity.Comment;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Map;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
@@ -12,4 +15,10 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     // 게시글별 댓글 수 조회
     Long countByPost_PostId(Long postId);
+
+    // 여러 게시글의 댓글 수 한 번에 조회
+    @Query("SELECT c.post.postId, COUNT(c) FROM Comment c " +
+            "WHERE c.post.postId IN :postIds " +
+            "GROUP BY c.post.postId")
+    Map<Long, Long> countByPostIds(@Param("postIds") List<Long> postIds);
 }

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/comment/repository/CommentRepository.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/comment/repository/CommentRepository.java
@@ -1,5 +1,6 @@
 package com.solif.backend.domain.comment.repository;
 
+import com.solif.backend.domain.comment.dto.PostCommentCount;
 import com.solif.backend.domain.comment.entity.Comment;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -17,8 +18,9 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     Long countByPost_PostId(Long postId);
 
     // 여러 게시글의 댓글 수 한 번에 조회
-    @Query("SELECT c.post.postId, COUNT(c) FROM Comment c " +
+    @Query("SELECT new com.solif.backend.domain.comment.dto.PostCommentCount(c.post.postId, COUNT(c)) " +
+            "FROM Comment c " +
             "WHERE c.post.postId IN :postIds " +
             "GROUP BY c.post.postId")
-    Map<Long, Long> countByPostIds(@Param("postIds") List<Long> postIds);
+    List<PostCommentCount> countByPostIds(@Param("postIds") List<Long> postIds);
 }

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/post/code/PostErrorCode.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/post/code/PostErrorCode.java
@@ -1,0 +1,19 @@
+package com.solif.backend.domain.post.code;
+
+import com.solif.backend.global.common.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum PostErrorCode implements ErrorCode {
+
+    POST_NOT_FOUND(HttpStatus.NOT_FOUND, "POST_001", "게시글을 찾을 수 없습니다."),
+    UNAUTHORIZED_POST_ACCESS(HttpStatus.FORBIDDEN, "POST_002", "게시글에 대한 권한이 없습니다."),
+    DELETED_POST(HttpStatus.GONE, "POST_003", "삭제된 게시글입니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/post/code/PostSuccessCode.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/post/code/PostSuccessCode.java
@@ -1,0 +1,21 @@
+package com.solif.backend.domain.post.code;
+
+import com.solif.backend.global.common.response.SuccessCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum PostSuccessCode implements SuccessCode {
+
+    POST_LIST_SUCCESS(HttpStatus.OK, "POST_200", "게시글 목록 조회에 성공했습니다."),
+    POST_DETAIL_SUCCESS(HttpStatus.OK, "POST_201", "게시글 상세 조회에 성공했습니다."),
+    POST_CREATE_SUCCESS(HttpStatus.CREATED, "POST_202", "게시글 작성에 성공했습니다."),
+    POST_UPDATE_SUCCESS(HttpStatus.OK, "POST_203", "게시글 수정에 성공했습니다."),
+    POST_DELETE_SUCCESS(HttpStatus.OK, "POST_204", "게시글 삭제에 성공했습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/post/controller/PostController.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/post/controller/PostController.java
@@ -1,0 +1,49 @@
+package com.solif.backend.domain.post.controller;
+
+import com.solif.backend.domain.post.dto.PostDetailResponse;
+import com.solif.backend.domain.post.dto.PostListResponse;
+import com.solif.backend.domain.post.code.PostSuccessCode;
+import com.solif.backend.domain.post.entity.PostCategory;
+import com.solif.backend.domain.post.service.PostService;
+import com.solif.backend.global.common.response.ResponseFactory;
+import com.solif.backend.global.common.response.SuccessResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "게시글", description = "게시글 API")
+@RestController
+@RequestMapping("/api/v1/posts")
+@RequiredArgsConstructor
+public class PostController {
+
+    private final PostService postService;
+
+    @Operation(summary = "게시글 목록 조회", description = "게시판별 게시글 목록을 페이징하여 조회합니다. 카테고리 필터링 가능합니다.")
+    @GetMapping
+    public ResponseEntity<SuccessResponse<Slice<PostListResponse>>> getPosts(
+            @RequestParam Long boardId,
+            @RequestParam(required = false) PostCategory category,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size
+    ) {
+        Pageable pageable = PageRequest.of(page, size, Sort.by("createdAt").descending());
+        Slice<PostListResponse> posts = postService.getPosts(boardId, category, pageable);
+        return ResponseFactory.success(PostSuccessCode.POST_LIST_SUCCESS, posts);
+    }
+
+    @Operation(summary = "게시글 상세 조회", description = "게시글 상세 내용을 조회합니다. 조회수가 1 증가합니다.")
+    @GetMapping("/{postId}")
+    public ResponseEntity<SuccessResponse<PostDetailResponse>> getPostDetail(
+            @PathVariable Long postId
+    ) {
+        PostDetailResponse post = postService.getPostDetail(postId);
+        return ResponseFactory.success(PostSuccessCode.POST_DETAIL_SUCCESS, post);
+    }
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/post/dto/PostDetailResponse.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/post/dto/PostDetailResponse.java
@@ -1,0 +1,60 @@
+package com.solif.backend.domain.post.dto;
+
+import com.solif.backend.domain.post.entity.Post;
+import com.solif.backend.domain.post.entity.PostCategory;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@Schema(description = "게시글 상세 응답")
+public class PostDetailResponse {
+
+    @Schema(description = "게시글 ID", example = "1")
+    private Long postId;
+
+    @Schema(description = "게시판 ID", example = "1")
+    private Long boardId;
+
+    @Schema(description = "카테고리", example = "STUDY", nullable = true)
+    private PostCategory postCategory;
+
+    @Schema(description = "게시글 제목", example = "부모님과 고등학교 문제로 다투었어요")
+    private String postTitle;
+
+    @Schema(description = "게시글 내용")
+    private String postContent;
+
+    @Schema(description = "작성자 ID (익명일 경우 null)", example = "1", nullable = true)
+    private Long authorId;
+
+    @Schema(description = "작성자 이름 (익명일 경우 '익명')", example = "홍길동")
+    private String authorName;
+
+    @Schema(description = "조회수", example = "43")
+    private Integer viewCount;
+
+    @Schema(description = "작성 일시", example = "2026-01-28T14:30:00")
+    private LocalDateTime createdAt;
+
+    @Schema(description = "수정 일시", example = "2026-01-28T15:00:00", nullable = true)
+    private LocalDateTime updatedAt;
+
+    public static PostDetailResponse from(Post post, boolean isAnonymous) {
+        return PostDetailResponse.builder()
+                .postId(post.getPostId())
+                .boardId(post.getBoard().getBoardId())
+                .postCategory(post.getPostCategory())
+                .postTitle(post.getPostTitle())
+                .postContent(post.getPostContent())
+                .authorId(isAnonymous ? null : post.getAuthor().getUserId())
+                .authorName(isAnonymous ? "익명" : post.getAuthor().getName())
+                .viewCount(post.getViewCount())
+                .createdAt(post.getCreatedAt())
+                .updatedAt(post.getUpdatedAt())
+                .build();
+    }
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/post/dto/PostDetailResponse.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/post/dto/PostDetailResponse.java
@@ -37,13 +37,16 @@ public class PostDetailResponse {
     @Schema(description = "조회수", example = "43")
     private Integer viewCount;
 
+    @Schema(description = "댓글 수", example = "15")
+    private Integer commentCount;
+
     @Schema(description = "작성 일시", example = "2026-01-28T14:30:00")
     private LocalDateTime createdAt;
 
     @Schema(description = "수정 일시", example = "2026-01-28T15:00:00", nullable = true)
     private LocalDateTime updatedAt;
 
-    public static PostDetailResponse from(Post post, boolean isAnonymous) {
+    public static PostDetailResponse from(Post post, Integer commentCount, boolean isAnonymous) {
         return PostDetailResponse.builder()
                 .postId(post.getPostId())
                 .boardId(post.getBoard().getBoardId())
@@ -53,6 +56,7 @@ public class PostDetailResponse {
                 .authorId(isAnonymous ? null : post.getAuthor().getUserId())
                 .authorName(isAnonymous ? "익명" : post.getAuthor().getName())
                 .viewCount(post.getViewCount())
+                .commentCount(commentCount)
                 .createdAt(post.getCreatedAt())
                 .updatedAt(post.getUpdatedAt())
                 .build();

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/post/dto/PostDetailResponse.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/post/dto/PostDetailResponse.java
@@ -38,7 +38,7 @@ public class PostDetailResponse {
     private Integer viewCount;
 
     @Schema(description = "댓글 수", example = "15")
-    private Integer commentCount;
+    private Long commentCount;
 
     @Schema(description = "작성 일시", example = "2026-01-28T14:30:00")
     private LocalDateTime createdAt;
@@ -46,7 +46,7 @@ public class PostDetailResponse {
     @Schema(description = "수정 일시", example = "2026-01-28T15:00:00", nullable = true)
     private LocalDateTime updatedAt;
 
-    public static PostDetailResponse from(Post post, Integer commentCount, boolean isAnonymous) {
+    public static PostDetailResponse from(Post post, Long commentCount, boolean isAnonymous) {
         return PostDetailResponse.builder()
                 .postId(post.getPostId())
                 .boardId(post.getBoard().getBoardId())

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/post/dto/PostListResponse.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/post/dto/PostListResponse.java
@@ -1,0 +1,52 @@
+package com.solif.backend.domain.post.dto;
+
+import com.solif.backend.domain.post.entity.Post;
+import com.solif.backend.domain.post.entity.PostCategory;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@Schema(description = "게시글 목록 응답")
+public class PostListResponse {
+
+    @Schema(description = "게시글 ID", example = "1")
+    private Long postId;
+
+    @Schema(description = "게시판 ID", example = "1")
+    private Long boardId;
+
+    @Schema(description = "카테고리", example = "STUDY", nullable = true)
+    private PostCategory postCategory;
+
+    @Schema(description = "게시글 제목", example = "부모님과 고등학교 문제로 다투었어요")
+    private String postTitle;
+
+    @Schema(description = "작성자 이름 (익명일 경우 '익명')", example = "홍길동")
+    private String authorName;
+
+    @Schema(description = "조회수", example = "42")
+    private Integer viewCount;
+
+    @Schema(description = "댓글 수", example = "10")
+    private Integer commentCount;
+
+    @Schema(description = "작성 일시", example = "2026-01-28T14:30:00")
+    private LocalDateTime createdAt;
+
+    public static PostListResponse from(Post post, Integer commentCount, boolean isAnonymous) {
+        return PostListResponse.builder()
+                .postId(post.getPostId())
+                .boardId(post.getBoard().getBoardId())
+                .postCategory(post.getPostCategory())
+                .postTitle(post.getPostTitle())
+                .authorName(isAnonymous ? "익명" : post.getAuthor().getName())
+                .viewCount(post.getViewCount())
+                .commentCount(commentCount)
+                .createdAt(post.getCreatedAt())
+                .build();
+    }
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/post/dto/PostListResponse.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/post/dto/PostListResponse.java
@@ -32,12 +32,12 @@ public class PostListResponse {
     private Integer viewCount;
 
     @Schema(description = "댓글 수", example = "10")
-    private Integer commentCount;
+    private Long commentCount;
 
     @Schema(description = "작성 일시", example = "2026-01-28T14:30:00")
     private LocalDateTime createdAt;
 
-    public static PostListResponse from(Post post, Integer commentCount, boolean isAnonymous) {
+    public static PostListResponse from(Post post, Long commentCount, boolean isAnonymous) {
         return PostListResponse.builder()
                 .postId(post.getPostId())
                 .boardId(post.getBoard().getBoardId())

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/post/entity/PostCategory.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/post/entity/PostCategory.java
@@ -11,7 +11,11 @@ public enum PostCategory {
     STUDY("학업"),
     JOB("취업"),
     MONEY("금전"),
-    ETC("기타");
+    ETC("기타"),
+
+    // 장학재단 소식 카테고리
+    NOTICE("운영공지"),
+    PROGRAM("프로그램");
 
     private final String description;
 }

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/post/service/PostService.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/post/service/PostService.java
@@ -18,6 +18,9 @@ import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+import java.util.Map;
+
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -48,11 +51,21 @@ public class PostService {
         // 익명 여부 판단 (boardId가 2면 고민상담 = 익명)
         boolean isAnonymous = boardId == 2L;
 
+        // N+1 해결: 모든 postId를 모아서 한 번에 댓글 수 조회
+        List<Long> postIds = posts.getContent()
+                .stream()
+                .map(Post::getPostId)
+                .toList();
+
+        // 한 번의 쿼리로 모든 게시글의 댓글 수 조회
+        Map<Long, Long> commentCounts = commentRepository.countByPostIds(postIds);
+
         // Post -> PostListResponse 변환
         return posts.map(post -> {
-            Long commentCount = commentRepository.countByPost_PostId(post.getPostId());
+            Long commentCount = commentCounts.getOrDefault(post.getPostId(), 0L);
             return PostListResponse.from(post, commentCount, isAnonymous);
         });
+
     }
 
     // 게시글 상세 조회 (조회수 증가)

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/post/service/PostService.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/post/service/PostService.java
@@ -3,6 +3,7 @@ package com.solif.backend.domain.post.service;
 import com.solif.backend.domain.board.code.BoardErrorCode;
 import com.solif.backend.domain.board.entity.Board;
 import com.solif.backend.domain.board.repository.BoardRepository;
+import com.solif.backend.domain.comment.dto.PostCommentCount;
 import com.solif.backend.domain.comment.repository.CommentRepository;
 import com.solif.backend.domain.post.dto.PostDetailResponse;
 import com.solif.backend.domain.post.dto.PostListResponse;
@@ -20,6 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -57,15 +59,21 @@ public class PostService {
                 .map(Post::getPostId)
                 .toList();
 
-        // 한 번의 쿼리로 모든 게시글의 댓글 수 조회
-        Map<Long, Long> commentCounts = commentRepository.countByPostIds(postIds);
+        // 빈 리스트 처리: postIds가 비어있으면 빈 Map 반환
+        Map<Long, Long> commentCounts = postIds.isEmpty()
+                ? Map.of()
+                : commentRepository.countByPostIds(postIds)
+                .stream()
+                .collect(Collectors.toMap(
+                        PostCommentCount::getPostId,
+                        PostCommentCount::getCommentCount
+                ));
 
         // Post -> PostListResponse 변환
         return posts.map(post -> {
             Long commentCount = commentCounts.getOrDefault(post.getPostId(), 0L);
             return PostListResponse.from(post, commentCount, isAnonymous);
         });
-
     }
 
     // 게시글 상세 조회 (조회수 증가)

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/post/service/PostService.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/post/service/PostService.java
@@ -1,0 +1,79 @@
+package com.solif.backend.domain.post.service;
+
+import com.solif.backend.domain.board.entity.Board;
+import com.solif.backend.domain.board.repository.BoardRepository;
+import com.solif.backend.domain.comment.repository.CommentRepository;
+import com.solif.backend.domain.post.dto.PostDetailResponse;
+import com.solif.backend.domain.post.dto.PostListResponse;
+import com.solif.backend.domain.post.entity.Post;
+import com.solif.backend.domain.post.entity.PostCategory;
+import com.solif.backend.domain.post.code.PostErrorCode;
+import com.solif.backend.domain.post.repository.PostRepository;
+import com.solif.backend.global.common.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PostService {
+
+    private final PostRepository postRepository;
+    private final BoardRepository boardRepository;
+    private final CommentRepository commentRepository;
+
+    // 게시글 목록 조회
+    public Slice<PostListResponse> getPosts(Long boardId, PostCategory category, Pageable pageable) {
+        log.info("게시글 목록 조회 - boardId: {}, category: {}", boardId, category);
+
+        // Board 존재 확인
+        Board board = boardRepository.findById(boardId)
+                .orElseThrow(() -> new CustomException(PostErrorCode.POST_NOT_FOUND));
+
+        // 카테고리 있으면 카테고리별 조회, 없으면 전체 조회
+        Slice<Post> posts;
+        if (category != null) {
+            posts = postRepository.findByBoard_BoardIdAndPostCategoryAndDeletedAtIsNull(
+                    boardId, category, pageable);
+        } else {
+            posts = postRepository.findByBoard_BoardIdAndDeletedAtIsNull(boardId, pageable);
+        }
+
+        // 익명 여부 판단 (boardId가 2면 고민상담 = 익명)
+        boolean isAnonymous = boardId == 2L;
+
+        // Post -> PostListResponse 변환
+        return posts.map(post -> {
+            Integer commentCount = commentRepository.countByPost_PostId(post.getPostId());
+            return PostListResponse.from(post, commentCount, isAnonymous);
+        });
+    }
+
+    // 게시글 상세 조회 (조회수 증가)
+    @Transactional
+    public PostDetailResponse getPostDetail(Long postId) {
+        log.info("게시글 상세 조회 - postId: {}", postId);
+
+        // 게시글 조회
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new CustomException(PostErrorCode.POST_NOT_FOUND));
+
+        // 삭제된 게시글 체크
+        if (post.isDeleted()) {
+            throw new CustomException(PostErrorCode.DELETED_POST);
+        }
+
+        // 조회수 증가
+        post.increaseViewCount();
+
+        // 익명 여부 판단
+        boolean isAnonymous = post.getBoard().getBoardId() == 2L;
+
+        return PostDetailResponse.from(post, isAnonymous);
+    }
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/post/service/PostService.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/post/service/PostService.java
@@ -1,5 +1,6 @@
 package com.solif.backend.domain.post.service;
 
+import com.solif.backend.domain.board.code.BoardErrorCode;
 import com.solif.backend.domain.board.entity.Board;
 import com.solif.backend.domain.board.repository.BoardRepository;
 import com.solif.backend.domain.comment.repository.CommentRepository;
@@ -33,7 +34,7 @@ public class PostService {
 
         // Board 존재 확인
         Board board = boardRepository.findById(boardId)
-                .orElseThrow(() -> new CustomException(PostErrorCode.POST_NOT_FOUND));
+                .orElseThrow(() -> new CustomException(BoardErrorCode.BOARD_NOT_FOUND));
 
         // 카테고리 있으면 카테고리별 조회, 없으면 전체 조회
         Slice<Post> posts;
@@ -49,7 +50,7 @@ public class PostService {
 
         // Post -> PostListResponse 변환
         return posts.map(post -> {
-            Integer commentCount = commentRepository.countByPost_PostId(post.getPostId());
+            Long commentCount = commentRepository.countByPost_PostId(post.getPostId());
             return PostListResponse.from(post, commentCount, isAnonymous);
         });
     }
@@ -75,7 +76,7 @@ public class PostService {
         boolean isAnonymous = post.getBoard().getBoardId() == 2L;
 
         // 댓글 수 조회
-        Integer commentCount = commentRepository.countByPost_PostId(postId);
+        Long commentCount = commentRepository.countByPost_PostId(postId);
 
         return PostDetailResponse.from(post, commentCount, isAnonymous);
     }

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/post/service/PostService.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/post/service/PostService.java
@@ -74,6 +74,9 @@ public class PostService {
         // 익명 여부 판단
         boolean isAnonymous = post.getBoard().getBoardId() == 2L;
 
-        return PostDetailResponse.from(post, isAnonymous);
+        // 댓글 수 조회
+        Integer commentCount = commentRepository.countByPost_PostId(postId);
+
+        return PostDetailResponse.from(post, commentCount, isAnonymous);
     }
 }

--- a/blue-sol-backend/src/main/java/com/solif/backend/global/config/SecurityConfig.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/global/config/SecurityConfig.java
@@ -57,6 +57,8 @@ public class SecurityConfig {
                         .requestMatchers(
                                 "/api/auth/signup",       // 회원가입
                                 "/api/auth/login",        // 로그인
+                                "/api/v1/posts",          // 게시글 목록 조회
+                                "/api/v1/posts/*",        // 게시글 상세 조회
                                 "/error",                 // Spring Boot 에러 핸들러
                                 "/swagger-ui/**",         // Swagger UI
                                 "/v3/api-docs/**",        // API 문서


### PR DESCRIPTION
## 🔍 개요
통합 게시판 게시글 조회 기능을 구현했습니다.
게시글 목록 조회와 상세 조회 API를 포함하며, 댓글 수 및 조회수 증가 로직을 함께 처리합니다.

## ✨ 변경 사항
- 게시글 목록 조회 API 구현 (페이지네이션 기반 조회)
- 게시글 상세 조회 API 구현
- 게시글 상세 조회 시 조회수 증가 처리
- 게시글 조회 응답에 댓글 수 포함
- 게시판 카테고리(PostCategory) 확장

## 🧪 테스트
- [x] 로컬 테스트 완료
- [ ] API 테스트 완료
- [ ] 테스트 코드 작성 (해당 시)

## 📎 관련 이슈
Closes: #31 

## ⚠️ 참고 사항
- 게시글 상세 조회 시 삭제된 게시글은 예외 처리됨
- 게시글 목록/상세 조회는 인증 없이 접근 가능하도록 Security 설정 추가


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 게시글 목록 및 상세 조회 API 추가(페이지네이션, 카테고리 필터 포함)
  * 게시글 상세 조회 시 조회수 자동 증가
  * 게시글 목록에 게시글별 댓글 수 동시 표시(일괄 집계)
  * 특정 게시판 익명 표시 지원 및 익명일 때 작성자 정보 마스킹
  * 게시글 카테고리 확대(운영공지, 프로그램 추가)
  * 성공/오류 코드와 한글 메시지 추가
  * 로그인 없이 게시글 목록·상세 열람 허용

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->