### PR TITLE
feat: 자치회 멤버 추가를 위한 사용자 검색 및 Network 응답 확장

### DIFF
--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/council/repository/CouncilMemberRepository.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/council/repository/CouncilMemberRepository.java
@@ -31,6 +31,9 @@ public interface CouncilMemberRepository extends JpaRepository<CouncilMember, Lo
     @Query("SELECT cm.user.userId FROM CouncilMember cm WHERE cm.user.userId IN :userIds")
     Set<Long> findUserIdsAlreadyInAnyCouncil(@Param("userIds") List<Long> userIds);
 
+    // 사용자 ID 목록으로 멤버십 조회 (배치)
+    @Query("SELECT cm FROM CouncilMember cm JOIN FETCH cm.council WHERE cm.user.userId IN :userIds")
+    List<CouncilMember> findByUserIdIn(@Param("userIds") Set<Long> userIds);
 
     // 자치회와 사용자 목록으로 멤버 삭제
     @Modifying(clearAutomatically = true)

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/network/dto/NetworkListResponse.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/network/dto/NetworkListResponse.java
@@ -67,5 +67,11 @@ public class NetworkListResponse {
 
         @Schema(description = "버튼 타입", example = "CHEER")
         private String buttonType;
+
+        @Schema(description = "자치회 소속 여부", example = "true")
+        private Boolean isInCouncil;
+
+        @Schema(description = "소속 자치회 이름", example = "제주최강산한이들")
+        private String councilName;
     }
 }

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/network/dto/NetworkRecommendationResponse.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/network/dto/NetworkRecommendationResponse.java
@@ -49,5 +49,11 @@ public class NetworkRecommendationResponse {
 
         @Schema(description = "관심사 목록")
         private List<String> interests;
+
+        @Schema(description = "자치회 소속 여부", example = "true")
+        private Boolean isInCouncil;
+
+        @Schema(description = "소속 자치회 이름", example = "제주최강산한이들")
+        private String councilName;
     }
 }

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/network/dto/NetworkSearchResponse.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/network/dto/NetworkSearchResponse.java
@@ -46,5 +46,12 @@ public class NetworkSearchResponse {
         @Schema(description = "이미 연결 여부")
         @JsonProperty("isConnected")
         private boolean isConnected;
+
+        @Schema(description = "자치회 소속 여부", example = "true")
+        @JsonProperty("isInCouncil")
+        private Boolean isInCouncil;
+
+        @Schema(description = "소속 자치회 이름", example = "제주최강산한이들")
+        private String councilName;
     }
 }

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/network/service/NetworkService.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/network/service/NetworkService.java
@@ -3,6 +3,8 @@ package com.solif.backend.domain.network.service;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.solif.backend.domain.council.entity.CouncilMember;
+import com.solif.backend.domain.council.repository.CouncilMemberRepository;
 import com.solif.backend.domain.interest.entity.UserInterest;
 import com.solif.backend.domain.interest.repository.UserInterestRepository;
 import com.solif.backend.domain.network.dto.*;
@@ -23,7 +25,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
+import java.util.*;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 @Service
@@ -36,6 +39,7 @@ public class NetworkService {
     private final UserRepository userRepository;
     private final UserProfileRepository userProfileRepository;
     private final UserInterestRepository userInterestRepository;
+    private final CouncilMemberRepository councilMemberRepository;
     private final ObjectMapper objectMapper;
 
     // 나의 교류망 목록 조회
@@ -61,6 +65,12 @@ public class NetworkService {
                 })
                 .collect(Collectors.toList());
 
