### PR TITLE
feat: 게시글 좋아요 API 구현

### DIFF
--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/post/controller/PostController.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/post/controller/PostController.java
@@ -40,12 +40,16 @@ public class PostController {
         return ResponseFactory.success(PostSuccessCode.POST_LIST_SUCCESS, posts);
     }
 
-    @Operation(summary = "게시글 상세 조회", description = "게시글 상세 내용을 조회합니다. 조회수가 1 증가합니다.")
+    @Operation(
+            summary = "게시글 상세 조회",
+            description = "게시글 상세 내용을 조회합니다. 조회수가 1 증가합니다.",
+            security = @SecurityRequirement(name = "bearerAuth"))
     @GetMapping("/{postId}")
     public ResponseEntity<SuccessResponse<PostDetailResponse>> getPostDetail(
+            @AuthenticationPrincipal Long userId,
             @PathVariable Long postId
     ) {
-        PostDetailResponse post = postService.getPostDetail(postId);
+        PostDetailResponse post = postService.getPostDetail(userId, postId);
         return ResponseFactory.success(PostSuccessCode.POST_DETAIL_SUCCESS, post);
     }
 

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/post/dto/PostDetailResponse.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/post/dto/PostDetailResponse.java
@@ -40,13 +40,19 @@ public class PostDetailResponse {
     @Schema(description = "댓글 수", example = "15")
     private Long commentCount;
 
+    @Schema(description = "좋아요 수", example = "7")
+    private Long likeCount;
+
+    @Schema(description = "현재 사용자가 좋아요 했는지 여부", example = "true")
+    private Boolean isLikedByUser;
+
     @Schema(description = "작성 일시", example = "2026-01-28T14:30:00")
     private LocalDateTime createdAt;
 
     @Schema(description = "수정 일시", example = "2026-01-28T15:00:00", nullable = true)
     private LocalDateTime updatedAt;
 
-    public static PostDetailResponse from(Post post, Long commentCount, boolean isAnonymous) {
+    public static PostDetailResponse from(Post post, Long commentCount, Long likeCount, Boolean isLikedByUser, boolean isAnonymous) {
         return PostDetailResponse.builder()
                 .postId(post.getPostId())
                 .boardId(post.getBoard().getBoardId())
@@ -57,6 +63,8 @@ public class PostDetailResponse {
                 .authorName(isAnonymous ? "익명" : post.getAuthor().getName())
                 .viewCount(post.getViewCount())
                 .commentCount(commentCount)
+                .likeCount(likeCount)
+                .isLikedByUser(isLikedByUser)
                 .createdAt(post.getCreatedAt())
                 .updatedAt(post.getUpdatedAt())
                 .build();

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/post/service/PostService.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/post/service/PostService.java
@@ -11,6 +11,7 @@ import com.solif.backend.domain.post.entity.Post;
 import com.solif.backend.domain.post.entity.PostCategory;
 import com.solif.backend.domain.post.code.PostErrorCode;
 import com.solif.backend.domain.post.repository.PostRepository;
+import com.solif.backend.domain.postlike.repository.PostLikeRepository;
 import com.solif.backend.domain.user.entity.User;
 import com.solif.backend.domain.user.repository.UserRepository;
 import com.solif.backend.global.common.exception.CustomException;
@@ -35,6 +36,7 @@ public class PostService {
     private final BoardRepository boardRepository;
     private final CommentRepository commentRepository;
     private final UserRepository userRepository;
+    private final PostLikeRepository postLikeRepository;
 
     // 게시글 목록 조회
     public Slice<PostListResponse> getPosts(Long boardId, PostCategory category, Pageable pageable) {
@@ -105,7 +107,7 @@ public class PostService {
 
     // 게시글 상세 조회
     @Transactional
-    public PostDetailResponse getPostDetail(Long postId) {
+    public PostDetailResponse getPostDetail(Long userId, Long postId) {
         log.info("게시글 상세 조회 - postId: {}", postId);
 
         // 게시글 조회
@@ -126,7 +128,13 @@ public class PostService {
         // 댓글 수 조회
         Long commentCount = commentRepository.countByPost_PostId(postId);
 
-        return PostDetailResponse.from(post, commentCount, isAnonymous);
+        // 좋아요 수 조회
+        Long likeCount = postLikeRepository.countByPost_PostId(postId);
+
+        // 현재 사용자의 좋아요 여부 조회
+        Boolean isLikedByUser = postLikeRepository.existsByUser_UserIdAndPost_PostId(userId, postId);
+
+        return PostDetailResponse.from(post, commentCount, likeCount, isLikedByUser, isAnonymous);
     }
 
     // 게시글 작성

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/postlike/code/PostLikeErrorCode.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/postlike/code/PostLikeErrorCode.java
@@ -1,0 +1,18 @@
+package com.solif.backend.domain.postlike.code;
+
+import com.solif.backend.global.common.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum PostLikeErrorCode implements ErrorCode {
+
+    ALREADY_LIKED(HttpStatus.CONFLICT, "POST_LIKE_001", "이미 좋아요한 게시글입니다."),
+    LIKE_NOT_FOUND(HttpStatus.NOT_FOUND, "POST_LIKE_002", "좋아요를 찾을 수 없습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/postlike/code/PostLikeSuccessCode.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/postlike/code/PostLikeSuccessCode.java
@@ -1,0 +1,18 @@
+package com.solif.backend.domain.postlike.code;
+
+import com.solif.backend.global.common.response.SuccessCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum PostLikeSuccessCode implements SuccessCode {
+
+    LIKE_SUCCESS(HttpStatus.CREATED, "POST_LIKE_200", "좋아요를 추가했습니다."),
+    UNLIKE_SUCCESS(HttpStatus.OK, "POST_LIKE_201", "좋아요를 취소했습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/postlike/controller/PostLikeController.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/postlike/controller/PostLikeController.java
@@ -1,0 +1,50 @@
+package com.solif.backend.domain.postlike.controller;
+
+import com.solif.backend.domain.postlike.code.PostLikeSuccessCode;
+import com.solif.backend.domain.postlike.service.PostLikeService;
+import com.solif.backend.global.common.response.ResponseFactory;
+import com.solif.backend.global.common.response.SuccessResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "게시글 좋아요", description = "게시글 좋아요 API")
+@RestController
+@RequestMapping("/api/v1/posts")
+@RequiredArgsConstructor
+public class PostLikeController {
+
+    private final PostLikeService postLikeService;
+
+    @Operation(
+            summary = "좋아요 추가",
+            description = "게시글에 좋아요를 추가합니다.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @PostMapping("/{postId}/like")
+    public ResponseEntity<SuccessResponse<Void>> likePost(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long postId
+    ) {
+        postLikeService.likePost(userId, postId);
+        return ResponseFactory.success(PostLikeSuccessCode.LIKE_SUCCESS);
+    }
+
+    @Operation(
+            summary = "좋아요 취소",
+            description = "게시글 좋아요를 취소합니다.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @DeleteMapping("/{postId}/like")
+    public ResponseEntity<SuccessResponse<Void>> unlikePost(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long postId
+    ) {
+        postLikeService.unlikePost(userId, postId);
+        return ResponseFactory.success(PostLikeSuccessCode.UNLIKE_SUCCESS);
+    }
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/postlike/entity/PostLike.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/postlike/entity/PostLike.java
@@ -1,0 +1,49 @@
+package com.solif.backend.domain.postlike.entity;
+
+import com.solif.backend.domain.post.entity.Post;
+import com.solif.backend.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "post_like",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_post_like_user_post",
+                columnNames = {"user_id", "post_id"}
+        )
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class PostLike {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "post_like_id")
+    private Long postLikeId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id", nullable = false)
+    private Post post;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Builder
+    public PostLike(User user, Post post) {
+        this.user = user;
+        this.post = post;
+    }
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/postlike/repository/PostLikeRepository.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/postlike/repository/PostLikeRepository.java
@@ -1,0 +1,18 @@
+package com.solif.backend.domain.postlike.repository;
+
+import com.solif.backend.domain.postlike.entity.PostLike;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
+
+    // 좋아요 존재 여부 확인
+    boolean existsByUser_UserIdAndPost_PostId(Long userId, Long postId);
+
+    // 좋아요 조회 (삭제용)
+    Optional<PostLike> findByUser_UserIdAndPost_PostId(Long userId, Long postId);
+
+    // 게시글의 좋아요 수
+    Long countByPost_PostId(Long postId);
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/postlike/service/PostLikeService.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/postlike/service/PostLikeService.java
@@ -1,0 +1,72 @@
+package com.solif.backend.domain.postlike.service;
+
+import com.solif.backend.domain.auth.exception.AuthErrorCode;
+import com.solif.backend.domain.post.code.PostErrorCode;
+import com.solif.backend.domain.post.entity.Post;
+import com.solif.backend.domain.post.repository.PostRepository;
+import com.solif.backend.domain.postlike.code.PostLikeErrorCode;
+import com.solif.backend.domain.postlike.entity.PostLike;
+import com.solif.backend.domain.postlike.repository.PostLikeRepository;
+import com.solif.backend.domain.user.entity.User;
+import com.solif.backend.domain.user.repository.UserRepository;
+import com.solif.backend.global.common.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PostLikeService {
+
+    private final PostLikeRepository postLikeRepository;
+    private final PostRepository postRepository;
+    private final UserRepository userRepository;
+
+    // 좋아요 추가
+    @Transactional
+    public void likePost(Long userId, Long postId) {
+        log.info("좋아요 추가 - userId: {}, postId: {}", userId, postId);
+
+        // 사용자 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(AuthErrorCode.USER_NOT_FOUND));
+
+        // 게시글 조회
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new CustomException(PostErrorCode.POST_NOT_FOUND));
+
+        // 삭제된 게시글 체크
+        if (post.isDeleted()) {
+            throw new CustomException(PostErrorCode.DELETED_POST);
+        }
+
+        // 이미 좋아요한 경우
+        if (postLikeRepository.existsByUser_UserIdAndPost_PostId(userId, postId)) {
+            throw new CustomException(PostLikeErrorCode.ALREADY_LIKED);
+        }
+
+        // PostLike 엔티티 생성 및 저장
+        PostLike postLike = PostLike.builder()
+                .user(user)
+                .post(post)
+                .build();
+
+        postLikeRepository.save(postLike);
+    }
+
+    // 좋아요 취소
+    @Transactional
+    public void unlikePost(Long userId, Long postId) {
+        log.info("좋아요 취소 - userId: {}, postId: {}", userId, postId);
+
+        // 좋아요 조회
+        PostLike postLike = postLikeRepository.findByUser_UserIdAndPost_PostId(userId, postId)
+                .orElseThrow(() -> new CustomException(PostLikeErrorCode.LIKE_NOT_FOUND));
+
+        // 삭제
+        postLikeRepository.delete(postLike);
+    }
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/global/config/SecurityConfig.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/global/config/SecurityConfig.java
@@ -4,6 +4,7 @@ import com.solif.backend.global.jwt.JwtAuthenticationFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -54,11 +55,14 @@ public class SecurityConfig {
                 // 요청 권한 설정
                 .authorizeHttpRequests(auth -> auth
                         // 인증 없이 접근 가능한 경로
+                        .requestMatchers(HttpMethod.GET,
+                                "/api/v1/posts",                    // 게시글 목록 조회
+                                "/api/v1/posts/*/comments"          // 댓글 목록 조회
+                        ).permitAll()
+
                         .requestMatchers(
                                 "/api/auth/signup",               // 회원가입
                                 "/api/auth/login",                // 로그인
-                                "/api/v1/posts",                  // 게시글 목록 조회
-                                "/api/v1/posts/*/comments",       // 댓글 목록 조회
                                 "/error",                         // Spring Boot 에러 핸들러
                                 "/swagger-ui/**",                 // Swagger UI
                                 "/v3/api-docs/**",                // API 문서

--- a/blue-sol-backend/src/main/java/com/solif/backend/global/config/SecurityConfig.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/global/config/SecurityConfig.java
@@ -55,14 +55,14 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         // 인증 없이 접근 가능한 경로
                         .requestMatchers(
-                                "/api/auth/signup",       // 회원가입
-                                "/api/auth/login",        // 로그인
-                                "/api/v1/posts",          // 게시글 목록 조회
-                                "/api/v1/posts/**",       // 게시글 상세 조회
-                                "/error",                 // Spring Boot 에러 핸들러
-                                "/swagger-ui/**",         // Swagger UI
-                                "/v3/api-docs/**",        // API 문서
-                                "/h2-console/**"          // H2 콘솔 (개발용)
+                                "/api/auth/signup",               // 회원가입
+                                "/api/auth/login",                // 로그인
+                                "/api/v1/posts",                  // 게시글 목록 조회
+                                "/api/v1/posts/*/comments",       // 댓글 목록 조회
+                                "/error",                         // Spring Boot 에러 핸들러
+                                "/swagger-ui/**",                 // Swagger UI
+                                "/v3/api-docs/**",                // API 문서
+                                "/h2-console/**"                  // H2 콘솔 (개발용)
                         ).permitAll()
                         // 그 외 모든 요청은 인증 필요
                         .anyRequest().authenticated()


### PR DESCRIPTION
## 🔍 개요
게시글 좋아요 기능을 구현
사용자는 게시글에 대해 좋아요를 추가/취소할 수 있으며, 게시글 상세 조회 시 좋아요 여부를 확인할 수 있다.

## ✨ 변경 사항
- 게시글 좋아요 추가 API 구현 (POST)
- 게시글 좋아요 취소 API 구현 (DELETE)
- 게시글 상세 조회 시 사용자 기준 좋아요 여부 포함
- 중복 좋아요 방지 로직 적용
- 인증 사용자만 좋아요 가능하도록 권한 검증

## 🧪 테스트
- [x] 로컬 테스트 완료
- [x] API 테스트 완료
- [ ] 테스트 코드 작성 (해당 시)

## 📎 관련 이슈
Closes: #41 

## ⚠️ 참고 사항
- 좋아요는 사용자 + 게시글 기준으로 유니크하게 관리된다.
- 좋아요 개수는 게시글 상세 조회 시 확인 가능하다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 게시글에 좋아요 기능이 추가되었습니다. 사용자는 게시글에 좋아요를 추가하거나 취소할 수 있습니다.
  * 게시글 상세 조회에 총 좋아요 수와 해당 사용자의 좋아요 여부가 표시됩니다.

* **보안**
  * 게시글 상세 조회는 인증이 필요합니다. 일부 게시글 관련 목록 조회만 공개 접근으로 유지됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->