### PR TITLE
feat: 자치회 기본 CRUD 구현

### DIFF
--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/council/code/CouncilErrorCode.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/council/code/CouncilErrorCode.java
@@ -28,7 +28,8 @@ public enum CouncilErrorCode implements ErrorCode {
     INSUFFICIENT_BUDGET(HttpStatus.BAD_REQUEST, "COUNCIL_010", "예산이 부족합니다."),
 
     // 자치회 소속 관련
-    ALREADY_IN_COUNCIL(HttpStatus.BAD_REQUEST, "COUNCIL_011", "이미 다른 자치회에 소속되어 있습니다.");
+    ALREADY_IN_COUNCIL(HttpStatus.BAD_REQUEST, "COUNCIL_011", "이미 다른 자치회에 소속되어 있습니다."),
+    BUDGET_REDUCTION_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "COUNCIL_012", "사용한 예산보다 적게 총 예산을 설정할 수 없습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/council/code/CouncilErrorCode.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/council/code/CouncilErrorCode.java
@@ -25,7 +25,10 @@ public enum CouncilErrorCode implements ErrorCode {
     ONLY_LEADER_CAN_DELETE_RULE(HttpStatus.FORBIDDEN, "COUNCIL_009", "자치회 리더만 활동 규칙을 삭제할 수 있습니다."),
 
     // 예산 관련
-    INSUFFICIENT_BUDGET(HttpStatus.BAD_REQUEST, "COUNCIL_010", "예산이 부족합니다.");
+    INSUFFICIENT_BUDGET(HttpStatus.BAD_REQUEST, "COUNCIL_010", "예산이 부족합니다."),
+
+    // 자치회 소속 관련
+    ALREADY_IN_COUNCIL(HttpStatus.BAD_REQUEST, "COUNCIL_011", "이미 다른 자치회에 소속되어 있습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/council/code/CouncilErrorCode.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/council/code/CouncilErrorCode.java
@@ -1,0 +1,33 @@
+package com.solif.backend.domain.council.code;
+
+import com.solif.backend.global.common.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum CouncilErrorCode implements ErrorCode {
+
+    // 자치회 관련
+    COUNCIL_NOT_FOUND(HttpStatus.NOT_FOUND, "COUNCIL_001", "존재하지 않는 자치회입니다."),
+
+    // 멤버 관련
+    NOT_COUNCIL_MEMBER(HttpStatus.FORBIDDEN, "COUNCIL_002", "해당 자치회의 멤버가 아닙니다."),
+    ONLY_LEADER_CAN_UPDATE(HttpStatus.FORBIDDEN, "COUNCIL_003", "자치회 리더만 수정할 수 있습니다."),
+    ONLY_LEADER_CAN_ADD_MEMBER(HttpStatus.FORBIDDEN, "COUNCIL_004", "자치회 리더만 멤버를 추가할 수 있습니다."),
+    ONLY_LEADER_CAN_DELETE_MEMBER(HttpStatus.FORBIDDEN, "COUNCIL_005", "자치회 리더만 멤버를 삭제할 수 있습니다."),
+    LEADER_CANNOT_DELETE_SELF(HttpStatus.BAD_REQUEST, "COUNCIL_006", "리더는 본인을 삭제할 수 없습니다."),
+
+    // 활동 규칙 관련
+    RULE_NOT_FOUND(HttpStatus.NOT_FOUND, "COUNCIL_007", "존재하지 않는 활동 규칙입니다."),
+    ONLY_LEADER_CAN_ADD_RULE(HttpStatus.FORBIDDEN, "COUNCIL_008", "자치회 리더만 활동 규칙을 추가할 수 있습니다."),
+    ONLY_LEADER_CAN_DELETE_RULE(HttpStatus.FORBIDDEN, "COUNCIL_009", "자치회 리더만 활동 규칙을 삭제할 수 있습니다."),
+
+    // 예산 관련
+    INSUFFICIENT_BUDGET(HttpStatus.BAD_REQUEST, "COUNCIL_010", "예산이 부족합니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/council/code/CouncilSuccessCode.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/council/code/CouncilSuccessCode.java
@@ -1,0 +1,25 @@
+package com.solif.backend.domain.council.code;
+
+import com.solif.backend.global.common.response.SuccessCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum CouncilSuccessCode implements SuccessCode {
+
+    // 자치회 조회
+    COUNCIL_LIST_SUCCESS(HttpStatus.OK, "COUNCIL_LIST_200", "자치회 목록 조회에 성공했습니다."),
+    COUNCIL_DETAIL_SUCCESS(HttpStatus.OK, "COUNCIL_DETAIL_201", "자치회 상세 조회에 성공했습니다."),
+    MY_COUNCIL_SUCCESS(HttpStatus.OK, "MY_COUNCIL_202", "내 자치회 조회에 성공했습니다."),
+
+    // 자치회 생성/수정/삭제
+    COUNCIL_CREATE_SUCCESS(HttpStatus.CREATED, "COUNCIL_CREATE_203", "자치회 생성에 성공했습니다."),
+    COUNCIL_UPDATE_SUCCESS(HttpStatus.OK, "COUNCIL_UPDATE_204", "자치회 수정에 성공했습니다."),
+    COUNCIL_DELETE_SUCCESS(HttpStatus.OK, "COUNCIL_DELETE_205", "자치회 삭제에 성공했습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/council/controller/CouncilController.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/council/controller/CouncilController.java
@@ -1,0 +1,93 @@
+package com.solif.backend.domain.council.controller;
+
+import com.solif.backend.domain.council.code.CouncilSuccessCode;
+import com.solif.backend.domain.council.dto.*;
+import com.solif.backend.domain.council.service.CouncilService;
+import com.solif.backend.global.common.response.ResponseFactory;
+import com.solif.backend.global.common.response.SuccessResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "자치회", description = "자치회 API")
+@RestController
+@RequestMapping("/api/v1/councils")
+@RequiredArgsConstructor
+public class CouncilController {
+
+    private final CouncilService councilService;
+
+    @Operation(
+            summary = "자치회 목록 조회",
+            description = "전체 자치회 목록을 조회합니다. 본인 자치회 정보도 포함됩니다.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @GetMapping
+    public ResponseEntity<SuccessResponse<CouncilListResponse>> getCouncils(
+            @AuthenticationPrincipal Long userId
+    ) {
+        CouncilListResponse response = councilService.getCouncils(userId);
+        return ResponseFactory.success(CouncilSuccessCode.COUNCIL_LIST_SUCCESS, response);
+    }
+
+    @Operation(
+            summary = "내 자치회 조회",
+            description = "현재 로그인한 사용자의 소속 자치회 정보를 조회합니다. (홈 화면 위젯용)",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @GetMapping("/my")
+    public ResponseEntity<SuccessResponse<CouncilMyResponse>> getMyCouncil(
+            @AuthenticationPrincipal Long userId
+    ) {
+        CouncilMyResponse myCouncil = councilService.getMyCouncil(userId);
+        return ResponseFactory.success(CouncilSuccessCode.MY_COUNCIL_SUCCESS, myCouncil);
+    }
+
+    @Operation(
+            summary = "자치회 상세 조회",
+            description = "자치회 상세 정보를 조회합니다. 본인 자치회와 다른 자치회의 응답이 다릅니다.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @GetMapping("/{councilId}")
+    public ResponseEntity<SuccessResponse<CouncilDetailResponse>> getCouncilDetail(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long councilId
+    ) {
+        CouncilDetailResponse council = councilService.getCouncilDetail(userId, councilId);
+        return ResponseFactory.success(CouncilSuccessCode.COUNCIL_DETAIL_SUCCESS, council);
+    }
+
+    @Operation(
+            summary = "자치회 생성",
+            description = "새로운 자치회를 생성합니다. 생성자는 자동으로 리더로 등록됩니다.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @PostMapping
+    public ResponseEntity<SuccessResponse<CouncilCreateResponse>> createCouncil(
+            @AuthenticationPrincipal Long userId,
+            @Valid @RequestBody CouncilCreateRequest request
+    ) {
+        CouncilCreateResponse response = councilService.createCouncil(userId, request);
+        return ResponseFactory.success(CouncilSuccessCode.COUNCIL_CREATE_SUCCESS, response);
+    }
+
+    @Operation(
+            summary = "자치회 수정",
+            description = "자치회 정보를 수정합니다. 리더만 수정 가능합니다.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @PatchMapping("/{councilId}")
+    public ResponseEntity<SuccessResponse<Void>> updateCouncil(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long councilId,
+            @Valid @RequestBody CouncilUpdateRequest request
+    ) {
+        councilService.updateCouncil(userId, councilId, request);
+        return ResponseFactory.success(CouncilSuccessCode.COUNCIL_UPDATE_SUCCESS);
+    }
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/council/dto/CouncilCreateRequest.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/council/dto/CouncilCreateRequest.java
@@ -1,0 +1,25 @@
+package com.solif.backend.domain.council.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class CouncilCreateRequest {
+
+    @NotBlank(message = "자치회 이름은 필수입니다.")
+    private String councilName;
+
+    private String description;
+
+    @NotNull(message = "총 예산은 필수입니다.")
+    private Long totalBudget;
+
+    private Long profileImageFileId;
+
+    private List<Long> memberUserIds;  // 초대할 멤버 ID 배열
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/council/dto/CouncilCreateRequest.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/council/dto/CouncilCreateRequest.java
@@ -14,6 +14,12 @@ public class CouncilCreateRequest {
     @NotBlank(message = "자치회 이름은 필수입니다.")
     private String councilName;
 
+    @NotBlank(message = "활동 지역은 필수입니다.")
+    private String region;
+
+    @NotBlank(message = "활동 주제는 필수입니다.")
+    private String activityCategory;
+
     private String description;
 
     @NotNull(message = "총 예산은 필수입니다.")
@@ -21,5 +27,7 @@ public class CouncilCreateRequest {
 
     private Long profileImageFileId;
 
-    private List<Long> memberUserIds;  // 초대할 멤버 ID 배열
+    private List<Long> memberUserIds;
+
+    private List<String> rules;
 }

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/council/dto/CouncilCreateResponse.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/council/dto/CouncilCreateResponse.java
@@ -1,0 +1,26 @@
+package com.solif.backend.domain.council.dto;
+
+import com.solif.backend.domain.council.entity.Council;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class CouncilCreateResponse {
+
+    private Long councilId;
+    private String councilName;
+    private LocalDateTime createdAt;
+    private Integer memberCount;
+
+    public static CouncilCreateResponse from(Council council, Integer memberCount) {
+        return CouncilCreateResponse.builder()
+                .councilId(council.getCouncilId())
+                .councilName(council.getCouncilName())
+                .createdAt(council.getCreatedAt())
+                .memberCount(memberCount)
+                .build();
+    }
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/council/dto/CouncilDetailResponse.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/council/dto/CouncilDetailResponse.java
@@ -1,0 +1,77 @@
+package com.solif.backend.domain.council.dto;
+
+import com.solif.backend.domain.council.entity.Council;
+import com.solif.backend.domain.council.entity.CouncilMemberRole;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class CouncilDetailResponse {
+
+    private Long councilId;
+    private String councilName;
+    private Long leaderUserId;
+    private String leaderName;
+    private String description;
+    private Long totalBudget;
+    private Long currentBudget;
+    private Long memberCount;
+    private Long activityCount;
+    private Long monthsSinceCreation;
+    private LocalDateTime createdAt;
+    private String profileImageUrl;
+    private String myRole;  // LEADER, MEMBER, NONE
+    private Boolean isMember;
+
+    // 본인 자치회용 (멤버/리더)
+    public static CouncilDetailResponse forMember(
+            Council council,
+            Long memberCount,
+            Long activityCount,
+            Long monthsSinceCreation,
+            CouncilMemberRole role
+    ) {
+        return CouncilDetailResponse.builder()
+                .councilId(council.getCouncilId())
+                .councilName(council.getCouncilName())
+                .leaderUserId(council.getLeader().getUserId())
+                .leaderName(council.getLeader().getName())
+                .description(council.getDescription())
+                .totalBudget(council.getTotalBudget())
+                .currentBudget(council.getCurrentBudget())
+                .memberCount(memberCount)
+                .activityCount(activityCount)
+                .monthsSinceCreation(monthsSinceCreation)
+                .createdAt(council.getCreatedAt())
+                .profileImageUrl(null)  // 이미지 처리
+                .myRole(role.name())
+                .isMember(true)
+                .build();
+    }
+
+    // 다른 자치회용 (비멤버)
+    public static CouncilDetailResponse forNonMember(
+            Council council,
+            Long memberCount
+    ) {
+        return CouncilDetailResponse.builder()
+                .councilId(council.getCouncilId())
+                .councilName(council.getCouncilName())
+                .leaderUserId(council.getLeader().getUserId())
+                .leaderName(council.getLeader().getName())
+                .description(council.getDescription())
+                .totalBudget(null)
+                .currentBudget(null)
+                .memberCount(memberCount)
+                .activityCount(null)
+                .monthsSinceCreation(null)
+                .createdAt(council.getCreatedAt())
+                .profileImageUrl(null)  // 이미지 처리
+                .myRole("NONE")
+                .isMember(false)
+                .build();
+    }
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/council/dto/CouncilDetailResponse.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/council/dto/CouncilDetailResponse.java
@@ -13,6 +13,8 @@ public class CouncilDetailResponse {
 
     private Long councilId;
     private String councilName;
+    private String region;
+    private String activityCategory;
     private Long leaderUserId;
     private String leaderName;
     private String description;
@@ -37,6 +39,8 @@ public class CouncilDetailResponse {
         return CouncilDetailResponse.builder()
                 .councilId(council.getCouncilId())
                 .councilName(council.getCouncilName())
+                .region(council.getRegion())
+                .activityCategory(council.getActivityCategory())
                 .leaderUserId(council.getLeader().getUserId())
                 .leaderName(council.getLeader().getName())
                 .description(council.getDescription())
@@ -60,6 +64,8 @@ public class CouncilDetailResponse {
         return CouncilDetailResponse.builder()
                 .councilId(council.getCouncilId())
                 .councilName(council.getCouncilName())
+                .region(council.getRegion())
+                .activityCategory(council.getActivityCategory())
                 .leaderUserId(council.getLeader().getUserId())
                 .leaderName(council.getLeader().getName())
                 .description(council.getDescription())

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/council/dto/CouncilListResponse.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/council/dto/CouncilListResponse.java
@@ -18,6 +18,7 @@ public class CouncilListResponse {
     public static class CouncilItem {
         private Long councilId;
         private String councilName;
+        private String region;
         private Long memberCount;
         private String profileImageUrl;
 
@@ -25,6 +26,7 @@ public class CouncilListResponse {
             return CouncilItem.builder()
                     .councilId(council.getCouncilId())
                     .councilName(council.getCouncilName())
+                    .region(council.getRegion())
                     .memberCount(memberCount)
                     .profileImageUrl(null)  // 이미지 처리
                     .build();

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/council/dto/CouncilListResponse.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/council/dto/CouncilListResponse.java
@@ -4,21 +4,30 @@ import com.solif.backend.domain.council.entity.Council;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.util.List;
+
 @Getter
 @Builder
 public class CouncilListResponse {
 
-    private Long councilId;
-    private String councilName;
-    private Long memberCount;
-    private String profileImageUrl;
+    private CouncilMyResponse myCouncil;  // 본인 자치회 정보 (없으면 null)
+    private List<CouncilItem> councils;   // 전체 자치회 리스트
 
-    public static CouncilListResponse from(Council council, Long memberCount) {
-        return CouncilListResponse.builder()
-                .councilId(council.getCouncilId())
-                .councilName(council.getCouncilName())
-                .memberCount(memberCount)
-                .profileImageUrl(null)  // 이미지 처리
-                .build();
+    @Getter
+    @Builder
+    public static class CouncilItem {
+        private Long councilId;
+        private String councilName;
+        private Long memberCount;
+        private String profileImageUrl;
+
+        public static CouncilItem from(Council council, Long memberCount) {
+            return CouncilItem.builder()
+                    .councilId(council.getCouncilId())
+                    .councilName(council.getCouncilName())
+                    .memberCount(memberCount)
+                    .profileImageUrl(null)  // 이미지 처리
+                    .build();
+        }
     }
 }

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/council/dto/CouncilListResponse.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/council/dto/CouncilListResponse.java
@@ -1,0 +1,24 @@
+package com.solif.backend.domain.council.dto;
+
+import com.solif.backend.domain.council.entity.Council;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class CouncilListResponse {
+
+    private Long councilId;
+    private String councilName;
+    private Long memberCount;
+    private String profileImageUrl;
+
+    public static CouncilListResponse from(Council council, Long memberCount) {
+        return CouncilListResponse.builder()
+                .councilId(council.getCouncilId())
+                .councilName(council.getCouncilName())
+                .memberCount(memberCount)
+                .profileImageUrl(null)  // 이미지 처리
+                .build();
+    }
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/council/dto/CouncilMyResponse.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/council/dto/CouncilMyResponse.java
@@ -1,0 +1,33 @@
+package com.solif.backend.domain.council.dto;
+
+import com.solif.backend.domain.council.entity.Council;
+import com.solif.backend.domain.council.entity.CouncilMemberRole;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class CouncilMyResponse {
+
+    private Long councilId;
+    private String councilName;
+    private Long currentBudget;
+    private Long totalBudget;
+    private Long memberCount;
+    private String role;
+
+    public static CouncilMyResponse from(
+            Council council,
+            Long memberCount,
+            CouncilMemberRole role
+    ) {
+        return CouncilMyResponse.builder()
+                .councilId(council.getCouncilId())
+                .councilName(council.getCouncilName())
+                .currentBudget(council.getCurrentBudget())
+                .totalBudget(council.getTotalBudget())
+                .memberCount(memberCount)
+                .role(role.name())
+                .build();
+    }
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/council/dto/CouncilUpdateRequest.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/council/dto/CouncilUpdateRequest.java
@@ -12,6 +12,12 @@ public class CouncilUpdateRequest {
     @NotBlank(message = "자치회 이름은 필수입니다.")
     private String councilName;
 
+    @NotBlank(message = "활동 지역은 필수입니다.")
+    private String region;
+
+    @NotBlank(message = "활동 주제는 필수입니다.")
+    private String activityCategory;
+
     private String description;
 
     @NotNull(message = "총 예산은 필수입니다.")

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/council/dto/CouncilUpdateRequest.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/council/dto/CouncilUpdateRequest.java
@@ -22,4 +22,6 @@ public class CouncilUpdateRequest {
 
     @NotNull(message = "총 예산은 필수입니다.")
     private Long totalBudget;
+
+    private Long profileImageFileId;
 }

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/council/dto/CouncilUpdateRequest.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/council/dto/CouncilUpdateRequest.java
@@ -1,0 +1,19 @@
+package com.solif.backend.domain.council.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class CouncilUpdateRequest {
+
+    @NotBlank(message = "자치회 이름은 필수입니다.")
+    private String councilName;
+
+    private String description;
+
+    @NotNull(message = "총 예산은 필수입니다.")
+    private Long totalBudget;
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/council/entity/Council.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/council/entity/Council.java
@@ -69,12 +69,13 @@ public class Council {
     // 비즈니스 로직
     public void updateCouncil(String councilName, String region,
                               String activityCategory, String description,
-                              Long totalBudget) {
+                              Long totalBudget, Long profileImageFileId) {
         this.councilName = councilName;
         this.region = region;
         this.activityCategory = activityCategory;
         this.description = description;
         this.totalBudget = totalBudget;
+        this.profileImageFileId = profileImageFileId;
     }
 
     public void decreaseBudget(Long usedBudget) {

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/council/entity/Council.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/council/entity/Council.java
@@ -1,6 +1,8 @@
 package com.solif.backend.domain.council.entity;
 
+import com.solif.backend.domain.council.code.CouncilErrorCode;
 import com.solif.backend.domain.user.entity.User;
+import com.solif.backend.global.common.exception.CustomException;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -70,6 +72,17 @@ public class Council {
     public void updateCouncil(String councilName, String region,
                               String activityCategory, String description,
                               Long totalBudget, Long profileImageFileId) {
+        // 사용한 예산 계산
+        Long usedBudget = this.totalBudget - this.currentBudget;
+
+        // 총 예산이 줄어들었을 때, 이미 사용한 예산보다 작으면 에러
+        if (totalBudget < usedBudget) {
+            throw new CustomException(CouncilErrorCode.BUDGET_REDUCTION_NOT_ALLOWED);
+        }
+
+        // 총 예산 변경에 따른 남은 예산 조정
+        this.currentBudget = totalBudget - usedBudget;
+
         this.councilName = councilName;
         this.region = region;
         this.activityCategory = activityCategory;
@@ -79,10 +92,12 @@ public class Council {
     }
 
     public void decreaseBudget(Long usedBudget) {
-        if (this.currentBudget < usedBudget) {
-            throw new IllegalArgumentException("예산이 부족합니다.");
+        if (usedBudget == null || usedBudget <= 0) {
+            throw new IllegalArgumentException("사용 예산은 0 이상이어야 합니다.");
         }
-        this.currentBudget -= usedBudget;
+
+        // 예산 초과 허용, 단 currentBudget은 음수 불가 (0원으로 표시)
+        this.currentBudget = Math.max(0L, this.currentBudget - usedBudget);
     }
 
     public boolean isLeader(Long userId) {

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/council/entity/Council.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/council/entity/Council.java
@@ -1,0 +1,77 @@
+package com.solif.backend.domain.council.entity;
+
+import com.solif.backend.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "council")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class Council {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "council_id")
+    private Long councilId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "leader_user_id", nullable = false)
+    private User leader;
+
+    @Column(name = "council_name", nullable = false, length = 100)
+    private String councilName;
+
+    @Column(name = "description", columnDefinition = "TEXT")
+    private String description;
+
+    @Column(name = "total_budget", nullable = false)
+    private Long totalBudget = 0L;
+
+    @Column(name = "current_budget", nullable = false)
+    private Long currentBudget = 0L;
+
+    @Column(name = "profile_image_file_id")
+    private Long profileImageFileId;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Builder
+    public Council(User leader, String councilName, String description,
+                   Long totalBudget, Long profileImageFileId) {
+        this.leader = leader;
+        this.councilName = councilName;
+        this.description = description;
+        this.totalBudget = totalBudget != null ? totalBudget : 0L;
+        this.currentBudget = totalBudget != null ? totalBudget : 0L;
+        this.profileImageFileId = profileImageFileId;
+    }
+
+    // 비즈니스 로직
+    public void updateCouncil(String councilName, String description, Long totalBudget) {
+        this.councilName = councilName;
+        this.description = description;
+        this.totalBudget = totalBudget;
+    }
+
+    public void decreaseBudget(Long usedBudget) {
+        if (this.currentBudget < usedBudget) {
+            throw new IllegalArgumentException("예산이 부족합니다.");
+        }
+        this.currentBudget -= usedBudget;
+    }
+
+    public boolean isLeader(Long userId) {
+        return this.leader.getUserId().equals(userId);
+    }
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/council/entity/Council.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/council/entity/Council.java
@@ -30,6 +30,12 @@ public class Council {
     @Column(name = "council_name", nullable = false, length = 100)
     private String councilName;
 
+    @Column(name = "region", length = 50)
+    private String region;  // 활동 지역
+
+    @Column(name = "activity_category", length = 50)
+    private String activityCategory;  // 활동 주제
+
     @Column(name = "description", columnDefinition = "TEXT")
     private String description;
 
@@ -47,10 +53,13 @@ public class Council {
     private LocalDateTime createdAt;
 
     @Builder
-    public Council(User leader, String councilName, String description,
+    public Council(User leader, String councilName, String region,
+                   String activityCategory, String description,
                    Long totalBudget, Long profileImageFileId) {
         this.leader = leader;
         this.councilName = councilName;
+        this.region = region;
+        this.activityCategory = activityCategory;
         this.description = description;
         this.totalBudget = totalBudget != null ? totalBudget : 0L;
         this.currentBudget = totalBudget != null ? totalBudget : 0L;
@@ -58,8 +67,12 @@ public class Council {
     }
 
     // 비즈니스 로직
-    public void updateCouncil(String councilName, String description, Long totalBudget) {
+    public void updateCouncil(String councilName, String region,
+                              String activityCategory, String description,
+                              Long totalBudget) {
         this.councilName = councilName;
+        this.region = region;
+        this.activityCategory = activityCategory;
         this.description = description;
         this.totalBudget = totalBudget;
     }

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/council/entity/Council.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/council/entity/Council.java
@@ -92,7 +92,7 @@ public class Council {
     }
 
     public void decreaseBudget(Long usedBudget) {
-        if (usedBudget == null || usedBudget <= 0) {
+        if (usedBudget == null || usedBudget < 0) {
             throw new IllegalArgumentException("사용 예산은 0 이상이어야 합니다.");
         }
 

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/council/entity/CouncilMember.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/council/entity/CouncilMember.java
@@ -12,7 +12,15 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "council_member")
+@Table(
+        name = "council_member",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_council_member_user",
+                        columnNames = {"user_id"}
+                )
+        }
+)
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @EntityListeners(AuditingEntityListener.class)

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/council/entity/CouncilMember.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/council/entity/CouncilMember.java
@@ -1,0 +1,57 @@
+package com.solif.backend.domain.council.entity;
+
+import com.solif.backend.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "council_member")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class CouncilMember {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "council_member_id")
+    private Long councilMemberId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "council_id", nullable = false)
+    private Council council;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "role", nullable = false)
+    private CouncilMemberRole role = CouncilMemberRole.MEMBER;
+
+    @CreatedDate
+    @Column(name = "joined_at", nullable = false, updatable = false)
+    private LocalDateTime joinedAt;
+
+    @Builder
+    public CouncilMember(User user, Council council, CouncilMemberRole role) {
+        this.user = user;
+        this.council = council;
+        this.role = role != null ? role : CouncilMemberRole.MEMBER;
+    }
+
+    // 비즈니스 로직
+    public boolean isLeader() {
+        return this.role == CouncilMemberRole.LEADER;
+    }
+
+    public boolean isMember() {
+        return this.role == CouncilMemberRole.MEMBER;
+    }
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/council/entity/CouncilMemberRole.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/council/entity/CouncilMemberRole.java
@@ -1,0 +1,6 @@
+package com.solif.backend.domain.council.entity;
+
+public enum CouncilMemberRole {
+    LEADER,   // 자치회 리더
+    MEMBER    // 일반 멤버
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/council/entity/CouncilRule.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/council/entity/CouncilRule.java
@@ -1,0 +1,51 @@
+package com.solif.backend.domain.council.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "council_rule")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class CouncilRule {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "council_rule_id")
+    private Long councilRuleId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "council_id", nullable = false)
+    private Council council;
+
+    @Column(name = "rule_content", nullable = false, length = 255)
+    private String ruleContent;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Builder
+    public CouncilRule(Council council, String ruleContent) {
+        this.council = council;
+        this.ruleContent = ruleContent;
+    }
+
+    // 비즈니스 로직
+    public void updateRuleContent(String ruleContent) {
+        this.ruleContent = ruleContent;
+    }
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/council/repository/CouncilMemberRepository.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/council/repository/CouncilMemberRepository.java
@@ -1,0 +1,33 @@
+package com.solif.backend.domain.council.repository;
+
+import com.solif.backend.domain.council.entity.Council;
+import com.solif.backend.domain.council.entity.CouncilMember;
+import com.solif.backend.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface CouncilMemberRepository extends JpaRepository<CouncilMember, Long> {
+
+    // 자치회와 사용자로 멤버 조회
+    Optional<CouncilMember> findByCouncilAndUser(Council council, User user);
+
+    // 자치회로 멤버 수 조회
+    Long countByCouncil(Council council);
+
+    // 자치회로 멤버 목록 조회 (User 정보 JOIN FETCH)
+    @Query("SELECT cm FROM CouncilMember cm JOIN FETCH cm.user WHERE cm.council = :council ORDER BY cm.role DESC, cm.joinedAt ASC")
+    List<CouncilMember> findByCouncilOrderByRoleDescJoinedAtAsc(@Param("council") Council council);
+
+    // 사용자로 소속 자치회 조회
+    Optional<CouncilMember> findByUser(User user);
+
+    // 자치회와 사용자 목록으로 멤버 삭제
+    @Modifying
+    @Query("DELETE FROM CouncilMember cm WHERE cm.council = :council AND cm.user IN :users")
+    int deleteByCouncilAndUserIn(@Param("council") Council council, @Param("users") List<User> users);
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/council/repository/CouncilMemberRepository.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/council/repository/CouncilMemberRepository.java
@@ -27,7 +27,7 @@ public interface CouncilMemberRepository extends JpaRepository<CouncilMember, Lo
     Optional<CouncilMember> findByUser(User user);
 
     // 자치회와 사용자 목록으로 멤버 삭제
-    @Modifying
+    @Modifying(clearAutomatically = true)
     @Query("DELETE FROM CouncilMember cm WHERE cm.council = :council AND cm.user IN :users")
     int deleteByCouncilAndUserIn(@Param("council") Council council, @Param("users") List<User> users);
 }

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/council/repository/CouncilRepository.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/council/repository/CouncilRepository.java
@@ -1,0 +1,7 @@
+package com.solif.backend.domain.council.repository;
+
+import com.solif.backend.domain.council.entity.Council;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CouncilRepository extends JpaRepository<Council, Long> {
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/council/repository/CouncilRuleRepository.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/council/repository/CouncilRuleRepository.java
@@ -1,0 +1,13 @@
+package com.solif.backend.domain.council.repository;
+
+import com.solif.backend.domain.council.entity.Council;
+import com.solif.backend.domain.council.entity.CouncilRule;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface CouncilRuleRepository extends JpaRepository<CouncilRule, Long> {
+
+    // 자치회로 활동 규칙 목록 조회
+    List<CouncilRule> findByCouncilOrderByCreatedAtAsc(Council council);
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/council/service/CouncilService.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/council/service/CouncilService.java
@@ -183,6 +183,13 @@ public class CouncilService {
                     throw new CustomException(AuthErrorCode.USER_NOT_FOUND);
                 }
 
+                // 이미 자치회에 소속된 사용자 검증
+                for (User member : members) {
+                    councilMemberRepository.findByUser(member).ifPresent(existingMember -> {
+                        throw new CustomException(CouncilErrorCode.ALREADY_IN_COUNCIL);
+                    });
+                }
+
                 List<CouncilMember> councilMembers = members.stream()
                         .map(member -> CouncilMember.builder()
                                 .user(member)

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/council/service/CouncilService.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/council/service/CouncilService.java
@@ -223,7 +223,8 @@ public class CouncilService {
                 request.getRegion(),
                 request.getActivityCategory(),
                 request.getDescription(),
-                request.getTotalBudget()
+                request.getTotalBudget(),
+                request.getProfileImageFileId()
         );
     }
 }

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/council/service/CouncilService.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/council/service/CouncilService.java
@@ -169,18 +169,31 @@ public class CouncilService {
         // 초대된 멤버들 MEMBER로 등록
         int addedMemberCount = 0;
         if (request.getMemberUserIds() != null && !request.getMemberUserIds().isEmpty()) {
-            List<User> members = userRepository.findAllById(request.getMemberUserIds());
-
-            List<CouncilMember> councilMembers = members.stream()
-                    .map(member -> CouncilMember.builder()
-                            .user(member)
-                            .council(savedCouncil)
-                            .role(CouncilMemberRole.MEMBER)
-                            .build())
+            // 리더 제외 + 중복 제거
+            List<Long> memberIds = request.getMemberUserIds().stream()
+                    .filter(id -> !id.equals(userId))
+                    .distinct()
                     .collect(Collectors.toList());
 
-            councilMemberRepository.saveAll(councilMembers);
-            addedMemberCount = councilMembers.size();
+            if (!memberIds.isEmpty()) {
+                List<User> members = userRepository.findAllById(memberIds);
+
+                // 존재하지 않는 사용자 ID 검증
+                if (members.size() != memberIds.size()) {
+                    throw new CustomException(AuthErrorCode.USER_NOT_FOUND);
+                }
+
+                List<CouncilMember> councilMembers = members.stream()
+                        .map(member -> CouncilMember.builder()
+                                .user(member)
+                                .council(savedCouncil)
+                                .role(CouncilMemberRole.MEMBER)
+                                .build())
+                        .collect(Collectors.toList());
+
+                councilMemberRepository.saveAll(councilMembers);
+                addedMemberCount = councilMembers.size();
+            }
         }
 
         // 활동 규칙 추가

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/council/service/CouncilService.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/council/service/CouncilService.java
@@ -1,0 +1,210 @@
+package com.solif.backend.domain.council.service;
+
+import com.solif.backend.domain.auth.exception.AuthErrorCode;
+import com.solif.backend.domain.council.code.CouncilErrorCode;
+import com.solif.backend.domain.council.dto.*;
+import com.solif.backend.domain.council.entity.Council;
+import com.solif.backend.domain.council.entity.CouncilMember;
+import com.solif.backend.domain.council.entity.CouncilMemberRole;
+import com.solif.backend.domain.council.repository.CouncilMemberRepository;
+import com.solif.backend.domain.council.repository.CouncilRepository;
+import com.solif.backend.domain.user.entity.User;
+import com.solif.backend.domain.user.repository.UserRepository;
+import com.solif.backend.global.common.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CouncilService {
+
+    private final CouncilRepository councilRepository;
+    private final CouncilMemberRepository councilMemberRepository;
+    private final UserRepository userRepository;
+
+    // 자치회 목록 조회
+    public CouncilListResponse getCouncils(Long userId) {
+        log.info("자치회 목록 조회 - userId: {}", userId);
+
+        // 사용자 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(AuthErrorCode.USER_NOT_FOUND));
+
+        // 내 자치회 조회
+        CouncilMyResponse myCouncil = getMyCouncil(userId);
+
+        // 전체 자치회 목록 조회
+        List<Council> councils = councilRepository.findAll();
+
+        List<CouncilListResponse.CouncilItem> councilItems = councils.stream()
+                .map(council -> {
+                    Long memberCount = councilMemberRepository.countByCouncil(council);
+                    return CouncilListResponse.CouncilItem.from(council, memberCount);
+                })
+                .collect(Collectors.toList());
+
+        return CouncilListResponse.builder()
+                .myCouncil(myCouncil)  // 있으면 정보, 없으면 null
+                .councils(councilItems)
+                .build();
+    }
+
+    // 내 자치회 조회 (홈 화면용)
+    public CouncilMyResponse getMyCouncil(Long userId) {
+        log.info("내 자치회 조회 - userId: {}", userId);
+
+        // 사용자 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(AuthErrorCode.USER_NOT_FOUND));
+
+        // 사용자의 자치회 멤버십 조회
+        CouncilMember myMembership = councilMemberRepository.findByUser(user)
+                .orElse(null);
+
+        if (myMembership == null) {
+            return null;  // 소속 자치회 없음
+        }
+
+        // 자치회 조회
+        Council council = myMembership.getCouncil();
+
+        // 멤버 수 조회
+        Long memberCount = councilMemberRepository.countByCouncil(council);
+
+        return CouncilMyResponse.from(council, memberCount, myMembership.getRole());
+    }
+
+    // 자치회 상세 조회
+    public CouncilDetailResponse getCouncilDetail(Long userId, Long councilId) {
+        log.info("자치회 상세 조회 - councilId: {}, userId: {}", councilId, userId);
+
+        // 사용자 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(AuthErrorCode.USER_NOT_FOUND));
+
+        // 자치회 조회
+        Council council = councilRepository.findById(councilId)
+                .orElseThrow(() -> new CustomException(CouncilErrorCode.COUNCIL_NOT_FOUND));
+
+        // 현재 사용자의 역할 확인
+        CouncilMember myMembership = councilMemberRepository
+                .findByCouncilAndUser(council, user)
+                .orElse(null);
+
+        // 멤버 수 조회
+        Long memberCount = councilMemberRepository.countByCouncil(council);
+
+        // 본인 자치회인 경우
+        if (myMembership != null) {
+            // 활동 후기 수 조회 (나중에 구현)
+            Long activityCount = 0L;
+
+            // 생성 이후 개월 수 계산
+            Long monthsSinceCreation = ChronoUnit.MONTHS.between(
+                    council.getCreatedAt().toLocalDate().withDayOfMonth(1),
+                    LocalDateTime.now().toLocalDate().withDayOfMonth(1)
+            );
+
+            return CouncilDetailResponse.forMember(
+                    council,
+                    memberCount,
+                    activityCount,
+                    monthsSinceCreation,
+                    myMembership.getRole()
+            );
+        } else {
+            // 다른 자치회인 경우
+            return CouncilDetailResponse.forNonMember(council, memberCount);
+        }
+    }
+
+    // 자치회 생성
+    @Transactional
+    public CouncilCreateResponse createCouncil(Long userId, CouncilCreateRequest request) {
+        log.info("자치회 생성 - userId: {}, councilName: {}", userId, request.getCouncilName());
+
+        // 사용자 조회
+        User leader = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(AuthErrorCode.USER_NOT_FOUND));
+
+        // 자치회 생성
+        Council council = Council.builder()
+                .leader(leader)
+                .councilName(request.getCouncilName())
+                .description(request.getDescription())
+                .totalBudget(request.getTotalBudget())
+                .profileImageFileId(request.getProfileImageFileId())
+                .build();
+
+        Council savedCouncil = councilRepository.save(council);
+
+        // 리더를 CouncilMember에 LEADER로 등록
+        CouncilMember leaderMember = CouncilMember.builder()
+                .user(leader)
+                .council(savedCouncil)
+                .role(CouncilMemberRole.LEADER)
+                .build();
+
+        councilMemberRepository.save(leaderMember);
+
+        // 초대된 멤버들 MEMBER로 등록
+        int addedMemberCount = 0;
+        if (request.getMemberUserIds() != null && !request.getMemberUserIds().isEmpty()) {
+            List<User> members = userRepository.findAllById(request.getMemberUserIds());
+
+            List<CouncilMember> councilMembers = members.stream()
+                    .map(member -> CouncilMember.builder()
+                            .user(member)
+                            .council(savedCouncil)
+                            .role(CouncilMemberRole.MEMBER)
+                            .build())
+                    .collect(Collectors.toList());
+
+            councilMemberRepository.saveAll(councilMembers);
+            addedMemberCount = councilMembers.size();
+        }
+
+        // 멤버들한테 알림 발송
+
+        return CouncilCreateResponse.from(savedCouncil, addedMemberCount + 1);
+    }
+
+    // 자치회 수정
+    @Transactional
+    public void updateCouncil(Long userId, Long councilId, CouncilUpdateRequest request) {
+        log.info("자치회 수정 - userId: {}, councilId: {}", userId, councilId);
+
+        // 사용자 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(AuthErrorCode.USER_NOT_FOUND));
+
+        // 자치회 조회
+        Council council = councilRepository.findById(councilId)
+                .orElseThrow(() -> new CustomException(CouncilErrorCode.COUNCIL_NOT_FOUND));
+
+        // 리더 권한 확인
+        CouncilMember member = councilMemberRepository
+                .findByCouncilAndUser(council, user)
+                .orElseThrow(() -> new CustomException(CouncilErrorCode.NOT_COUNCIL_MEMBER));
+
+        if (!member.isLeader()) {
+            throw new CustomException(CouncilErrorCode.ONLY_LEADER_CAN_UPDATE);
+        }
+
+        // 자치회 수정
+        council.updateCouncil(
+                request.getCouncilName(),
+                request.getDescription(),
+                request.getTotalBudget()
+        );
+    }
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/council/service/CouncilService.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/council/service/CouncilService.java
@@ -139,6 +139,11 @@ public class CouncilService {
         User leader = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(AuthErrorCode.USER_NOT_FOUND));
 
+        // 이미 자치회에 소속되어 있는지 확인
+        councilMemberRepository.findByUser(leader).ifPresent(existingMember -> {
+            throw new CustomException(CouncilErrorCode.ALREADY_IN_COUNCIL);
+        });
+
         // 자치회 생성
         Council council = Council.builder()
                 .leader(leader)

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/council/service/CouncilService.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/council/service/CouncilService.java
@@ -6,8 +6,10 @@ import com.solif.backend.domain.council.dto.*;
 import com.solif.backend.domain.council.entity.Council;
 import com.solif.backend.domain.council.entity.CouncilMember;
 import com.solif.backend.domain.council.entity.CouncilMemberRole;
+import com.solif.backend.domain.council.entity.CouncilRule;
 import com.solif.backend.domain.council.repository.CouncilMemberRepository;
 import com.solif.backend.domain.council.repository.CouncilRepository;
+import com.solif.backend.domain.council.repository.CouncilRuleRepository;
 import com.solif.backend.domain.user.entity.User;
 import com.solif.backend.domain.user.repository.UserRepository;
 import com.solif.backend.global.common.exception.CustomException;
@@ -29,6 +31,7 @@ public class CouncilService {
 
     private final CouncilRepository councilRepository;
     private final CouncilMemberRepository councilMemberRepository;
+    private final CouncilRuleRepository councilRuleRepository;
     private final UserRepository userRepository;
 
     // 자치회 목록 조회
@@ -140,6 +143,8 @@ public class CouncilService {
         Council council = Council.builder()
                 .leader(leader)
                 .councilName(request.getCouncilName())
+                .region(request.getRegion())
+                .activityCategory(request.getActivityCategory())
                 .description(request.getDescription())
                 .totalBudget(request.getTotalBudget())
                 .profileImageFileId(request.getProfileImageFileId())
@@ -173,7 +178,19 @@ public class CouncilService {
             addedMemberCount = councilMembers.size();
         }
 
-        // 멤버들한테 알림 발송
+        // 활동 규칙 추가
+        if (request.getRules() != null && !request.getRules().isEmpty()) {
+            List<CouncilRule> rules = request.getRules().stream()
+                    .map(ruleContent -> CouncilRule.builder()
+                            .council(savedCouncil)
+                            .ruleContent(ruleContent)
+                            .build())
+                    .collect(Collectors.toList());
+
+            councilRuleRepository.saveAll(rules);
+        }
+
+        // 알림 발송
 
         return CouncilCreateResponse.from(savedCouncil, addedMemberCount + 1);
     }
@@ -203,6 +220,8 @@ public class CouncilService {
         // 자치회 수정
         council.updateCouncil(
                 request.getCouncilName(),
+                request.getRegion(),
+                request.getActivityCategory(),
                 request.getDescription(),
                 request.getTotalBudget()
         );


### PR DESCRIPTION
## 🔍 개요
자치회 기본 CRUD 기능을 구현

## ✨ 변경 사항
- Council, CouncilMember, CouncilRule 엔티티 생성
- 자치회 목록/상세/생성/수정 API 구현
- 자치회 생성 시 멤버 초대 및 활동 규칙 자동 생성
- 본인 자치회 유무에 따른 응답 분기 처리
- region, activityCategory 필드 추가
- 프로필 이미지 수정 지원

## 🧪 테스트
- [x] 로컬 테스트 완료
- [x] API 테스트 완료
- [ ] 테스트 코드 작성 (해당 시)

## 📎 관련 이슈
Closes: #43 

## ⚠️ 참고 사항
- 자치회 생성 시 리더가 자동으로 CouncilMember 테이블에 LEADER 역할로 등록됩니다
- 자치회 목록 조회 시 본인 자치회 정보('myCouncil')도 함께 반환됩니다
- 활동 규칙은 자치회 생성 시 배열('rules')로 받아 자동 생성됩니다
- 활동 멤버/활동 규칙 상세 API는 이후의 Issue에서 구현 예정입니다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 자치회 목록/상세 조회, 내 자치회 조회, 생성 및 수정 API 추가
  * 자치회 회원 초대·관리 및 역할(리더/회원) 지원
  * 자치회 규칙 등록·수정 기능 추가
  * 자치회 예산 관리(총예산/현재예산 업데이트 및 사용 처리) 기능 추가
  * 표준화된 성공/오류 코드와 사용자 안내 메시지 추가하여 응답 일관성 향상

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->