+        // 자치회 정보 배치 조회 (N+1 방지)
+        List<Long> targetUserIds = connections.stream()
+                .map(conn -> conn.getTarget().getUserId())
+                .collect(Collectors.toList());
+        Map<Long, CouncilMember> membershipMap = getCouncilMembershipMap(targetUserIds);
+
         List<NetworkListResponse.NetworkCard> networkCards = connections.stream()
                 .map(conn -> {
                     User target = conn.getTarget();
@@ -68,6 +78,9 @@ public class NetworkService {
                     List<String> interests = getInterestsByUser(target);
                     List<String> mainGoals = convertJsonToList(profile.getMainGoal());
                     String buttonType = determineButtonType(user, target);
+
+                    // 자치회 정보 추가
+                    CouncilMember membership = membershipMap.get(target.getUserId());
 
                     return NetworkListResponse.NetworkCard.builder()
                             .userId(target.getUserId())
@@ -78,6 +91,8 @@ public class NetworkService {
                             .mainGoals(mainGoals)
                             .interests(interests)
                             .buttonType(buttonType)
+                            .isInCouncil(membership != null)
+                            .councilName(membership != null ? membership.getCouncil().getCouncilName() : null)
                             .build();
                 })
                 .collect(Collectors.toList());
@@ -214,12 +229,22 @@ public class NetworkService {
 
         List<User> searchedUsers = userRepository.findByNameContaining(keyword);
 
+        // 자치회 정보 배치 조회 (N+1 방지)
+        List<Long> userIds = searchedUsers.stream()
+                .map(User::getUserId)
+                .filter(id -> !id.equals(userId))
+                .collect(Collectors.toList());
+        Map<Long, CouncilMember> membershipMap = getCouncilMembershipMap(userIds);
+
         List<NetworkSearchResponse.SearchedUser> users = searchedUsers.stream()
                 .filter(u -> !u.getUserId().equals(userId))
                 .map(u -> {
                     UserProfile profile = userProfileRepository.findByUser_UserId(u.getUserId()).orElse(null);
                     List<String> interests = getInterestsByUser(u);
                     boolean isConnected = connectionRepository.existsByRegisterAndTarget(user, u);
+
+                    // 자치회 정보 추가
+                    CouncilMember membership = membershipMap.get(u.getUserId());
 
                     return NetworkSearchResponse.SearchedUser.builder()
                             .userId(u.getUserId())
@@ -229,6 +254,8 @@ public class NetworkService {
                             .solidGoalName(profile != null ? profile.getSolidGoalName() : null)
                             .interests(interests)
                             .isConnected(isConnected)
+                            .isInCouncil(membership != null)
+                            .councilName(membership != null ? membership.getCouncil().getCouncilName() : null)
                             .build();
                 })
                 .collect(Collectors.toList());
@@ -263,6 +290,20 @@ public class NetworkService {
                 .stream()
                 .map(UserInterest::getCategoryName)
                 .collect(Collectors.toList());
+    }
+
+    // 자치회 멤버십 배치 조회 (N+1 방지)
+    private Map<Long, CouncilMember> getCouncilMembershipMap(List<Long> userIds) {
+        if (userIds.isEmpty()) {
+            return Map.of();
+        }
+
+        Set<Long> userIdSet = new HashSet<>(userIds);
+        return councilMemberRepository.findByUserIdIn(userIdSet).stream()
+                .collect(Collectors.toMap(
+                        cm -> cm.getUser().getUserId(),
+                        Function.identity()
+                ));
     }
 
     private String determineButtonType(User me, User target) {
@@ -306,14 +347,25 @@ public class NetworkService {
             return List.of();
         }
 
-        return userInterestRepository.findAllByCategoryNameIn(myInterests).stream()
+        List<User> users = userInterestRepository.findAllByCategoryNameIn(myInterests).stream()
                 .map(UserInterest::getUser)
                 .filter(u -> !u.getUserId().equals(user.getUserId()))
                 .distinct()
                 .limit(10)
+                .collect(Collectors.toList());
+
+        // 자치회 정보 배치 조회 (N+1 방지)
+        List<Long> userIds = users.stream()
+                .map(User::getUserId)
+                .collect(Collectors.toList());
+        Map<Long, CouncilMember> membershipMap = getCouncilMembershipMap(userIds);
+
+        return users.stream()
                 .map(u -> {
                     UserProfile profile = userProfileRepository.findByUser_UserId(u.getUserId()).orElse(null);
                     List<String> interests = getInterestsByUser(u);
+                    CouncilMember membership = membershipMap.get(u.getUserId());
+
                     return NetworkRecommendationResponse.RecommendedUser.builder()
                             .userId(u.getUserId())
                             .userName(u.getName())
@@ -321,18 +373,31 @@ public class NetworkService {
                             .backgroundPattern(profile != null ? profile.getBackgroundPattern() : null)
                             .solidGoalName(profile != null ? profile.getSolidGoalName() : null)
                             .interests(interests)
+                            .isInCouncil(membership != null)
+                            .councilName(membership != null ? membership.getCouncil().getCouncilName() : null)
                             .build();
                 })
                 .collect(Collectors.toList());
     }
 
     private List<NetworkRecommendationResponse.RecommendedUser> findAllUsersExcept(User user) {
-        return userRepository.findAll().stream()
+        List<User> users = userRepository.findAll().stream()
                 .filter(u -> !u.getUserId().equals(user.getUserId()))
                 .limit(20)
+                .collect(Collectors.toList());
+
+        // 자치회 정보 배치 조회 (N+1 방지)
+        List<Long> userIds = users.stream()
+                .map(User::getUserId)
+                .collect(Collectors.toList());
+        Map<Long, CouncilMember> membershipMap = getCouncilMembershipMap(userIds);
+
+        return users.stream()
                 .map(u -> {
                     UserProfile profile = userProfileRepository.findByUser_UserId(u.getUserId()).orElse(null);
                     List<String> interests = getInterestsByUser(u);
+                    CouncilMember membership = membershipMap.get(u.getUserId());
+
                     return NetworkRecommendationResponse.RecommendedUser.builder()
                             .userId(u.getUserId())
                             .userName(u.getName())
@@ -340,6 +405,8 @@ public class NetworkService {
                             .backgroundPattern(profile != null ? profile.getBackgroundPattern() : null)
                             .solidGoalName(profile != null ? profile.getSolidGoalName() : null)
                             .interests(interests)
+                            .isInCouncil(membership != null)
+                            .councilName(membership != null ? membership.getCouncil().getCouncilName() : null)
                             .build();
                 })
                 .collect(Collectors.toList());

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/user/controller/UserController.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/user/controller/UserController.java
@@ -1,11 +1,13 @@
 package com.solif.backend.domain.user.controller;
 
 import com.solif.backend.domain.user.dto.UserMeResponse;
+import com.solif.backend.domain.user.dto.UserSearchResponse;
 import com.solif.backend.domain.user.dto.UserSuccessCode;
 import com.solif.backend.domain.user.service.UserService;
 import com.solif.backend.global.common.response.ResponseFactory;
 import com.solif.backend.global.common.response.SuccessResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -13,11 +15,14 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @Tag(name = "사용자", description = "테스트용 사용자 정보 API")
 @RestController
-@RequestMapping("/api/users")
+@RequestMapping("/api/v1/users")
 @RequiredArgsConstructor
 public class UserController {
 
@@ -34,5 +39,19 @@ public class UserController {
     ) {
         UserMeResponse response = userService.getMyInfo(userId);
         return ResponseFactory.success(UserSuccessCode.GET_MY_INFO_SUCCESS, response);
+    }
+
+    @Operation(
+            summary = "사용자 검색",
+            description = "이름으로 사용자를 검색합니다. 자치회 소속 여부도 함께 반환합니다. (최대 20명)",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @GetMapping("/search")
+    public ResponseEntity<SuccessResponse<List<UserSearchResponse>>> searchUsers(
+            @Parameter(description = "검색 키워드 (이름)", required = true, example = "김지환")
+            @RequestParam String keyword
+    ) {
+        List<UserSearchResponse> response = userService.searchUsers(keyword);
+        return ResponseFactory.success(UserSuccessCode.USER_SEARCH_SUCCESS, response);
     }
 }

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/user/dto/UserSearchResponse.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/user/dto/UserSearchResponse.java
@@ -1,0 +1,42 @@
+package com.solif.backend.domain.user.dto;
+
+import com.solif.backend.domain.council.entity.CouncilMember;
+import com.solif.backend.domain.user.entity.User;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@Schema(description = "사용자 검색 응답")
+public class UserSearchResponse {
+
+    @Schema(description = "사용자 ID", example = "1")
+    private Long userId;
+
+    @Schema(description = "사용자 이름", example = "김지환")
+    private String name;
+
+    @Schema(description = "지역", example = "제주")
+    private String region;
+
+    @Schema(description = "학교명", example = "제주대학교")
+    private String schoolName;
+
+    @Schema(description = "자치회 소속 여부", example = "true")
+    private Boolean isInCouncil;
+
+    @Schema(description = "소속 자치회 이름", example = "제주최강산한이들")
+    private String councilName;
+
+    public static UserSearchResponse from(User user, CouncilMember membership) {
+        return UserSearchResponse.builder()
+                .userId(user.getUserId())
+                .name(user.getName())
+                .region(user.getRegion())
+                .schoolName(user.getSchoolName())
+                .isInCouncil(membership != null)
+                .councilName(membership != null ? membership.getCouncil().getCouncilName() : null)
+                .build();
+    }
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/user/dto/UserSuccessCode.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/user/dto/UserSuccessCode.java
@@ -9,7 +9,8 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum UserSuccessCode implements SuccessCode {
     
-    GET_MY_INFO_SUCCESS(HttpStatus.OK, "USER_001", "내 정보 조회 성공");
+    GET_MY_INFO_SUCCESS(HttpStatus.OK, "USER_001", "내 정보 조회 성공"),
+    USER_SEARCH_SUCCESS(HttpStatus.OK, "USER_002", "사용자 검색 성공");
 
     private final HttpStatus status;
     private final String code;

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/user/repository/UserRepository.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/user/repository/UserRepository.java
@@ -1,7 +1,10 @@
 package com.solif.backend.domain.user.repository;
 
 import com.solif.backend.domain.user.entity.User;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -22,4 +25,8 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     // 이름으로 검색
     List<User> findByNameContaining(String name);
+
+    // 이름으로 검색 (페이징, 정렬)
+    @Query("SELECT u FROM User u WHERE u.name LIKE %:keyword% ORDER BY u.name")
+    List<User> searchByName(@Param("keyword") String keyword, Pageable pageable);
 }

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/user/service/UserService.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/user/service/UserService.java
@@ -1,14 +1,25 @@
 package com.solif.backend.domain.user.service;
 
 import com.solif.backend.domain.auth.exception.AuthErrorCode;
+import com.solif.backend.domain.council.entity.CouncilMember;
+import com.solif.backend.domain.council.repository.CouncilMemberRepository;
 import com.solif.backend.domain.user.dto.UserMeResponse;
+import com.solif.backend.domain.user.dto.UserSearchResponse;
 import com.solif.backend.domain.user.entity.User;
 import com.solif.backend.domain.user.repository.UserRepository;
 import com.solif.backend.global.common.exception.CustomException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -17,13 +28,52 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserService {
 
     private final UserRepository userRepository;
+    private final CouncilMemberRepository councilMemberRepository;
 
-    //내 정보 조회
+    // 내 정보 조회
     public UserMeResponse getMyInfo(Long userId) {
 
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(AuthErrorCode.USER_NOT_FOUND));
 
         return UserMeResponse.from(user);
+    }
+
+    // 사용자 검색
+    public List<UserSearchResponse> searchUsers(String keyword) {
+        log.info("사용자 검색 - keyword: {}", keyword);
+
+        // 키워드가 비어있으면 빈 리스트 반환
+        if (keyword == null || keyword.trim().isEmpty()) {
+            return List.of();
+        }
+
+        // 최대 20명까지만 조회
+        Pageable pageable = PageRequest.of(0, 20);
+        List<User> users = userRepository.searchByName(keyword.trim(), pageable);
+
+        if (users.isEmpty()) {
+            return List.of();
+        }
+
+        // 사용자 ID 목록
+        Set<Long> userIds = users.stream()
+                .map(User::getUserId)
+                .collect(Collectors.toSet());
+
+        // 한 번의 쿼리로 모든 멤버십 조회 (N+1 방지)
+        List<CouncilMember> memberships = councilMemberRepository.findByUserIdIn(userIds);
+
+        // userId -> CouncilMember 매핑
+        Map<Long, CouncilMember> membershipMap = memberships.stream()
+                .collect(Collectors.toMap(
+                        cm -> cm.getUser().getUserId(),
+                        Function.identity()
+                ));
+
+        // DTO 변환
+        return users.stream()
+                .map(user -> UserSearchResponse.from(user, membershipMap.get(user.getUserId())))
+                .collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
## 🔍 개요
자치회 멤버 추가 화면에서 사용자를 검색할 수 있도록 사용자 검색 API를 추가하고,
네트워크 관련 API 응답에 자치회 소속 정보를 포함하도록 개선했다.

## ✨ 변경 사항
- 사용자 검색 API 추가
- 사용자 검색 응답에 자치회 소속 여부 및 자치회명 포함
- Network API 응답에 자치회 정보 필드 추가
- CouncilMemberRepository를 활용한 자치회 소속 여부 조회 로직 구현

## 🧪 테스트
- [x] 로컬 테스트 완료
- [x] API 테스트 완료
- [ ] 테스트 코드 작성 (해당 시)

## 📎 관련 이슈
Closes: #53 

## ⚠️ 참고 사항
- 사용자 검색 API는 자치회 멤버 추가 외에도 쪽지 보내기, 네트워크 기능에서 재사용 가능하도록 설계했습니다.
- Network API 수정은 응답 DTO 필드 확장만 수행하며 기존 기능에는 영향이 없습니다.
- N+1 쿼리 방지를 위해 자치회 소속 여부 조회는 Repository 레벨에서 처리했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **신규 기능**
  * 사용자 검색 기능 추가 - 이름으로 사용자를 검색할 수 있습니다.
  * 네트워크 카드 및 검색 결과에 의회 회원 여부와 의회명 정보 표시
  * 네트워크 추천 결과에 의회 소속 정보 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->