### PR TITLE
fature : 쪽지 기능 구현

### DIFF
--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/message/code/MessageErrorCode.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/message/code/MessageErrorCode.java
@@ -1,0 +1,21 @@
+package com.solif.backend.domain.message.code;
+
+import com.solif.backend.global.common.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum MessageErrorCode implements ErrorCode {
+
+    MESSAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "MESSAGE_ERR_001", "쪽지를 찾을 수 없습니다."),
+    UNAUTHORIZED_MESSAGE_ACCESS(HttpStatus.FORBIDDEN, "MESSAGE_ERR_002", "쪽지에 대한 접근 권한이 없습니다."),
+    CANNOT_SEND_TO_SELF(HttpStatus.BAD_REQUEST, "MESSAGE_ERR_003", "자기 자신에게 쪽지를 보낼 수 없습니다."),
+    RECEIVER_NOT_FOUND(HttpStatus.NOT_FOUND, "MESSAGE_ERR_004", "받는 사람을 찾을 수 없습니다."),
+    ALREADY_DELETED_MESSAGE(HttpStatus.GONE, "MESSAGE_ERR_005", "이미 삭제된 쪽지입니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/message/code/MessageSuccessCode.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/message/code/MessageSuccessCode.java
@@ -1,0 +1,21 @@
+package com.solif.backend.domain.message.code;
+
+import com.solif.backend.global.common.response.SuccessCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum MessageSuccessCode implements SuccessCode {
+
+    MESSAGE_SEND_SUCCESS(HttpStatus.CREATED, "MESSAGE_001", "쪽지가 성공적으로 발송되었습니다."),
+    MESSAGE_RECEIVED_LIST_SUCCESS(HttpStatus.OK, "MESSAGE_002", "받은 쪽지 목록 조회에 성공했습니다."),
+    MESSAGE_SENT_LIST_SUCCESS(HttpStatus.OK, "MESSAGE_003", "보낸 쪽지 목록 조회에 성공했습니다."),
+    MESSAGE_DETAIL_SUCCESS(HttpStatus.OK, "MESSAGE_004", "쪽지 상세 조회에 성공했습니다."),
+    MESSAGE_DELETE_SUCCESS(HttpStatus.OK, "MESSAGE_005", "쪽지가 삭제되었습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/message/controller/MessageController.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/message/controller/MessageController.java
@@ -1,0 +1,101 @@
+package com.solif.backend.domain.message.controller;
+
+import com.solif.backend.domain.message.code.MessageSuccessCode;
+import com.solif.backend.domain.message.dto.*;
+import com.solif.backend.domain.message.service.MessageService;
+import com.solif.backend.global.common.response.ResponseFactory;
+import com.solif.backend.global.common.response.SuccessResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "쪽지", description = "쪽지 API")
+@RestController
+@RequestMapping("/api/v1/messages")
+@RequiredArgsConstructor
+public class MessageController {
+
+    private final MessageService messageService;
+
+    @Operation(
+            summary = "쪽지 발송",
+            description = "새로운 쪽지를 발송합니다.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @PostMapping
+    public ResponseEntity<SuccessResponse<MessageSendResponse>> sendMessage(
+            @AuthenticationPrincipal Long userId,
+            @Valid @RequestBody MessageSendRequest request
+    ) {
+        MessageSendResponse response = messageService.sendMessage(userId, request);
+        return ResponseFactory.success(MessageSuccessCode.MESSAGE_SEND_SUCCESS, response);
+    }
+
+    @Operation(
+            summary = "받은 쪽지 목록 조회",
+            description = "받은 쪽지 목록을 페이징하여 조회합니다.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @GetMapping("/received")
+    public ResponseEntity<SuccessResponse<Slice<MessageListResponse>>> getReceivedMessages(
+            @AuthenticationPrincipal Long userId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size
+    ) {
+        Pageable pageable = PageRequest.of(page, size);
+        Slice<MessageListResponse> messages = messageService.getReceivedMessages(userId, pageable);
+        return ResponseFactory.success(MessageSuccessCode.MESSAGE_RECEIVED_LIST_SUCCESS, messages);
+    }
+
+    @Operation(
+            summary = "보낸 쪽지 목록 조회",
+            description = "보낸 쪽지 목록을 페이징하여 조회합니다.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @GetMapping("/sent")
+    public ResponseEntity<SuccessResponse<Slice<MessageListResponse>>> getSentMessages(
+            @AuthenticationPrincipal Long userId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size
+    ) {
+        Pageable pageable = PageRequest.of(page, size);
+        Slice<MessageListResponse> messages = messageService.getSentMessages(userId, pageable);
+        return ResponseFactory.success(MessageSuccessCode.MESSAGE_SENT_LIST_SUCCESS, messages);
+    }
+
+    @Operation(
+            summary = "쪽지 상세 조회",
+            description = "쪽지 상세 내용을 조회합니다. 수신자가 조회 시 읽음 처리됩니다.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @GetMapping("/{messageId}")
+    public ResponseEntity<SuccessResponse<MessageDetailResponse>> getMessageDetail(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long messageId
+    ) {
+        MessageDetailResponse response = messageService.getMessageDetail(userId, messageId);
+        return ResponseFactory.success(MessageSuccessCode.MESSAGE_DETAIL_SUCCESS, response);
+    }
+
+    @Operation(
+            summary = "쪽지 삭제",
+            description = "쪽지를 삭제합니다. 발신자/수신자 각각 삭제 가능합니다.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @DeleteMapping("/{messageId}")
+    public ResponseEntity<SuccessResponse<Void>> deleteMessage(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long messageId
+    ) {
+        messageService.deleteMessage(userId, messageId);
+        return ResponseFactory.success(MessageSuccessCode.MESSAGE_DELETE_SUCCESS);
+    }
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/message/dto/MessageDetailResponse.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/message/dto/MessageDetailResponse.java
@@ -1,0 +1,52 @@
+package com.solif.backend.domain.message.dto;
+
+import com.solif.backend.domain.message.entity.Message;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+@Schema(description = "쪽지 상세 응답")
+public class MessageDetailResponse {
+
+    @Schema(description = "쪽지 ID", example = "1")
+    private Long messageId;
+
+    @Schema(description = "보낸 사람 ID", example = "2")
+    private Long senderId;
+
+    @Schema(description = "보낸 사람 이름", example = "박민수")
+    private String senderName;
+
+    @Schema(description = "쪽지 제목", example = "한국대학교 재학생 박민수 입니다.")
+    private String messageTitle;
+
+    @Schema(description = "쪽지 내용")
+    private String messageContent;
+
+    @Schema(description = "읽은 시간", nullable = true)
+    private LocalDateTime readAt;
+
+    @Schema(description = "발송 일시", example = "2026-01-31T12:00:00")
+    private LocalDateTime createdAt;
+
+    @Schema(description = "첨부 파일 URL 목록", nullable = true)
+    private List<String> fileUrls;
+
+    public static MessageDetailResponse from(Message message, List<String> fileUrls) {
+        return MessageDetailResponse.builder()
+                .messageId(message.getMessageId())
+                .senderId(message.getSender().getUserId())
+                .senderName(message.getSender().getName())
+                .messageTitle(message.getMessageTitle())
+                .messageContent(message.getMessageContent())
+                .readAt(message.getReadAt())
+                .createdAt(message.getCreatedAt())
+                .fileUrls(fileUrls)
+                .build();
+    }
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/message/dto/MessageListResponse.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/message/dto/MessageListResponse.java
@@ -1,0 +1,51 @@
+package com.solif.backend.domain.message.dto;
+
+import com.solif.backend.domain.message.entity.Message;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@Schema(description = "쪽지 목록 응답")
+public class MessageListResponse {
+
+    @Schema(description = "쪽지 ID", example = "1")
+    private Long messageId;
+
+    @Schema(description = "상대방 이름 (받은 쪽지: 보낸 사람, 보낸 쪽지: 받는 사람)", example = "박민수")
+    private String counterpartName;
+
+    @Schema(description = "쪽지 제목", example = "한국대학교 재학생 박민수 입니다.")
+    private String messageTitle;
+
+    @Schema(description = "읽음 여부", example = "false")
+    private Boolean isRead;
+
+    @Schema(description = "발송 일시", example = "2026-01-31T12:00:00")
+    private LocalDateTime createdAt;
+
+    // 받은 쪽지용
+    public static MessageListResponse fromReceived(Message message) {
+        return MessageListResponse.builder()
+                .messageId(message.getMessageId())
+                .counterpartName(message.getSender().getName())
+                .messageTitle(message.getMessageTitle())
+                .isRead(message.getIsRead())
+                .createdAt(message.getCreatedAt())
+                .build();
+    }
+
+    // 보낸 쪽지용
+    public static MessageListResponse fromSent(Message message) {
+        return MessageListResponse.builder()
+                .messageId(message.getMessageId())
+                .counterpartName(message.getReceiver().getName())
+                .messageTitle(message.getMessageTitle())
+                .isRead(message.getIsRead())
+                .createdAt(message.getCreatedAt())
+                .build();
+    }
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/message/dto/MessageSendRequest.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/message/dto/MessageSendRequest.java
@@ -1,0 +1,32 @@
+package com.solif.backend.domain.message.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@Schema(description = "쪽지 발송 요청")
+public class MessageSendRequest {
+
+    @NotNull(message = "받는 사람 ID는 필수입니다.")
+    @Schema(description = "받는 사람 ID", example = "2")
+    private Long receiverId;
+
+    @NotBlank(message = "제목은 필수입니다.")
+    @Size(max = 255, message = "제목은 255자 이하여야 합니다.")
+    @Schema(description = "쪽지 제목", example = "자산 관리의 어려움")
+    private String messageTitle;
+
+    @NotBlank(message = "내용은 필수입니다.")
+    @Schema(description = "쪽지 내용", example = "대학생이 된 후 저의 자산을 어떻게 관리하는지 어려움을 느끼고 있습니다.")
+    private String messageContent;
+
+    @Schema(description = "첨부 파일 ID 목록", nullable = true)
+    private List<Long> fileIds;
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/message/dto/MessageSendResponse.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/message/dto/MessageSendResponse.java
@@ -1,0 +1,27 @@
+package com.solif.backend.domain.message.dto;
+
+import com.solif.backend.domain.message.entity.Message;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@Schema(description = "쪽지 발송 응답")
+public class MessageSendResponse {
+
+    @Schema(description = "쪽지 ID", example = "1")
+    private Long messageId;
+
+    @Schema(description = "발송 일시", example = "2026-01-31T12:00:00")
+    private LocalDateTime createdAt;
+
+    public static MessageSendResponse from(Message message) {
+        return MessageSendResponse.builder()
+                .messageId(message.getMessageId())
+                .createdAt(message.getCreatedAt())
+                .build();
+    }
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/message/entity/Message.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/message/entity/Message.java
@@ -1,0 +1,94 @@
+package com.solif.backend.domain.message.entity;
+
+import com.solif.backend.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "message")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class Message {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "message_id")
+    private Long messageId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "sender_id", nullable = false)
+    private User sender;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "receiver_id", nullable = false)
+    private User receiver;
+
+    @Column(name = "message_title", nullable = false, length = 255)
+    private String messageTitle;
+
+    @Column(name = "message_content", nullable = false, columnDefinition = "TEXT")
+    private String messageContent;
+
+    @Column(name = "is_read", nullable = false)
+    private Boolean isRead = false;
+
+    @Column(name = "read_at")
+    private LocalDateTime readAt;
+
+    @Column(name = "deleted_by_sender", nullable = false)
+    private Boolean deletedBySender = false;
+
+    @Column(name = "deleted_by_receiver", nullable = false)
+    private Boolean deletedByReceiver = false;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Builder
+    public Message(User sender, User receiver, String messageTitle, String messageContent) {
+        this.sender = sender;
+        this.receiver = receiver;
+        this.messageTitle = messageTitle;
+        this.messageContent = messageContent;
+        this.isRead = false;
+        this.deletedBySender = false;
+        this.deletedByReceiver = false;
+    }
+
+    // 비즈니스 로직
+    public void markAsRead() {
+        if (!this.isRead) {
+            this.isRead = true;
+            this.readAt = LocalDateTime.now();
+        }
+    }
+
+    public void deleteBySender() {
+        this.deletedBySender = true;
+    }
+
+    public void deleteByReceiver() {
+        this.deletedByReceiver = true;
+    }
+
+    public boolean isSender(Long userId) {
+        return this.sender.getUserId().equals(userId);
+    }
+
+    public boolean isReceiver(Long userId) {
+        return this.receiver.getUserId().equals(userId);
+    }
+
+    public boolean canAccess(Long userId) {
+        return isSender(userId) || isReceiver(userId);
+    }
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/message/repository/MessageRepository.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/message/repository/MessageRepository.java
@@ -1,0 +1,25 @@
+package com.solif.backend.domain.message.repository;
+
+import com.solif.backend.domain.message.entity.Message;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface MessageRepository extends JpaRepository<Message, Long> {
+
+    // 받은 쪽지 목록 (삭제되지 않은 것만)
+    @Query("SELECT m FROM Message m JOIN FETCH m.sender " +
+            "WHERE m.receiver.userId = :userId " +
+            "AND m.deletedByReceiver = false " +
+            "ORDER BY m.createdAt DESC")
+    Slice<Message> findReceivedMessages(@Param("userId") Long userId, Pageable pageable);
+
+    // 보낸 쪽지 목록 (삭제되지 않은 것만)
+    @Query("SELECT m FROM Message m JOIN FETCH m.receiver " +
+            "WHERE m.sender.userId = :userId " +
+            "AND m.deletedBySender = false " +
+            "ORDER BY m.createdAt DESC")
+    Slice<Message> findSentMessages(@Param("userId") Long userId, Pageable pageable);
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/message/service/MessageService.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/message/service/MessageService.java
@@ -1,0 +1,147 @@
+package com.solif.backend.domain.message.service;
+
+import com.solif.backend.domain.auth.exception.AuthErrorCode;
+import com.solif.backend.domain.message.code.MessageErrorCode;
+import com.solif.backend.domain.message.dto.*;
+import com.solif.backend.domain.message.entity.Message;
+import com.solif.backend.domain.message.repository.MessageRepository;
+import com.solif.backend.domain.user.entity.User;
+import com.solif.backend.domain.user.repository.UserRepository;
+import com.solif.backend.global.common.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collections;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MessageService {
+
+    private final MessageRepository messageRepository;
+    private final UserRepository userRepository;
+    // TODO: FileAttachmentRepository 추가 (파일 첨부 기능 구현 시)
+
+    // 쪽지 발송
+    @Transactional
+    public MessageSendResponse sendMessage(Long senderId, MessageSendRequest request) {
+        log.info("쪽지 발송 - senderId: {}, receiverId: {}", senderId, request.getReceiverId());
+
+        // 자기 자신에게 보내기 방지
+        if (senderId.equals(request.getReceiverId())) {
+            throw new CustomException(MessageErrorCode.CANNOT_SEND_TO_SELF);
+        }
+
+        // 발신자 조회
+        User sender = userRepository.findById(senderId)
+                .orElseThrow(() -> new CustomException(AuthErrorCode.USER_NOT_FOUND));
+
+        // 수신자 조회
+        User receiver = userRepository.findById(request.getReceiverId())
+                .orElseThrow(() -> new CustomException(MessageErrorCode.RECEIVER_NOT_FOUND));
+
+        // 메시지 생성
+        Message message = Message.builder()
+                .sender(sender)
+                .receiver(receiver)
+                .messageTitle(request.getMessageTitle())
+                .messageContent(request.getMessageContent())
+                .build();
+
+        Message savedMessage = messageRepository.save(message);
+
+        // TODO: 파일 첨부 처리 (fileIds가 있을 경우)
+        // if (request.getFileIds() != null && !request.getFileIds().isEmpty()) {
+        //     fileAttachmentService.attachFiles("MESSAGE", savedMessage.getMessageId(), request.getFileIds());
+        // }
+
+        return MessageSendResponse.from(savedMessage);
+    }
+
+    // 받은 쪽지 목록 조회
+    public Slice<MessageListResponse> getReceivedMessages(Long userId, Pageable pageable) {
+        log.info("받은 쪽지 목록 조회 - userId: {}", userId);
+
+        Slice<Message> messages = messageRepository.findReceivedMessages(userId, pageable);
+
+        return messages.map(MessageListResponse::fromReceived);
+    }
+
+    // 보낸 쪽지 목록 조회
+    public Slice<MessageListResponse> getSentMessages(Long userId, Pageable pageable) {
+        log.info("보낸 쪽지 목록 조회 - userId: {}", userId);
+
+        Slice<Message> messages = messageRepository.findSentMessages(userId, pageable);
+
+        return messages.map(MessageListResponse::fromSent);
+    }
+
+    // 쪽지 상세 조회
+    @Transactional
+    public MessageDetailResponse getMessageDetail(Long userId, Long messageId) {
+        log.info("쪽지 상세 조회 - userId: {}, messageId: {}", userId, messageId);
+
+        Message message = messageRepository.findById(messageId)
+                .orElseThrow(() -> new CustomException(MessageErrorCode.MESSAGE_NOT_FOUND));
+
+        // 접근 권한 확인 (발신자 또는 수신자만 조회 가능)
+        if (!message.canAccess(userId)) {
+            throw new CustomException(MessageErrorCode.UNAUTHORIZED_MESSAGE_ACCESS);
+        }
+
+        // 수신자가 조회하는 경우 읽음 처리
+        if (message.isReceiver(userId)) {
+            // 이미 삭제된 쪽지인지 확인
+            if (message.getDeletedByReceiver()) {
+                throw new CustomException(MessageErrorCode.ALREADY_DELETED_MESSAGE);
+            }
+            message.markAsRead();
+        }
+
+        // 발신자가 조회하는 경우 삭제 여부 확인
+        if (message.isSender(userId) && message.getDeletedBySender()) {
+            throw new CustomException(MessageErrorCode.ALREADY_DELETED_MESSAGE);
+        }
+
+        // TODO: 첨부 파일 URL 조회
+        List<String> fileUrls = Collections.emptyList();
+        // List<String> fileUrls = fileAttachmentService.getFileUrls("MESSAGE", messageId);
+
+        return MessageDetailResponse.from(message, fileUrls);
+    }
+
+    // 쪽지 삭제
+    @Transactional
+    public void deleteMessage(Long userId, Long messageId) {
+        log.info("쪽지 삭제 - userId: {}, messageId: {}", userId, messageId);
+
+        Message message = messageRepository.findById(messageId)
+                .orElseThrow(() -> new CustomException(MessageErrorCode.MESSAGE_NOT_FOUND));
+
+        // 접근 권한 확인
+        if (!message.canAccess(userId)) {
+            throw new CustomException(MessageErrorCode.UNAUTHORIZED_MESSAGE_ACCESS);
+        }
+
+        // 발신자/수신자에 따라 삭제 처리
+        if (message.isSender(userId)) {
+            if (message.getDeletedBySender()) {
+                throw new CustomException(MessageErrorCode.ALREADY_DELETED_MESSAGE);
+            }
+            message.deleteBySender();
+        }
+
+        if (message.isReceiver(userId)) {
+            if (message.getDeletedByReceiver()) {
+                throw new CustomException(MessageErrorCode.ALREADY_DELETED_MESSAGE);
+            }
+            message.deleteByReceiver();
+        }
+    }
+}


### PR DESCRIPTION
## 🔍 개요
사용자 간 1:1 쪽지 발송 및 조회 기능을 구현

## ✨ 변경 사항
- 쪽지 발송 API 구현
- 받은 쪽지 목록 조회 API 구현
- 보낸 쪽지 목록 조회 API 구현
- 쪽지 상세 조회 API 구현
- 쪽지 삭제 API 구현
- 수신자 조회 시 자동 읽음 처리 기능 추가
- 발신자/수신자 각각 Soft Delete 처리

## 🧪 테스트
- [ ] 로컬 테스트 완료
- [ ] API 테스트 완료
- [ ] 테스트 코드 작성 (해당 시)

## 📎 관련 이슈
Closes: #46 

## ⚠️ 참고 사항
- 이미지 첨부 기능은 `file_attachment` 테이블 구현 후 연동 예정입니다. (TODO 처리)
- 쪽지 삭제는 Soft Delete로 처리되며, 발신자와 수신자가 각각 삭제할 수 있습니다.
- 양쪽 모두 삭제해도 DB에서는 완전 삭제되지 않습니다. (추후 배치 처리 고려)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 메시지 전송 기능 추가 - 다른 사용자에게 메시지 전송 가능
  * 받은 메시지 목록 조회 - 페이지네이션 지원
  * 보낸 메시지 목록 조회 - 페이지네이션 지원
  * 메시지 상세 조회 기능 추가
  * 메시지 삭제 기능 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->