### PR TITLE
feat: 댓글 CRUD API 구현

### DIFF
--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/comment/code/CommentErrorCode.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/comment/code/CommentErrorCode.java
@@ -1,0 +1,18 @@
+package com.solif.backend.domain.comment.code;
+
+import com.solif.backend.global.common.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum CommentErrorCode implements ErrorCode {
+
+    COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "COMMENT_001", "댓글을 찾을 수 없습니다."),
+    UNAUTHORIZED_COMMENT_ACCESS(HttpStatus.FORBIDDEN, "COMMENT_002", "댓글에 대한 권한이 없습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/comment/code/CommentSuccessCode.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/comment/code/CommentSuccessCode.java
@@ -1,0 +1,20 @@
+package com.solif.backend.domain.comment.code;
+
+import com.solif.backend.global.common.response.SuccessCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum CommentSuccessCode implements SuccessCode {
+
+    COMMENT_LIST_SUCCESS(HttpStatus.OK, "COMMENT_200", "댓글 목록 조회에 성공했습니다."),
+    COMMENT_CREATE_SUCCESS(HttpStatus.CREATED, "COMMENT_201", "댓글 작성에 성공했습니다."),
+    COMMENT_UPDATE_SUCCESS(HttpStatus.OK, "COMMENT_202", "댓글 수정에 성공했습니다."),
+    COMMENT_DELETE_SUCCESS(HttpStatus.OK, "COMMENT_203", "댓글 삭제에 성공했습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/comment/controller/CommentController.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/comment/controller/CommentController.java
@@ -1,0 +1,81 @@
+package com.solif.backend.domain.comment.controller;
+
+import com.solif.backend.domain.comment.code.CommentSuccessCode;
+import com.solif.backend.domain.comment.dto.CommentCreateRequest;
+import com.solif.backend.domain.comment.dto.CommentResponse;
+import com.solif.backend.domain.comment.dto.CommentUpdateRequest;
+import com.solif.backend.domain.comment.service.CommentService;
+import com.solif.backend.global.common.response.ResponseFactory;
+import com.solif.backend.global.common.response.SuccessResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "댓글", description = "댓글 API")
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+public class CommentController {
+
+    private final CommentService commentService;
+
+    @Operation(summary = "댓글 목록 조회", description = "특정 게시글의 댓글 목록을 조회합니다.")
+    @GetMapping("/posts/{postId}/comments")
+    public ResponseEntity<SuccessResponse<List<CommentResponse>>> getComments(
+            @PathVariable Long postId
+    ) {
+        List<CommentResponse> comments = commentService.getComments(postId);
+        return ResponseFactory.success(CommentSuccessCode.COMMENT_LIST_SUCCESS, comments);
+    }
+
+    @Operation(
+            summary = "댓글 작성",
+            description = "게시글에 댓글을 작성합니다. 익명 여부를 선택할 수 있습니다.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @PostMapping("/posts/{postId}/comments")
+    public ResponseEntity<SuccessResponse<CommentResponse>> createComment(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long postId,
+            @Valid @RequestBody CommentCreateRequest request
+    ) {
+        CommentResponse response = commentService.createComment(userId, postId, request);
+        return ResponseFactory.success(CommentSuccessCode.COMMENT_CREATE_SUCCESS, response);
+    }
+
+    @Operation(
+            summary = "댓글 수정",
+            description = "댓글 내용을 수정합니다. 작성자만 수정 가능합니다.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @PatchMapping("/comments/{commentId}")
+    public ResponseEntity<SuccessResponse<Void>> updateComment(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long commentId,
+            @Valid @RequestBody CommentUpdateRequest request
+    ) {
+        commentService.updateComment(userId, commentId, request);
+        return ResponseFactory.success(CommentSuccessCode.COMMENT_UPDATE_SUCCESS);
+    }
+
+    @Operation(
+            summary = "댓글 삭제",
+            description = "댓글을 삭제합니다. 작성자만 삭제 가능합니다.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @DeleteMapping("/comments/{commentId}")
+    public ResponseEntity<SuccessResponse<Void>> deleteComment(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long commentId
+    ) {
+        commentService.deleteComment(userId, commentId);
+        return ResponseFactory.success(CommentSuccessCode.COMMENT_DELETE_SUCCESS);
+    }
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/comment/dto/CommentCreateRequest.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/comment/dto/CommentCreateRequest.java
@@ -1,0 +1,21 @@
+package com.solif.backend.domain.comment.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@Schema(description = "댓글 작성 요청")
+public class CommentCreateRequest {
+
+    @NotBlank(message = "댓글 내용은 필수입니다.")
+    @Schema(description = "댓글 내용", example = "도움이 되는 글이네요!")
+    private String commentContent;
+
+    @NotNull(message = "익명 여부는 필수입니다.")
+    @Schema(description = "익명 여부", example = "false")
+    private Boolean commentIsAnonymous;
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/comment/dto/CommentResponse.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/comment/dto/CommentResponse.java
@@ -41,7 +41,7 @@ public class CommentResponse {
                 .commentId(comment.getCommentId())
                 .postId(comment.getPost().getPostId())
                 .authorName(comment.getCommentIsAnonymous() ? "익명" : comment.getUser().getName())
-                .authorId(comment.getUser().getUserId())
+                .authorId(comment.getCommentIsAnonymous() ? null : comment.getUser().getUserId())
                 .commentContent(comment.getCommentContent())
                 .commentIsAnonymous(comment.getCommentIsAnonymous())
                 .createdAt(comment.getCreatedAt())

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/comment/dto/CommentResponse.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/comment/dto/CommentResponse.java
@@ -1,0 +1,51 @@
+package com.solif.backend.domain.comment.dto;
+
+import com.solif.backend.domain.comment.entity.Comment;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@Schema(description = "댓글 응답")
+public class CommentResponse {
+
+    @Schema(description = "댓글 ID", example = "1")
+    private Long commentId;
+
+    @Schema(description = "게시글 ID", example = "10")
+    private Long postId;
+
+    @Schema(description = "작성자 이름 (익명일 경우 '익명')", example = "홍길동")
+    private String authorName;
+
+    @Schema(description = "작성자 ID (본인 확인용)", example = "5")
+    private Long authorId;
+
+    @Schema(description = "댓글 내용", example = "도움이 되는 글이네요!")
+    private String commentContent;
+
+    @Schema(description = "익명 여부", example = "false")
+    private Boolean commentIsAnonymous;
+
+    @Schema(description = "작성 일시", example = "2026-01-29T14:30:00")
+    private LocalDateTime createdAt;
+
+    @Schema(description = "수정 일시", example = "2026-01-29T15:00:00")
+    private LocalDateTime updatedAt;
+
+    public static CommentResponse from(Comment comment) {
+        return CommentResponse.builder()
+                .commentId(comment.getCommentId())
+                .postId(comment.getPost().getPostId())
+                .authorName(comment.getCommentIsAnonymous() ? "익명" : comment.getUser().getName())
+                .authorId(comment.getUser().getUserId())
+                .commentContent(comment.getCommentContent())
+                .commentIsAnonymous(comment.getCommentIsAnonymous())
+                .createdAt(comment.getCreatedAt())
+                .updatedAt(comment.getUpdatedAt())
+                .build();
+    }
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/comment/dto/CommentUpdateRequest.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/comment/dto/CommentUpdateRequest.java
@@ -1,0 +1,16 @@
+package com.solif.backend.domain.comment.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@Schema(description = "댓글 수정 요청")
+public class CommentUpdateRequest {
+
+    @NotBlank(message = "댓글 내용은 필수입니다.")
+    @Schema(description = "댓글 내용", example = "수정된 댓글 내용입니다.")
+    private String commentContent;
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/comment/entity/Comment.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/comment/entity/Comment.java
@@ -8,6 +8,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
@@ -41,6 +42,10 @@ public class Comment {
     @CreatedDate
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
 
     @Builder
     public Comment(User user, Post post, String commentContent, Boolean commentIsAnonymous) {

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/comment/service/CommentService.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/comment/service/CommentService.java
@@ -1,0 +1,121 @@
+package com.solif.backend.domain.comment.service;
+
+import com.solif.backend.domain.auth.exception.AuthErrorCode;
+import com.solif.backend.domain.comment.code.CommentErrorCode;
+import com.solif.backend.domain.comment.dto.CommentCreateRequest;
+import com.solif.backend.domain.comment.dto.CommentResponse;
+import com.solif.backend.domain.comment.dto.CommentUpdateRequest;
+import com.solif.backend.domain.comment.entity.Comment;
+import com.solif.backend.domain.comment.repository.CommentRepository;
+import com.solif.backend.domain.post.code.PostErrorCode;
+import com.solif.backend.domain.post.entity.Post;
+import com.solif.backend.domain.post.repository.PostRepository;
+import com.solif.backend.domain.user.entity.User;
+import com.solif.backend.domain.user.repository.UserRepository;
+import com.solif.backend.global.common.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CommentService {
+
+    private final CommentRepository commentRepository;
+    private final PostRepository postRepository;
+    private final UserRepository userRepository;
+
+    // 댓글 목록 조회
+    public List<CommentResponse> getComments(Long postId) {
+        log.info("댓글 목록 조회 - postId: {}", postId);
+
+        // 게시글 존재 확인
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new CustomException(PostErrorCode.POST_NOT_FOUND));
+
+        // 삭제된 게시글 체크
+        if (post.isDeleted()) {
+            throw new CustomException(PostErrorCode.DELETED_POST);
+        }
+
+        // 댓글 조회
+        List<Comment> comments = commentRepository.findByPost_PostIdOrderByCreatedAtAsc(postId);
+
+        return comments.stream()
+                .map(CommentResponse::from)
+                .toList();
+    }
+
+    // 댓글 작성
+    @Transactional
+    public CommentResponse createComment(Long userId, Long postId, CommentCreateRequest request) {
+        log.info("댓글 작성 - userId: {}, postId: {}", userId, postId);
+
+        // 사용자 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(AuthErrorCode.USER_NOT_FOUND));
+
+        // 게시글 조회
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new CustomException(PostErrorCode.POST_NOT_FOUND));
+
+        // 삭제된 게시글 체크
+        if (post.isDeleted()) {
+            throw new CustomException(PostErrorCode.DELETED_POST);
+        }
+
+        // Comment 엔티티 생성
+        Comment comment = Comment.builder()
+                .user(user)
+                .post(post)
+                .commentContent(request.getCommentContent())
+                .commentIsAnonymous(request.getCommentIsAnonymous())
+                .build();
+
+        // 저장
+        Comment savedComment = commentRepository.save(comment);
+
+        return CommentResponse.from(savedComment);
+    }
+
+    // 댓글 수정
+    @Transactional
+    public void updateComment(Long userId, Long commentId, CommentUpdateRequest request) {
+        log.info("댓글 수정 - userId: {}, commentId: {}", userId, commentId);
+
+        // 댓글 조회
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new CustomException(CommentErrorCode.COMMENT_NOT_FOUND));
+
+        // 작성자 본인 확인
+        if (!comment.isAuthor(userId)) {
+            throw new CustomException(CommentErrorCode.UNAUTHORIZED_COMMENT_ACCESS);
+        }
+
+        // 댓글 수정
+        comment.updateContent(request.getCommentContent());
+    }
+
+    // 댓글 삭제 (Hard Delete)
+    @Transactional
+    public void deleteComment(Long userId, Long commentId) {
+        log.info("댓글 삭제 - userId: {}, commentId: {}", userId, commentId);
+
+        // 댓글 조회
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new CustomException(CommentErrorCode.COMMENT_NOT_FOUND));
+
+        // 작성자 본인 확인
+        if (!comment.isAuthor(userId)) {
+            throw new CustomException(CommentErrorCode.UNAUTHORIZED_COMMENT_ACCESS);
+        }
+
+        // Hard Delete
+        commentRepository.delete(comment);
+    }
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/global/config/SecurityConfig.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/global/config/SecurityConfig.java
@@ -58,7 +58,7 @@ public class SecurityConfig {
                                 "/api/auth/signup",       // 회원가입
                                 "/api/auth/login",        // 로그인
                                 "/api/v1/posts",          // 게시글 목록 조회
-                                "/api/v1/posts/*",        // 게시글 상세 조회
+                                "/api/v1/posts/**",       // 게시글 상세 조회
                                 "/error",                 // Spring Boot 에러 핸들러
                                 "/swagger-ui/**",         // Swagger UI
                                 "/v3/api-docs/**",        // API 문서


### PR DESCRIPTION
## 🔍 개요
게시글에 종속되는 댓글(Comment)에 대한 CRUD API를 구현했다.
댓글 작성, 조회, 수정, 삭제 기능을 제공하며, 작성자 기준으로 수정/삭제 권한을 검증

## ✨ 변경 사항
- 댓글 작성 API 구현
- 게시글별 댓글 목록 조회 API 구현
- 댓글 수정 API 구현 (작성자 본인만 가능)
- 댓글 삭제 API 구현 (작성자 본인만 가능)
- 댓글–게시글 연관 관계 기반 권한 검증 로직 추가

## 🧪 테스트
- [x] 로컬 테스트 완료
- [x] API 테스트 완료
- [ ] 테스트 코드 작성 (해당 시)

## 📎 관련 이슈
Closes: #39 

## ⚠️ 참고 사항
- 댓글은 게시글에 종속되며 단독 조회는 지원하지 않습니다.
- 대댓글 기능은 이번 PR 범위에서 제외했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 댓글 목록 조회, 작성, 수정, 삭제 REST API 추가
  * 익명 댓글 옵션 지원 및 요청/응답 형식 추가
  * 성공/오류 코드로 표준화된 응답 제공

* **Bug Fixes**
  * 인증 기반 권한 검증 강화(권한 없는 접근 차단)

* **Chores**
  * 댓글 엔티티에 수정 시각(updatedAt) 자동 추적 추가



<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->