### PR TITLE
feat: 알림 api 구현

### DIFF
--- a/blue-sol-backend/src/main/java/com/solif/backend/BlueSolBackendApplication.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/BlueSolBackendApplication.java
@@ -3,9 +3,11 @@ package com.solif.backend;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableAsync;
 
 @SpringBootApplication
 @EnableJpaAuditing  // JPA Auditing 활성화
+@EnableAsync         // 비동기 이벤트 처리 활성화
 public class BlueSolBackendApplication {
 
 	public static void main(String[] args) {

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/message/service/MessageService.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/message/service/MessageService.java
@@ -2,7 +2,7 @@ package com.solif.backend.domain.message.service;
 
 import com.solif.backend.domain.notification.entity.NotificationType;
 import com.solif.backend.domain.notification.entity.TargetType;
-import com.solif.backend.domain.notification.service.NotificationService;
+import com.solif.backend.domain.notification.event.NotificationEvent;
 import com.solif.backend.domain.auth.exception.AuthErrorCode;
 import com.solif.backend.domain.message.code.MessageErrorCode;
 import com.solif.backend.domain.message.dto.*;
@@ -13,6 +13,7 @@ import com.solif.backend.domain.user.repository.UserRepository;
 import com.solif.backend.global.common.exception.CustomException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
@@ -29,7 +30,7 @@ public class MessageService {
 
     private final MessageRepository messageRepository;
     private final UserRepository userRepository;
-    private final NotificationService notificationService;
+    private final ApplicationEventPublisher eventPublisher;
     // TODO: FileAttachmentRepository 추가 (파일 첨부 기능 구현 시)
 
     // 쪽지 발송
@@ -60,20 +61,15 @@ public class MessageService {
 
         Message savedMessage = messageRepository.save(message);
 
-        // 수신자에게 알림 생성 + SSE 실시간 전송 (알림 실패가 쪽지 저장을 롤백시키지 않도록 try-catch)
-        try {
-            notificationService.send(
-                    request.getReceiverId(),
-                    NotificationType.MESSAGE,
-                    TargetType.MESSAGE,
-                    savedMessage.getMessageId(),
-                    "새로운 쪽지가 도착했습니다.",
-                    savedMessage.getMessageTitle()
-            );
-        } catch (Exception e) {
-            log.warn("쪽지 알림 발송 실패 - messageId: {}, receiverId: {}, error: {}",
-                    savedMessage.getMessageId(), request.getReceiverId(), e.getMessage());
-        }
+        // 수신자에게 알림 생성 + SSE 실시간 전송 (트랜잭션 커밋 후 이벤트 리스너에서 처리)
+        eventPublisher.publishEvent(new NotificationEvent(
+                request.getReceiverId(),
+                NotificationType.MESSAGE,
+                TargetType.MESSAGE,
+                savedMessage.getMessageId(),
+                "새로운 쪽지가 도착했습니다.",
+                savedMessage.getMessageTitle()
+        ));
 
         return MessageSendResponse.from(savedMessage);
     }

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/message/service/MessageService.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/message/service/MessageService.java
@@ -1,5 +1,8 @@
 package com.solif.backend.domain.message.service;
 
+import com.solif.backend.domain.notification.entity.NotificationType;
+import com.solif.backend.domain.notification.entity.TargetType;
+import com.solif.backend.domain.notification.service.NotificationService;
 import com.solif.backend.domain.auth.exception.AuthErrorCode;
 import com.solif.backend.domain.message.code.MessageErrorCode;
 import com.solif.backend.domain.message.dto.*;
@@ -26,6 +29,7 @@ public class MessageService {
 
     private final MessageRepository messageRepository;
     private final UserRepository userRepository;
+    private final NotificationService notificationService;
     // TODO: FileAttachmentRepository 추가 (파일 첨부 기능 구현 시)
 
     // 쪽지 발송
@@ -56,10 +60,15 @@ public class MessageService {
 
         Message savedMessage = messageRepository.save(message);
 
-        // TODO: 파일 첨부 처리 (fileIds가 있을 경우)
-        // if (request.getFileIds() != null && !request.getFileIds().isEmpty()) {
-        //     fileAttachmentService.attachFiles("MESSAGE", savedMessage.getMessageId(), request.getFileIds());
-        // }
+        // 수신자에게 알림 생성 + SSE 실시간 전송
+        notificationService.send(
+                request.getReceiverId(),
+                NotificationType.MESSAGE,
+                TargetType.MESSAGE,
+                savedMessage.getMessageId(),
+                "새로운 쪽지가 도착했습니다.",
+                savedMessage.getMessageTitle()
+        );
 
         return MessageSendResponse.from(savedMessage);
     }

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/message/service/MessageService.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/message/service/MessageService.java
@@ -60,15 +60,20 @@ public class MessageService {
 
         Message savedMessage = messageRepository.save(message);
 
-        // 수신자에게 알림 생성 + SSE 실시간 전송
-        notificationService.send(
-                request.getReceiverId(),
-                NotificationType.MESSAGE,
-                TargetType.MESSAGE,
-                savedMessage.getMessageId(),
-                "새로운 쪽지가 도착했습니다.",
-                savedMessage.getMessageTitle()
-        );
+        // 수신자에게 알림 생성 + SSE 실시간 전송 (알림 실패가 쪽지 저장을 롤백시키지 않도록 try-catch)
+        try {
+            notificationService.send(
+                    request.getReceiverId(),
+                    NotificationType.MESSAGE,
+                    TargetType.MESSAGE,
+                    savedMessage.getMessageId(),
+                    "새로운 쪽지가 도착했습니다.",
+                    savedMessage.getMessageTitle()
+            );
+        } catch (Exception e) {
+            log.warn("쪽지 알림 발송 실패 - messageId: {}, receiverId: {}, error: {}",
+                    savedMessage.getMessageId(), request.getReceiverId(), e.getMessage());
+        }
 
         return MessageSendResponse.from(savedMessage);
     }

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/notification/code/NotificationErrorCode.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/notification/code/NotificationErrorCode.java
@@ -1,0 +1,19 @@
+package com.solif.backend.domain.notification.code;
+
+import com.solif.backend.global.common.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum NotificationErrorCode implements ErrorCode {
+
+    NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "NOTIFICATION_ERR_001", "알림을 찾을 수 없습니다."),
+    UNAUTHORIZED_NOTIFICATION_ACCESS(HttpStatus.FORBIDDEN, "NOTIFICATION_ERR_002", "알림에 대한 접근 권한이 없습니다."),
+    SSE_CONNECTION_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "NOTIFICATION_ERR_003", "실시간 알림 연결에 실패했습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/notification/code/NotificationSuccessCode.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/notification/code/NotificationSuccessCode.java
@@ -1,0 +1,21 @@
+package com.solif.backend.domain.notification.code;
+
+import com.solif.backend.global.common.response.SuccessCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum NotificationSuccessCode implements SuccessCode {
+
+    NOTIFICATION_LIST_SUCCESS(HttpStatus.OK, "NOTIFICATION_001", "알림 목록 조회에 성공했습니다."),
+    NOTIFICATION_READ_SUCCESS(HttpStatus.OK, "NOTIFICATION_002", "알림이 읽음 처리되었습니다."),
+    NOTIFICATION_UNREAD_COUNT_SUCCESS(HttpStatus.OK, "NOTIFICATION_003", "안읽은 알림 개수 조회 성공"),
+    NOTIFICATION_DETAIL_SUCCESS(HttpStatus.OK, "NOTIFICATION_004", "알림 상세 조회에 성공했습니다."),
+    NOTIFICATION_SUBSCRIBE_SUCCESS(HttpStatus.OK, "NOTIFICATION_005", "SSE 연결에 성공했습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/notification/controller/NotificationController.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/notification/controller/NotificationController.java
@@ -1,0 +1,114 @@
+package com.solif.backend.domain.notification.controller;
+
+import com.solif.backend.domain.notification.code.NotificationSuccessCode;
+import com.solif.backend.domain.notification.dto.*;
+import com.solif.backend.domain.notification.entity.NotificationCategory;
+import com.solif.backend.domain.notification.entity.NotificationSubCategory;
+import com.solif.backend.domain.notification.service.NotificationService;
+import com.solif.backend.global.common.response.ResponseFactory;
+import com.solif.backend.global.common.response.SuccessResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@Tag(name = "알림", description = "알림 API")
+@RestController
+@RequestMapping("/api/v1/notifications")
+@RequiredArgsConstructor
+public class NotificationController {
+
+    private final NotificationService notificationService;
+
+    //  SSE 구독
+    @Operation(
+            summary = "SSE 실시간 알림 구독",
+            description = "서버와 SSE 연결을 맺어 실시간 알림을 수신합니다. "
+                    + "클라이언트는 EventSource 또는 fetch API로 연결합니다.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @GetMapping(value = "/subscribe", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public SseEmitter subscribe(@AuthenticationPrincipal Long userId) {
+        return notificationService.subscribe(userId);
+    }
+
+    //  알림 목록 조회
+    @Operation(
+            summary = "알림 전체 목록 조회",
+            description = "카테고리(공지사항/활동)와 필터(전체/안읽음)로 알림 목록을 조회합니다. "
+                    + "활동 탭에서는 서브 카테고리(쪽지/교류/자치회 활동)로 추가 필터링 가능합니다.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @GetMapping
+    public ResponseEntity<SuccessResponse<Slice<NotificationListResponse>>> getNotifications(
+            @AuthenticationPrincipal Long userId,
+            @Parameter(description = "카테고리 (NOTICE: 공지사항, ACTIVITY: 활동)")
+            @RequestParam NotificationCategory category,
+            @Parameter(description = "서브 카테고리 - 활동 탭 전용 (MESSAGE: 쪽지, NETWORK: 교류, COUNCIL: 자치회 활동)")
+            @RequestParam(required = false) NotificationSubCategory subCategory,
+            @Parameter(description = "필터 (ALL: 전체, UNREAD: 안읽음)")
+            @RequestParam(defaultValue = "ALL") String filter,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size
+    ) {
+        Pageable pageable = PageRequest.of(page, size);
+        Slice<NotificationListResponse> response =
+                notificationService.getNotifications(userId, category, subCategory, filter, pageable);
+        return ResponseFactory.success(NotificationSuccessCode.NOTIFICATION_LIST_SUCCESS, response);
+    }
+
+    //  알림 읽음 처리
+    @Operation(
+            summary = "알림 읽음 처리",
+            description = "특정 알림을 터치하여 상세 화면 진입 시 호출합니다. "
+                    + "is_read를 true로 변경하고 read_at에 현재 시각을 기록합니다.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @PatchMapping("/{notificationId}/read")
+    public ResponseEntity<SuccessResponse<NotificationReadResponse>> markAsRead(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long notificationId
+    ) {
+        NotificationReadResponse response = notificationService.markAsRead(userId, notificationId);
+        return ResponseFactory.success(NotificationSuccessCode.NOTIFICATION_READ_SUCCESS, response);
+    }
+
+    //  안읽은 알림 개수
+    @Operation(
+            summary = "안읽은 알림 개수 조회",
+            description = "현재 사용자의 안읽은 알림 총 개수를 반환합니다.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @GetMapping("/unread-count")
+    public ResponseEntity<SuccessResponse<UnreadCountResponse>> getUnreadCount(
+            @AuthenticationPrincipal Long userId
+    ) {
+        UnreadCountResponse response = notificationService.getUnreadCount(userId);
+        return ResponseFactory.success(NotificationSuccessCode.NOTIFICATION_UNREAD_COUNT_SUCCESS, response);
+    }
+
+    //  알림 상세 조회
+    @Operation(
+            summary = "알림 세부 조회",
+            description = "알림의 상세 내용을 조회합니다. 이미지 첨부 리스트와 이동 버튼 정보를 포함합니다.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @GetMapping("/{notificationId}")
+    public ResponseEntity<SuccessResponse<NotificationDetailResponse>> getNotificationDetail(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long notificationId
+    ) {
+        NotificationDetailResponse response =
+                notificationService.getNotificationDetail(userId, notificationId);
+        return ResponseFactory.success(NotificationSuccessCode.NOTIFICATION_DETAIL_SUCCESS, response);
+    }
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/notification/dto/NotificationDetailResponse.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/notification/dto/NotificationDetailResponse.java
@@ -1,0 +1,64 @@
+package com.solif.backend.domain.notification.dto;
+
+import com.solif.backend.domain.notification.entity.Notification;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+@Schema(description = "알림 상세 응답")
+public class NotificationDetailResponse {
+
+    @Schema(description = "알림 ID", example = "1")
+    private Long notificationId;
+
+    @Schema(description = "알림 제목")
+    private String notificationTitle;
+
+    @Schema(description = "알림 내용")
+    private String notificationContent;
+
+    @Schema(description = "알림 종류", example = "NOTICE")
+    private String notificationType;
+
+    @Schema(description = "생성 일시")
+    private LocalDateTime createdAt;
+
+    @Schema(description = "첨부 이미지 목록")
+    private List<ImageInfo> images;
+
+    @Schema(description = "이동 대상 타입", example = "MESSAGE")
+    private String targetType;
+
+    @Schema(description = "이동 대상 ID", example = "10")
+    private Long targetId;
+
+    @Getter
+    @Builder
+    @Schema(description = "이미지 정보")
+    public static class ImageInfo {
+
+        @Schema(description = "이미지 파일 ID", example = "1")
+        private Long imageId;
+
+        @Schema(description = "이미지 URL", example = "https://cdn.solid.com/images/...")
+        private String imageUrl;
+    }
+
+    public static NotificationDetailResponse from(Notification notification, List<ImageInfo> images) {
+        return NotificationDetailResponse.builder()
+                .notificationId(notification.getNotificationId())
+                .notificationTitle(notification.getNotificationTitle())
+                .notificationContent(notification.getNotificationContent())
+                .notificationType(notification.getNotificationType().name())
+                .createdAt(notification.getCreatedAt())
+                .images(images)
+                .targetType(notification.getTargetType().name())
+                .targetId(notification.getTargetId())
+                .build();
+    }
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/notification/dto/NotificationListResponse.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/notification/dto/NotificationListResponse.java
@@ -1,0 +1,51 @@
+package com.solif.backend.domain.notification.dto;
+
+import com.solif.backend.domain.notification.entity.Notification;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@Schema(description = "알림 목록 응답")
+public class NotificationListResponse {
+
+    @Schema(description = "알림 ID", example = "1")
+    private Long notificationId;
+
+    @Schema(description = "알림 종류", example = "MESSAGE")
+    private String notificationType;
+
+    @Schema(description = "알림 제목", example = "[공지] 2026년도 신규 장학생 모집 시작!")
+    private String notificationTitle;
+
+    @Schema(description = "알림 내용", example = "꿈을 향한 여러분의 도전을 응원합니다.")
+    private String notificationContent;
+
+    @Schema(description = "이동 대상 타입", example = "MESSAGE")
+    private String targetType;
+
+    @Schema(description = "이동 대상 ID", example = "10")
+    private Long targetId;
+
+    @Schema(description = "읽음 여부", example = "false")
+    private Boolean isRead;
+
+    @Schema(description = "생성 일시", example = "2026-01-31T12:00:00")
+    private LocalDateTime createdAt;
+
+    public static NotificationListResponse from(Notification notification) {
+        return NotificationListResponse.builder()
+                .notificationId(notification.getNotificationId())
+                .notificationType(notification.getNotificationType().name())
+                .notificationTitle(notification.getNotificationTitle())
+                .notificationContent(notification.getNotificationContent())
+                .targetType(notification.getTargetType().name())
+                .targetId(notification.getTargetId())
+                .isRead(notification.getIsRead())
+                .createdAt(notification.getCreatedAt())
+                .build();
+    }
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/notification/dto/NotificationReadResponse.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/notification/dto/NotificationReadResponse.java
@@ -1,0 +1,27 @@
+package com.solif.backend.domain.notification.dto;
+
+import com.solif.backend.domain.notification.entity.Notification;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@Schema(description = "알림 읽음 처리 응답")
+public class NotificationReadResponse {
+
+    @Schema(description = "알림 ID", example = "1")
+    private Long notificationId;
+
+    @Schema(description = "읽은 시각", example = "2026-01-31T12:30:00")
+    private LocalDateTime readAt;
+
+    public static NotificationReadResponse from(Notification notification) {
+        return NotificationReadResponse.builder()
+                .notificationId(notification.getNotificationId())
+                .readAt(notification.getReadAt())
+                .build();
+    }
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/notification/dto/NotificationSseResponse.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/notification/dto/NotificationSseResponse.java
@@ -1,0 +1,33 @@
+package com.solif.backend.domain.notification.dto;
+
+import com.solif.backend.domain.notification.entity.Notification;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+//SSE로 실시간 전송할 알림 데이터
+@Getter
+@Builder
+public class NotificationSseResponse {
+
+    private Long notificationId;
+    private String notificationType;
+    private String notificationTitle;
+    private String notificationContent;
+    private String targetType;
+    private Long targetId;
+    private LocalDateTime createdAt;
+
+    public static NotificationSseResponse from(Notification notification) {
+        return NotificationSseResponse.builder()
+                .notificationId(notification.getNotificationId())
+                .notificationType(notification.getNotificationType().name())
+                .notificationTitle(notification.getNotificationTitle())
+                .notificationContent(notification.getNotificationContent())
+                .targetType(notification.getTargetType().name())
+                .targetId(notification.getTargetId())
+                .createdAt(notification.getCreatedAt())
+                .build();
+    }
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/notification/dto/UnreadCountResponse.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/notification/dto/UnreadCountResponse.java
@@ -1,0 +1,14 @@
+package com.solif.backend.domain.notification.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Schema(description = "안읽은 알림 개수 응답")
+public class UnreadCountResponse {
+
+    @Schema(description = "안읽은 알림 개수", example = "12")
+    private long unreadCount;
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/notification/entity/NotificationCategory.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/notification/entity/NotificationCategory.java
@@ -1,0 +1,36 @@
+package com.solif.backend.domain.notification.entity;
+
+import java.util.List;
+
+/**
+ * 알림 목록 조회 시 카테고리 필터용 (공지사항 / 활동 탭 구분)
+ */
+public enum NotificationCategory {
+    NOTICE,     // 공지사항 탭
+    ACTIVITY;   // 활동 탭
+
+    /**
+     * 카테고리 + 서브카테고리 기반으로 NotificationType 목록 반환
+     *
+     * @param subCategory 활동 탭 내 서브 필터 (null이면 활동 전체)
+     */
+    public List<NotificationType> getTypes(NotificationSubCategory subCategory) {
+        if (this == NOTICE) {
+            return List.of(NotificationType.NOTICE);
+        }
+
+        // ACTIVITY인 경우
+        if (subCategory != null) {
+            return subCategory.getTypes();
+        }
+
+        // 서브카테고리 없으면 활동 전체
+        return List.of(
+                NotificationType.COMMENT,
+                NotificationType.MESSAGE,
+                NotificationType.CHEER,
+                NotificationType.HELP,
+                NotificationType.COUNCIL_ACTIVITY
+        );
+    }
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/notification/entity/NotificationSubCategory.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/notification/entity/NotificationSubCategory.java
@@ -1,0 +1,21 @@
+package com.solif.backend.domain.notification.entity;
+
+import java.util.List;
+
+/**
+ * 활동 탭 내 서브 필터 (쪽지 / 교류 / 자치회 활동)
+ * category=ACTIVITY 일 때만 사용됩니다.
+ */
+public enum NotificationSubCategory {
+    MESSAGE,    // 쪽지
+    NETWORK,    // 교류 (응원하기, 도와줄게)
+    COUNCIL;    // 자치회 활동
+
+    public List<NotificationType> getTypes() {
+        return switch (this) {
+            case MESSAGE -> List.of(NotificationType.MESSAGE);
+            case NETWORK -> List.of(NotificationType.CHEER, NotificationType.HELP);
+            case COUNCIL -> List.of(NotificationType.COUNCIL_ACTIVITY);
+        };
+    }
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/notification/entity/NotificationType.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/notification/entity/NotificationType.java
@@ -1,8 +1,10 @@
 package com.solif.backend.domain.notification.entity;
 
 public enum NotificationType {
-    COMMENT,    // 댓글
-    MESSAGE,    // 쪽지
-    CHEER,      // 응원하기
-    HELP        // 도와줄게
+    COMMENT,// 댓글
+    MESSAGE,// 쪽지
+    CHEER,// 응원하기
+    HELP,// 도와줄게
+    NOTICE,// 공지사항
+    COUNCIL_ACTIVITY// 자치회 활동
 }

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/notification/entity/TargetType.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/notification/entity/TargetType.java
@@ -1,7 +1,7 @@
 package com.solif.backend.domain.notification.entity;
 
 public enum TargetType {
-    POST,       // 게시글
-    MESSAGE,    // 쪽지
-    NETWORK     // 교류망
+    POST,// 게시글
+    MESSAGE,// 쪽지
+    NETWORK// 교류망
 }

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/notification/entity/TargetType.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/notification/entity/TargetType.java
@@ -1,7 +1,7 @@
 package com.solif.backend.domain.notification.entity;
 
 public enum TargetType {
-    POST,// 게시글
-    MESSAGE,// 쪽지
-    NETWORK// 교류망
+    POST, // 게시글
+    MESSAGE, // 쪽지
+    NETWORK // 교류망
 }

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/notification/event/NotificationEvent.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/notification/event/NotificationEvent.java
@@ -1,0 +1,22 @@
+package com.solif.backend.domain.notification.event;
+
+import com.solif.backend.domain.notification.entity.NotificationType;
+import com.solif.backend.domain.notification.entity.TargetType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * 알림 발송 이벤트.
+ * 트랜잭션 커밋 이후에 리스너가 수신하여 알림을 생성합니다.
+ */
+@Getter
+@AllArgsConstructor
+public class NotificationEvent {
+
+    private final Long receiverUserId;
+    private final NotificationType notificationType;
+    private final TargetType targetType;
+    private final Long targetId;
+    private final String title;
+    private final String content;
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/notification/event/NotificationEventListener.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/notification/event/NotificationEventListener.java
@@ -1,0 +1,42 @@
+package com.solif.backend.domain.notification.event;
+
+import com.solif.backend.domain.notification.service.NotificationService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+/**
+ * 알림 이벤트 리스너.
+ * 호출자의 트랜잭션이 커밋된 후(AFTER_COMMIT)에만 알림을 발송합니다.
+ * - 고아 알림 방지: 메시지가 롤백되면 알림도 발송되지 않음
+ * - 알림 실패가 메시지 저장에 영향을 주지 않음
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class NotificationEventListener {
+
+    private final NotificationService notificationService;
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleNotificationEvent(NotificationEvent event) {
+        try {
+            notificationService.send(
+                    event.getReceiverUserId(),
+                    event.getNotificationType(),
+                    event.getTargetType(),
+                    event.getTargetId(),
+                    event.getTitle(),
+                    event.getContent()
+            );
+        } catch (Exception e) {
+            log.warn("알림 발송 실패 - targetType: {}, targetId: {}, receiverId: {}, error: {}",
+                    event.getTargetType(), event.getTargetId(),
+                    event.getReceiverUserId(), e.getMessage());
+        }
+    }
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/notification/repository/NotificationRepository.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/notification/repository/NotificationRepository.java
@@ -1,16 +1,24 @@
 package com.solif.backend.domain.notification.repository;
 
 import com.solif.backend.domain.notification.entity.Notification;
+import com.solif.backend.domain.notification.entity.NotificationType;
 import com.solif.backend.domain.user.entity.User;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
 
-    // 사용자의 알림 목록 조회
-    List<Notification> findAllByReceiverOrderByCreatedAtDesc(User receiver);
+    // 카테고리별 전체 조회 (페이징)
+    Slice<Notification> findByReceiverAndNotificationTypeInOrderByCreatedAtDesc(
+            User receiver, List<NotificationType> types, Pageable pageable);
 
-    // 읽지 않은 알림 수
+    // 카테고리별 안읽은 알림만 조회 (페이징)
+    Slice<Notification> findByReceiverAndNotificationTypeInAndIsReadFalseOrderByCreatedAtDesc(
+            User receiver, List<NotificationType> types, Pageable pageable);
+
+    // 안읽은 알림 수
     long countByReceiverAndIsReadFalse(User receiver);
 }

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/notification/repository/SseEmitterRepository.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/notification/repository/SseEmitterRepository.java
@@ -1,0 +1,44 @@
+package com.solif.backend.domain.notification.repository;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Repository;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+/**
+ * 유저별 SseEmitter를 인메모리로 관리하는 저장소.
+ * Key: "userId_UUID" (한 유저가 여러 기기에서 접속 가능)
+ *
+ * 서버가 여러 대로 확장 시 Redis Pub/Sub으로 대체 가능.
+ */
+@Slf4j
+@Repository
+public class SseEmitterRepository {
+
+    private final Map<String, SseEmitter> emitters = new ConcurrentHashMap<>();
+
+    //Emitter 저장
+    public SseEmitter save(String emitterId, SseEmitter emitter) {
+        emitters.put(emitterId, emitter);
+        log.info("SSE Emitter 저장 - emitterId: {}, 현재 연결 수: {}", emitterId, emitters.size());
+        return emitter;
+    }
+
+    //Emitter 삭제
+    public void deleteById(String emitterId) {
+        emitters.remove(emitterId);
+        log.info("SSE Emitter 삭제 - emitterId: {}, 현재 연결 수: {}", emitterId, emitters.size());
+    }
+
+    //특정 유저의 모든 Emitter 조회
+    //Key가 "userId_" 로 시작하는 모든 Emitter 반환
+    public Map<String, SseEmitter> findAllByUserId(Long userId) {
+        String prefix = userId + "_";
+        return emitters.entrySet().stream()
+                .filter(entry -> entry.getKey().startsWith(prefix))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/notification/service/NotificationService.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/notification/service/NotificationService.java
@@ -183,7 +183,7 @@ public class NotificationService {
                     .id(emitterId)
                     .name(eventName)
                     .data(data));
-        } catch (IOException e) {
+        } catch (IOException | IllegalStateException e) {
             log.warn("SSE 전송 실패 - emitterId: {}, 제거합니다.", emitterId);
             sseEmitterRepository.deleteById(emitterId);
         }

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/notification/service/NotificationService.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/notification/service/NotificationService.java
@@ -14,7 +14,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
@@ -60,7 +59,7 @@ public class NotificationService {
 
      //알림 생성 후 실시간 전송
      //다른 도메인 서비스(MessageService 등)에서 호출합니다.
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @Transactional
     public Notification send(Long receiverUserId, NotificationType type, TargetType targetType,
                              Long targetId, String title, String content) {
 

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/notification/service/NotificationService.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/notification/service/NotificationService.java
@@ -1,0 +1,198 @@
+package com.solif.backend.domain.notification.service;
+
+import com.solif.backend.domain.auth.exception.AuthErrorCode;
+import com.solif.backend.domain.notification.code.NotificationErrorCode;
+import com.solif.backend.domain.notification.dto.*;
+import com.solif.backend.domain.notification.entity.*;
+import com.solif.backend.domain.notification.repository.NotificationRepository;
+import com.solif.backend.domain.notification.repository.SseEmitterRepository;
+import com.solif.backend.domain.user.entity.User;
+import com.solif.backend.domain.user.repository.UserRepository;
+import com.solif.backend.global.common.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class NotificationService {
+
+    private static final Long SSE_TIMEOUT = 60L * 60 * 1000; // 1시간
+
+    private final NotificationRepository notificationRepository;
+    private final SseEmitterRepository sseEmitterRepository;
+    private final UserRepository userRepository;
+
+    //  SSE 연결
+
+    //SSE 구독 (클라이언트가 앱 진입 시 호출)
+    public SseEmitter subscribe(Long userId) {
+        String emitterId = userId + "_" + UUID.randomUUID();
+
+        SseEmitter emitter = new SseEmitter(SSE_TIMEOUT);
+        sseEmitterRepository.save(emitterId, emitter);
+
+        // 콜백 등록: 타임아웃/에러/완료 시 emitter 제거
+        emitter.onCompletion(() -> sseEmitterRepository.deleteById(emitterId));
+        emitter.onTimeout(() -> sseEmitterRepository.deleteById(emitterId));
+        emitter.onError(e -> sseEmitterRepository.deleteById(emitterId));
+
+        // 연결 직후 더미 이벤트 전송 (503 방지)
+        sendToEmitter(emitter, emitterId, "connect", "SSE 연결 성공 [userId=" + userId + "]");
+
+        return emitter;
+    }
+
+    //  알림 생성 + SSE 전송 (다른 서비스에서 호출)
+
+     //알림 생성 후 실시간 전송
+     //다른 도메인 서비스(MessageService 등)에서 호출합니다.
+    @Transactional
+    public Notification send(Long receiverUserId, NotificationType type, TargetType targetType,
+                             Long targetId, String title, String content) {
+
+        User receiver = userRepository.findById(receiverUserId)
+                .orElseThrow(() -> new CustomException(AuthErrorCode.USER_NOT_FOUND));
+
+        // 1. DB 저장
+        Notification notification = Notification.builder()
+                .receiver(receiver)
+                .notificationType(type)
+                .targetType(targetType)
+                .targetId(targetId)
+                .notificationTitle(title)
+                .notificationContent(content)
+                .build();
+
+        Notification saved = notificationRepository.save(notification);
+
+        // 2. SSE 실시간 전송
+        sendSseToUser(receiverUserId, saved);
+
+        return saved;
+    }
+
+    //  REST API: 알림 목록 조회
+
+    //알림 목록 조회 (카테고리 + 서브카테고리 + 필터)
+    public Slice<NotificationListResponse> getNotifications(Long userId, NotificationCategory category,
+                                                             NotificationSubCategory subCategory,
+                                                             String filter, Pageable pageable) {
+        log.info("알림 목록 조회 - userId: {}, category: {}, subCategory: {}, filter: {}",
+                userId, category, subCategory, filter);
+
+        User receiver = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(AuthErrorCode.USER_NOT_FOUND));
+
+        List<NotificationType> types = category.getTypes(subCategory);
+
+        Slice<Notification> notifications;
+        if ("UNREAD".equalsIgnoreCase(filter)) {
+            notifications = notificationRepository
+                    .findByReceiverAndNotificationTypeInAndIsReadFalseOrderByCreatedAtDesc(
+                            receiver, types, pageable);
+        } else {
+            notifications = notificationRepository
+                    .findByReceiverAndNotificationTypeInOrderByCreatedAtDesc(
+                            receiver, types, pageable);
+        }
+
+        return notifications.map(NotificationListResponse::from);
+    }
+
+    //  REST API: 알림 읽음 처리
+
+    //알림 읽음 처리
+    @Transactional
+    public NotificationReadResponse markAsRead(Long userId, Long notificationId) {
+        log.info("알림 읽음 처리 - userId: {}, notificationId: {}", userId, notificationId);
+
+        Notification notification = notificationRepository.findById(notificationId)
+                .orElseThrow(() -> new CustomException(NotificationErrorCode.NOTIFICATION_NOT_FOUND));
+
+        // 본인 알림인지 확인
+        validateOwner(userId, notification);
+
+        notification.markAsRead();
+
+        return NotificationReadResponse.from(notification);
+    }
+
+    //  REST API: 안읽은 알림 개수
+
+    //안읽은 알림 개수 조회
+    public UnreadCountResponse getUnreadCount(Long userId) {
+        log.info("안읽은 알림 개수 조회 - userId: {}", userId);
+
+        User receiver = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(AuthErrorCode.USER_NOT_FOUND));
+
+        long count = notificationRepository.countByReceiverAndIsReadFalse(receiver);
+
+        return new UnreadCountResponse(count);
+    }
+
+    //  REST API: 알림 상세 조회
+
+    //알림 상세 조회
+    public NotificationDetailResponse getNotificationDetail(Long userId, Long notificationId) {
+        log.info("알림 상세 조회 - userId: {}, notificationId: {}", userId, notificationId);
+
+        Notification notification = notificationRepository.findById(notificationId)
+                .orElseThrow(() -> new CustomException(NotificationErrorCode.NOTIFICATION_NOT_FOUND));
+
+        validateOwner(userId, notification);
+
+        // TODO: 알림의 targetType/targetId 기반으로 첨부 이미지 조회
+        // List<NotificationDetailResponse.ImageInfo> images =
+        //     fileAttachmentService.getImages(notification.getTargetType().name(), notification.getTargetId());
+        List<NotificationDetailResponse.ImageInfo> images = Collections.emptyList();
+
+        return NotificationDetailResponse.from(notification, images);
+    }
+
+    //  Private 메서드
+
+    //특정 유저에게 SSE 알림 전송
+    private void sendSseToUser(Long userId, Notification notification) {
+        Map<String, SseEmitter> emitters = sseEmitterRepository.findAllByUserId(userId);
+
+        NotificationSseResponse data = NotificationSseResponse.from(notification);
+
+        emitters.forEach((emitterId, emitter) -> {
+            sendToEmitter(emitter, emitterId, "notification", data);
+        });
+    }
+
+    //개별 Emitter에 이벤트 전송
+    private void sendToEmitter(SseEmitter emitter, String emitterId, String eventName, Object data) {
+        try {
+            emitter.send(SseEmitter.event()
+                    .id(emitterId)
+                    .name(eventName)
+                    .data(data));
+        } catch (IOException e) {
+            log.warn("SSE 전송 실패 - emitterId: {}, 제거합니다.", emitterId);
+            sseEmitterRepository.deleteById(emitterId);
+        }
+    }
+
+    //알림 소유자 검증
+    private void validateOwner(Long userId, Notification notification) {
+        if (!notification.getReceiver().getUserId().equals(userId)) {
+            throw new CustomException(NotificationErrorCode.UNAUTHORIZED_NOTIFICATION_ACCESS);
+        }
+    }
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/notification/service/NotificationService.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/notification/service/NotificationService.java
@@ -14,6 +14,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
@@ -59,7 +60,7 @@ public class NotificationService {
 
      //알림 생성 후 실시간 전송
      //다른 도메인 서비스(MessageService 등)에서 호출합니다.
-    @Transactional
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public Notification send(Long receiverUserId, NotificationType type, TargetType targetType,
                              Long targetId, String title, String content) {
 

--- a/blue-sol-backend/src/main/java/com/solif/backend/global/config/SecurityConfig.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/global/config/SecurityConfig.java
@@ -88,7 +88,7 @@ public class SecurityConfig {
         configuration.setAllowedOrigins(Arrays.asList("https://blue-sol.netlify.app", "http://localhost:3000"));
 
         // 허용할 HTTP 메서드
-        configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
 
         // 허용할 헤더 (Authorization 헤더 포함)
         configuration.setAllowedHeaders(Arrays.asList("Authorization", "Content-Type", "Cache-Control"));
@@ -97,7 +97,7 @@ public class SecurityConfig {
         configuration.setAllowCredentials(true);
 
         // 브라우저에서 Authorization 헤더를 읽을 수 있도록 노출
-        configuration.addExposedHeader("Authorization");
+        configuration.setExposedHeaders(Arrays.asList("Authorization", "X-Accel-Buffering"));
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", configuration);

--- a/blue-sol-backend/src/main/java/com/solif/backend/global/config/WebConfig.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/global/config/WebConfig.java
@@ -3,6 +3,7 @@ package com.solif.backend.global.config;
 import com.solif.backend.global.interceptor.LoggingInterceptor;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.AsyncSupportConfigurer;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
@@ -16,6 +17,12 @@ public class WebConfig implements WebMvcConfigurer {
     public void addInterceptors(InterceptorRegistry registry) {
         // 로깅 인터셉터 (모든 요청)
         registry.addInterceptor(loggingInterceptor)
-                .addPathPatterns("/api/**");
+                .addPathPatterns("/api/**")
+                .excludePathPatterns("/api/v1/notifications/subscribe"); // SSE 연결은 로깅 제외
+    }
+
+    @Override
+    public void configureAsyncSupport(AsyncSupportConfigurer configurer) {
+        configurer.setDefaultTimeout(60L * 60 * 1000); // SSE 타임아웃 1시간
     }
 }


### PR DESCRIPTION
## 🔍 개요
알림 API + SSE 실시간 알림 구현

## ✨ 변경 사항
- 쪽지 발송 → 알림 자동 생성 확인
- 알림 목록 조회 (카테고리/서브카테고리/필터별)
- 알림 읽음 처리
- 안읽은 알림 개수 조회
- 알림 상세 조회
- SSE 실시간 알림 수신

## 🧪 테스트
- [x] 로컬 테스트 완료
- [x] API 테스트 완료
- [ ] 테스트 코드 작성 (해당 시)

## 📎 관련 이슈
Closes: #48 

## ⚠️ 참고 사항
알림 상세의 이미지 조회(FileAttachment 연동)는 TODO로 남겨둠
배포 시 Nginx에 SSE 프록시 버퍼링 비활성화 설정 필요:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 실시간 알림(SSE) 구독/푸시 및 알림 생성·전송 자동화(메시지 전송 시 알림 발송 포함)
  * 알림 목록·상세·읽음 처리·미확인 개수 조회 API, 카테고리·서브카테고리 필터·페이징 지원

* **버그 수정 / 안정성**
  * 알림 전송 오류가 주요 흐름에 영향 주지 않도록 예외 처리 개선 및 연결 정리

* **설정 변경**
  * SSE 엔드포인트 로깅 제외, 비동기 타임아웃 1시간, CORS에 PATCH 허용 및 노출 헤더 확장

* **API/응답형식**
  * 알림 관련 응답 DTO 및 성공/오류 코드 정리 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->