### PR TITLE
feat: 홈화면 목표 및 목표 개수 불러오기 api 구현

### DIFF
--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/goal/controller/GoalController.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/goal/controller/GoalController.java
@@ -1,0 +1,52 @@
+package com.solif.backend.domain.goal.controller;
+
+import com.solif.backend.domain.goal.dto.GoalCountResponse;
+import com.solif.backend.domain.goal.dto.GoalFirstResponse;
+import com.solif.backend.domain.goal.dto.GoalSuccessCode;
+import com.solif.backend.domain.goal.service.GoalService;
+import com.solif.backend.global.common.response.ResponseFactory;
+import com.solif.backend.global.common.response.SuccessResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "홈 화면 목표", description = "나의 목표 API")
+@RestController
+@RequestMapping("/api/goals")
+@RequiredArgsConstructor
+public class GoalController {
+
+    private final GoalService goalService;
+
+    @Operation(
+            summary = "첫 번째 목표 조회",
+            description = "온보딩에서 작성한 첫 번째 목표를 조회합니다.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @GetMapping("/first")
+    public ResponseEntity<SuccessResponse<GoalFirstResponse>> getFirstGoal(
+            @AuthenticationPrincipal Long userId
+    ) {
+        GoalFirstResponse response = goalService.getFirstGoal(userId);
+        return ResponseFactory.success(GoalSuccessCode.GOAL_FIRST_READ_SUCCESS, response);
+    }
+
+    @Operation(
+            summary = "목표 개수 조회",
+            description = "작성한 목표 개수와 최대 목표 개수를 조회합니다.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @GetMapping("/count")
+    public ResponseEntity<SuccessResponse<GoalCountResponse>> getGoalCount(
+            @AuthenticationPrincipal Long userId
+    ) {
+        GoalCountResponse response = goalService.getGoalCount(userId);
+        return ResponseFactory.success(GoalSuccessCode.GOAL_COUNT_READ_SUCCESS, response);
+    }
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/goal/controller/GoalController.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/goal/controller/GoalController.java
@@ -39,7 +39,7 @@ public class GoalController {
 
     @Operation(
             summary = "목표 개수 조회",
-            description = "작성한 목표 개수와 최대 목표 개수를 조회합니다.",
+            description = "작성한 목표 개수를 조회합니다.",
             security = @SecurityRequirement(name = "bearerAuth")
     )
     @GetMapping("/count")

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/goal/dto/GoalCountResponse.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/goal/dto/GoalCountResponse.java
@@ -1,0 +1,17 @@
+package com.solif.backend.domain.goal.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class GoalCountResponse {
+
+    private int goalCount;
+
+    public static GoalCountResponse of(int goalCount) {
+        return GoalCountResponse.builder()
+                .goalCount(goalCount)
+                .build();
+    }
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/goal/dto/GoalFirstResponse.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/goal/dto/GoalFirstResponse.java
@@ -1,0 +1,21 @@
+package com.solif.backend.domain.goal.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class GoalFirstResponse {
+
+    private String firstGoal;
+    private int currentIndex;
+    private int totalCount;
+
+    public static GoalFirstResponse of(String firstGoal, int currentIndex, int totalCount) {
+        return GoalFirstResponse.builder()
+                .firstGoal(firstGoal)
+                .currentIndex(currentIndex)
+                .totalCount(totalCount)
+                .build();
+    }
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/goal/dto/GoalSuccessCode.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/goal/dto/GoalSuccessCode.java
@@ -1,0 +1,18 @@
+package com.solif.backend.domain.goal.dto;
+
+import com.solif.backend.global.common.response.SuccessCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum GoalSuccessCode implements SuccessCode {
+
+    GOAL_FIRST_READ_SUCCESS(HttpStatus.OK, "GOAL_001", "첫 번째 목표 조회에 성공했습니다."),
+    GOAL_COUNT_READ_SUCCESS(HttpStatus.OK, "GOAL_002", "목표 개수 조회에 성공했습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/goal/exception/GoalErrorCode.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/goal/exception/GoalErrorCode.java
@@ -1,0 +1,18 @@
+package com.solif.backend.domain.goal.exception;
+
+import com.solif.backend.global.common.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum GoalErrorCode implements ErrorCode {
+
+    PROFILE_NOT_FOUND(HttpStatus.NOT_FOUND, "GOAL_001", "프로필을 찾을 수 없습니다."),
+    GOAL_NOT_FOUND(HttpStatus.NOT_FOUND, "GOAL_002", "목표가 존재하지 않습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/goal/service/GoalService.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/goal/service/GoalService.java
@@ -1,0 +1,60 @@
+package com.solif.backend.domain.goal.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.solif.backend.domain.goal.dto.GoalCountResponse;
+import com.solif.backend.domain.goal.dto.GoalFirstResponse;
+import com.solif.backend.domain.goal.exception.GoalErrorCode;
+import com.solif.backend.domain.profile.entity.UserProfile;
+import com.solif.backend.domain.profile.repository.UserProfileRepository;
+import com.solif.backend.global.common.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class GoalService {
+
+    private final UserProfileRepository userProfileRepository;
+    private final ObjectMapper objectMapper;
+
+    //첫 번째 목표 조회
+    public GoalFirstResponse getFirstGoal(Long userId) {
+        UserProfile profile = userProfileRepository.findByUser_UserId(userId)
+                .orElseThrow(() -> new CustomException(GoalErrorCode.PROFILE_NOT_FOUND));
+
+        List<String> goals = convertJsonToList(profile.getMainGoal());
+
+        if (goals.isEmpty()) {
+            throw new CustomException(GoalErrorCode.GOAL_NOT_FOUND);
+        }
+
+        return GoalFirstResponse.of(goals.get(0), 1, goals.size());
+    }
+
+    //목표 개수 조회
+    public GoalCountResponse getGoalCount(Long userId) {
+        UserProfile profile = userProfileRepository.findByUser_UserId(userId)
+                .orElseThrow(() -> new CustomException(GoalErrorCode.PROFILE_NOT_FOUND));
+
+        List<String> goals = convertJsonToList(profile.getMainGoal());
+
+        return GoalCountResponse.of(goals.size());
+    }
+
+    private List<String> convertJsonToList(String json) {
+        if (json == null || json.isEmpty()) {
+            return List.of();
+        }
+        try {
+            return objectMapper.readValue(json, new TypeReference<List<String>>() {});
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("JSON 파싱 실패", e);
+        }
+    }
+}


### PR DESCRIPTION
## 🔍 개요
홈 화면에서 사용할 첫 번째 목표 조회 API와 목표 개수 조회 API를 구현

## ✨ 변경 사항
- GET /api/goals/first - 첫 번째 목표 조회 API 추가
- GET /api/goals/count - 목표 개수 조회 API 추가
- Goal 도메인 패키지 구조 생성 (controller, service, dto, exception)

## 🧪 테스트
- [x] 로컬 테스트 완료
- [x] API 테스트 완료
- [ ] 테스트 코드 작성 (해당 시)

## 📎 관련 이슈
Closes: #35 

## ⚠️ 참고 사항
리뷰어가 알아야 할 사항이나 논의가 필요한 부분을 작성해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 홈 화면 목표 관리를 위한 새 API 추가
  * 첫 번째 목표 조회: 첫 목표 내용과 현재 인덱스/전체 개수 반환
  * 목표 개수 조회: 사용자 목표 총수 반환
  * 관련 성공 응답과 빈 상태에 대한 적절한 처리 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->