### PR TITLE
feat: 자치회 멤버 관리 API 구현 (조회/추가/삭제)

### DIFF
--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/council/code/CouncilErrorCode.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/council/code/CouncilErrorCode.java
@@ -18,6 +18,7 @@ public enum CouncilErrorCode implements ErrorCode {
     ONLY_LEADER_CAN_ADD_MEMBER(HttpStatus.FORBIDDEN, "COUNCIL_004", "자치회 리더만 멤버를 추가할 수 있습니다."),
     ONLY_LEADER_CAN_DELETE_MEMBER(HttpStatus.FORBIDDEN, "COUNCIL_005", "자치회 리더만 멤버를 삭제할 수 있습니다."),
     LEADER_CANNOT_DELETE_SELF(HttpStatus.BAD_REQUEST, "COUNCIL_006", "리더는 본인을 삭제할 수 없습니다."),
+    EMPTY_USER_IDS_TO_ADD(HttpStatus.BAD_REQUEST, "COUNCIL_013", "추가할 사용자가 없습니다."),
 
     // 활동 규칙 관련
     RULE_NOT_FOUND(HttpStatus.NOT_FOUND, "COUNCIL_007", "존재하지 않는 활동 규칙입니다."),

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/council/code/CouncilSuccessCode.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/council/code/CouncilSuccessCode.java
@@ -17,7 +17,12 @@ public enum CouncilSuccessCode implements SuccessCode {
     // 자치회 생성/수정/삭제
     COUNCIL_CREATE_SUCCESS(HttpStatus.CREATED, "COUNCIL_CREATE_203", "자치회 생성에 성공했습니다."),
     COUNCIL_UPDATE_SUCCESS(HttpStatus.OK, "COUNCIL_UPDATE_204", "자치회 수정에 성공했습니다."),
-    COUNCIL_DELETE_SUCCESS(HttpStatus.OK, "COUNCIL_DELETE_205", "자치회 삭제에 성공했습니다.");
+    COUNCIL_DELETE_SUCCESS(HttpStatus.OK, "COUNCIL_DELETE_205", "자치회 삭제에 성공했습니다."),
+
+    // 멤버 관리
+    MEMBER_LIST_SUCCESS(HttpStatus.OK, "COUNCIL_206", "멤버 목록 조회에 성공했습니다."),
+    MEMBER_ADD_SUCCESS(HttpStatus.OK, "COUNCIL_207", "멤버 추가에 성공했습니다."),
+    MEMBER_DELETE_SUCCESS(HttpStatus.OK, "COUNCIL_208", "멤버 삭제에 성공했습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/council/controller/CouncilMemberController.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/council/controller/CouncilMemberController.java
@@ -1,0 +1,75 @@
+package com.solif.backend.domain.council.controller;
+
+import com.solif.backend.domain.council.code.CouncilSuccessCode;
+import com.solif.backend.domain.council.dto.AddMemberRequest;
+import com.solif.backend.domain.council.dto.AddMemberResponse;
+import com.solif.backend.domain.council.dto.DeleteMemberResponse;
+import com.solif.backend.domain.council.dto.MemberListResponse;
+import com.solif.backend.domain.council.service.CouncilMemberService;
+import com.solif.backend.global.common.response.ResponseFactory;
+import com.solif.backend.global.common.response.SuccessResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "자치회 멤버", description = "자치회 멤버 관리 API")
+@RestController
+@RequestMapping("/api/v1/councils/{councilId}/members")
+@RequiredArgsConstructor
+public class CouncilMemberController {
+
+    private final CouncilMemberService councilMemberService;
+
+    @Operation(
+            summary = "자치회 멤버 목록 조회",
+            description = "자치회의 모든 멤버를 조회합니다. (LEADER 먼저, 가입일 순)",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @GetMapping
+    public ResponseEntity<SuccessResponse<MemberListResponse>> getMembers(
+            @Parameter(description = "자치회 ID", required = true, example = "1")
+            @PathVariable Long councilId
+    ) {
+        MemberListResponse response = councilMemberService.getMembers(councilId);
+        return ResponseFactory.success(CouncilSuccessCode.MEMBER_LIST_SUCCESS, response);
+    }
+
+    @Operation(
+            summary = "자치회 멤버 추가",
+            description = "자치회에 새로운 멤버를 추가합니다. (LEADER만 가능)",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @PostMapping
+    public ResponseEntity<SuccessResponse<AddMemberResponse>> addMembers(
+            @AuthenticationPrincipal Long userId,
+            @Parameter(description = "자치회 ID", required = true, example = "1")
+            @PathVariable Long councilId,
+            @Valid @RequestBody AddMemberRequest request
+    ) {
+        AddMemberResponse response = councilMemberService.addMembers(userId, councilId, request.getUserIds());
+        return ResponseFactory.success(CouncilSuccessCode.MEMBER_ADD_SUCCESS, response);
+    }
+
+    @Operation(
+            summary = "자치회 멤버 삭제",
+            description = "자치회에서 멤버를 삭제합니다. (LEADER만 가능, 본인 삭제 불가)",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @DeleteMapping("/{userId}")
+    public ResponseEntity<SuccessResponse<DeleteMemberResponse>> deleteMember(
+            @AuthenticationPrincipal Long currentUserId,
+            @Parameter(description = "자치회 ID", required = true, example = "1")
+            @PathVariable Long councilId,
+            @Parameter(description = "삭제할 사용자 ID", required = true, example = "2")
+            @PathVariable("userId") Long userIdToDelete
+    ) {
+        DeleteMemberResponse response = councilMemberService.deleteMember(currentUserId, councilId, userIdToDelete);
+        return ResponseFactory.success(CouncilSuccessCode.MEMBER_DELETE_SUCCESS, response);
+    }
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/council/dto/AddMemberRequest.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/council/dto/AddMemberRequest.java
@@ -1,0 +1,18 @@
+package com.solif.backend.domain.council.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@Schema(description = "자치회 멤버 추가 요청")
+public class AddMemberRequest {
+
+    @NotEmpty(message = "추가할 사용자 ID 목록은 필수입니다.")
+    @Schema(description = "추가할 사용자 ID 목록", example = "[2, 3, 4]")
+    private List<Long> userIds;
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/council/dto/AddMemberResponse.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/council/dto/AddMemberResponse.java
@@ -1,0 +1,28 @@
+package com.solif.backend.domain.council.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@Schema(description = "자치회 멤버 추가 응답")
+public class AddMemberResponse {
+
+    @Schema(description = "자치회 ID", example = "1")
+    private Long councilId;
+
+    @Schema(description = "추가된 멤버 수", example = "3")
+    private Integer addedCount;
+
+    @Schema(description = "총 멤버 수", example = "8")
+    private Integer totalMemberCount;
+
+    public static AddMemberResponse of(Long councilId, int addedCount, int totalMemberCount) {
+        return AddMemberResponse.builder()
+                .councilId(councilId)
+                .addedCount(addedCount)
+                .totalMemberCount(totalMemberCount)
+                .build();
+    }
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/council/dto/CouncilMemberResponse.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/council/dto/CouncilMemberResponse.java
@@ -1,0 +1,44 @@
+package com.solif.backend.domain.council.dto;
+
+import com.solif.backend.domain.council.entity.CouncilMember;
+import com.solif.backend.domain.council.entity.CouncilMemberRole;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@Schema(description = "자치회 멤버 정보")
+public class CouncilMemberResponse {
+
+    @Schema(description = "사용자 ID", example = "1")
+    private Long userId;
+
+    @Schema(description = "사용자 이름", example = "김지환")
+    private String name;
+
+    @Schema(description = "역할", example = "LEADER")
+    private CouncilMemberRole role;
+
+    @Schema(description = "가입 일시", example = "2025-03-01T10:00:00")
+    private LocalDateTime joinedAt;
+
+    @Schema(description = "지역", example = "제주")
+    private String region;
+
+    @Schema(description = "학교명", example = "제주대학교")
+    private String schoolName;
+
+    public static CouncilMemberResponse from(CouncilMember member) {
+        return CouncilMemberResponse.builder()
+                .userId(member.getUser().getUserId())
+                .name(member.getUser().getName())
+                .role(member.getRole())
+                .joinedAt(member.getJoinedAt())
+                .region(member.getUser().getRegion())
+                .schoolName(member.getUser().getSchoolName())
+                .build();
+    }
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/council/dto/DeleteMemberResponse.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/council/dto/DeleteMemberResponse.java
@@ -1,0 +1,28 @@
+package com.solif.backend.domain.council.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@Schema(description = "자치회 멤버 삭제 응답")
+public class DeleteMemberResponse {
+
+    @Schema(description = "자치회 ID", example = "1")
+    private Long councilId;
+
+    @Schema(description = "삭제된 사용자 ID", example = "2")
+    private Long deletedUserId;
+
+    @Schema(description = "총 멤버 수", example = "7")
+    private Integer totalMemberCount;
+
+    public static DeleteMemberResponse of(Long councilId, Long deletedUserId, int totalMemberCount) {
+        return DeleteMemberResponse.builder()
+                .councilId(councilId)
+                .deletedUserId(deletedUserId)
+                .totalMemberCount(totalMemberCount)
+                .build();
+    }
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/council/dto/MemberListResponse.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/council/dto/MemberListResponse.java
@@ -1,0 +1,30 @@
+package com.solif.backend.domain.council.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+@Schema(description = "자치회 멤버 목록 응답")
+public class MemberListResponse {
+
+    @Schema(description = "자치회 ID", example = "1")
+    private Long councilId;
+
+    @Schema(description = "총 멤버 수", example = "5")
+    private Integer memberCount;
+
+    @Schema(description = "멤버 목록 (LEADER 먼저, 그 다음 가입일 순)")
+    private List<CouncilMemberResponse> members;
+
+    public static MemberListResponse of(Long councilId, List<CouncilMemberResponse> members) {
+        return MemberListResponse.builder()
+                .councilId(councilId)
+                .memberCount(members.size())
+                .members(members)
+                .build();
+    }
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/council/repository/CouncilMemberRepository.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/council/repository/CouncilMemberRepository.java
@@ -10,6 +10,7 @@ import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 public interface CouncilMemberRepository extends JpaRepository<CouncilMember, Long> {
 
@@ -25,6 +26,11 @@ public interface CouncilMemberRepository extends JpaRepository<CouncilMember, Lo
 
     // 사용자로 소속 자치회 조회
     Optional<CouncilMember> findByUser(User user);
+
+    // 사용자 ID 목록으로 이미 자치회에 소속된 사용자 ID 조회 (배치)
+    @Query("SELECT cm.user.userId FROM CouncilMember cm WHERE cm.user.userId IN :userIds")
+    Set<Long> findUserIdsAlreadyInAnyCouncil(@Param("userIds") List<Long> userIds);
+
 
     // 자치회와 사용자 목록으로 멤버 삭제
     @Modifying(clearAutomatically = true)

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/council/service/CouncilMemberService.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/council/service/CouncilMemberService.java
@@ -20,6 +20,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -92,10 +93,9 @@ public class CouncilMemberService {
         }
 
         // 이미 자치회에 소속된 사용자 검증
-        for (User user : usersToAdd) {
-            councilMemberRepository.findByUser(user).ifPresent(existingMember -> {
-                throw new CustomException(CouncilErrorCode.ALREADY_IN_COUNCIL);
-            });
+        Set<Long> existingUserIds = councilMemberRepository.findUserIdsAlreadyInAnyCouncil(uniqueUserIds);
+        if (!existingUserIds.isEmpty()) {
+            throw new CustomException(CouncilErrorCode.ALREADY_IN_COUNCIL);
         }
 
         // CouncilMember 생성 및 저장

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/council/service/CouncilMemberService.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/council/service/CouncilMemberService.java
@@ -107,7 +107,12 @@ public class CouncilMemberService {
                         .build())
                 .collect(Collectors.toList());
 
-        councilMemberRepository.saveAll(newMembers);
+        try {
+            councilMemberRepository.saveAll(newMembers);
+        } catch (org.springframework.dao.DataIntegrityViolationException e) {
+            // 동시성 이슈로 인한 중복 추가 시도
+            throw new CustomException(CouncilErrorCode.ALREADY_IN_COUNCIL);
+        }
 
         // 총 멤버 수 조회
         Long totalMemberCount = councilMemberRepository.countByCouncil(council);

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/council/service/CouncilMemberService.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/council/service/CouncilMemberService.java
@@ -1,0 +1,166 @@
+package com.solif.backend.domain.council.service;
+
+import com.solif.backend.domain.auth.exception.AuthErrorCode;
+import com.solif.backend.domain.council.code.CouncilErrorCode;
+import com.solif.backend.domain.council.dto.AddMemberResponse;
+import com.solif.backend.domain.council.dto.CouncilMemberResponse;
+import com.solif.backend.domain.council.dto.DeleteMemberResponse;
+import com.solif.backend.domain.council.dto.MemberListResponse;
+import com.solif.backend.domain.council.entity.Council;
+import com.solif.backend.domain.council.entity.CouncilMember;
+import com.solif.backend.domain.council.entity.CouncilMemberRole;
+import com.solif.backend.domain.council.repository.CouncilMemberRepository;
+import com.solif.backend.domain.council.repository.CouncilRepository;
+import com.solif.backend.domain.user.entity.User;
+import com.solif.backend.domain.user.repository.UserRepository;
+import com.solif.backend.global.common.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CouncilMemberService {
+
+    private final CouncilRepository councilRepository;
+    private final CouncilMemberRepository councilMemberRepository;
+    private final UserRepository userRepository;
+
+    // 자치회 멤버 목록 조회
+    public MemberListResponse getMembers(Long councilId) {
+        log.info("자치회 멤버 목록 조회 - councilId: {}", councilId);
+
+        // 자치회 조회
+        Council council = councilRepository.findById(councilId)
+                .orElseThrow(() -> new CustomException(CouncilErrorCode.COUNCIL_NOT_FOUND));
+
+        // 멤버 목록 조회 (JOIN FETCH로 N+1 방지)
+        List<CouncilMember> members = councilMemberRepository
+                .findByCouncilOrderByRoleDescJoinedAtAsc(council);
+
+        // DTO 변환
+        List<CouncilMemberResponse> memberResponses = members.stream()
+                .map(CouncilMemberResponse::from)
+                .collect(Collectors.toList());
+
+        return MemberListResponse.of(councilId, memberResponses);
+    }
+
+    // 자치회 멤버 추가
+    @Transactional
+    public AddMemberResponse addMembers(Long userId, Long councilId, List<Long> userIdsToAdd) {
+        log.info("자치회 멤버 추가 - userId: {}, councilId: {}, userIdsToAdd: {}", userId, councilId, userIdsToAdd);
+
+        // 사용자 조회
+        User currentUser = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(AuthErrorCode.USER_NOT_FOUND));
+
+        // 자치회 조회
+        Council council = councilRepository.findById(councilId)
+                .orElseThrow(() -> new CustomException(CouncilErrorCode.COUNCIL_NOT_FOUND));
+
+        // 리더 권한 확인
+        CouncilMember currentMember = councilMemberRepository
+                .findByCouncilAndUser(council, currentUser)
+                .orElseThrow(() -> new CustomException(CouncilErrorCode.NOT_COUNCIL_MEMBER));
+
+        if (!currentMember.isLeader()) {
+            throw new CustomException(CouncilErrorCode.ONLY_LEADER_CAN_ADD_MEMBER);
+        }
+
+        // 중복 제거
+        List<Long> uniqueUserIds = userIdsToAdd.stream()
+                .distinct()
+                .collect(Collectors.toList());
+
+        if (uniqueUserIds.isEmpty()) {
+            throw new IllegalArgumentException("추가할 사용자가 없습니다.");
+        }
+
+        // 사용자 조회
+        List<User> usersToAdd = userRepository.findAllById(uniqueUserIds);
+
+        // 존재하지 않는 사용자 검증
+        if (usersToAdd.size() != uniqueUserIds.size()) {
+            throw new CustomException(AuthErrorCode.USER_NOT_FOUND);
+        }
+
+        // 이미 자치회에 소속된 사용자 검증
+        for (User user : usersToAdd) {
+            councilMemberRepository.findByUser(user).ifPresent(existingMember -> {
+                throw new CustomException(CouncilErrorCode.ALREADY_IN_COUNCIL);
+            });
+        }
+
+        // CouncilMember 생성 및 저장
+        List<CouncilMember> newMembers = usersToAdd.stream()
+                .map(user -> CouncilMember.builder()
+                        .user(user)
+                        .council(council)
+                        .role(CouncilMemberRole.MEMBER)
+                        .build())
+                .collect(Collectors.toList());
+
+        councilMemberRepository.saveAll(newMembers);
+
+        // 총 멤버 수 조회
+        Long totalMemberCount = councilMemberRepository.countByCouncil(council);
+
+        // 알림 발송 (TODO: 나중에 구현)
+
+        return AddMemberResponse.of(councilId, newMembers.size(), totalMemberCount.intValue());
+    }
+
+    // 자치회 멤버 삭제
+    @Transactional
+    public DeleteMemberResponse deleteMember(Long userId, Long councilId, Long userIdToDelete) {
+        log.info("자치회 멤버 삭제 - userId: {}, councilId: {}, userIdToDelete: {}", userId, councilId, userIdToDelete);
+
+        // 사용자 조회
+        User currentUser = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(AuthErrorCode.USER_NOT_FOUND));
+
+        // 자치회 조회
+        Council council = councilRepository.findById(councilId)
+                .orElseThrow(() -> new CustomException(CouncilErrorCode.COUNCIL_NOT_FOUND));
+
+        // 리더 권한 확인
+        CouncilMember currentMember = councilMemberRepository
+                .findByCouncilAndUser(council, currentUser)
+                .orElseThrow(() -> new CustomException(CouncilErrorCode.NOT_COUNCIL_MEMBER));
+
+        if (!currentMember.isLeader()) {
+            throw new CustomException(CouncilErrorCode.ONLY_LEADER_CAN_DELETE_MEMBER);
+        }
+
+        // 본인 삭제 방지
+        if (userId.equals(userIdToDelete)) {
+            throw new CustomException(CouncilErrorCode.LEADER_CANNOT_DELETE_SELF);
+        }
+
+        // 삭제할 사용자 조회
+        User userToDelete = userRepository.findById(userIdToDelete)
+                .orElseThrow(() -> new CustomException(AuthErrorCode.USER_NOT_FOUND));
+
+        // 삭제할 멤버가 자치회에 속해있는지 확인
+        CouncilMember memberToDelete = councilMemberRepository
+                .findByCouncilAndUser(council, userToDelete)
+                .orElseThrow(() -> new CustomException(CouncilErrorCode.NOT_COUNCIL_MEMBER));
+
+        // 멤버 삭제
+        councilMemberRepository.delete(memberToDelete);
+
+        // 총 멤버 수 조회
+        Long totalMemberCount = councilMemberRepository.countByCouncil(council);
+
+        // 알림 발송 (TODO: 나중에 구현)
+
+        return DeleteMemberResponse.of(councilId, userIdToDelete, totalMemberCount.intValue());
+    }
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/council/service/CouncilMemberService.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/council/service/CouncilMemberService.java
@@ -80,7 +80,7 @@ public class CouncilMemberService {
                 .collect(Collectors.toList());
 
         if (uniqueUserIds.isEmpty()) {
-            throw new IllegalArgumentException("추가할 사용자가 없습니다.");
+            throw new CustomException(CouncilErrorCode.EMPTY_USER_IDS_TO_ADD);
         }
 
         // 사용자 조회


### PR DESCRIPTION
## 🔍 개요
자치회 멤버 관리 기능을 구현했습니다.
멤버 목록 조회, 멤버 추가(LEADER), 멤버 삭제(LEADER) API를 제공하며,
권한/중복/본인삭제 방지 및 N+1 방지를 함께 처리했습니다.

## ✨ 변경 사항
- Council 멤버 관리 DTO 추가 (request/response)
- CouncilMemberController / CouncilMemberService 신규 구현
- 멤버 목록 조회 API 추가 (GET /api/v1/councils/{councilId}/members)
- 멤버 추가 API 추가 (POST /api/v1/councils/{councilId}/members) - LEADER only
- 멤버 삭제 API 추가 (DELETE /api/v1/councils/{councilId}/members/{userId}) - LEADER only
- CouncilSuccessCode 3개 코드 추가

## 🧪 테스트
- [x] 로컬 테스트 완료
- [x] API 테스트 완료
- [ ] 테스트 코드 작성 (해당 시)

## 📎 관련 이슈
Closes: #49 

## ⚠️ 참고 사항
- 멤버 추가 시 입력 userId 리스트가 중복될 수 있어 중복 제거 후 처리했습니다.
- 멤버 조회 성능을 위해 fetch 전략을 조정했습니다(JOIN FETCH).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 자치회 멤버 관리 추가: 멤버 목록 조회, 멤버 추가, 멤버 삭제 API 제공 (요청/응답 DTO 및 API 문서화 포함).
  * 멤버 추가/삭제 응답에 추가된 수 및 갱신된 총 멤버 수 반환.

* **Bug Fixes / Validation**
  * 멤버 추가 요청에서 빈 사용자 ID 목록 제출 시 명확한 유효성 오류 코드 및 메시지 반환 처리.


<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->