### PR TITLE
feat: 자치회 활동 후기/릴레이/질문 API 구현

### DIFF
--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/council/code/CouncilErrorCode.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/council/code/CouncilErrorCode.java
@@ -27,6 +27,7 @@ public enum CouncilErrorCode implements ErrorCode {
 
     // 예산 관련
     INSUFFICIENT_BUDGET(HttpStatus.BAD_REQUEST, "COUNCIL_010", "예산이 부족합니다."),
+    INVALID_BUDGET_AMOUNT(HttpStatus.BAD_REQUEST, "COUNCIL_013", "예산 금액이 유효하지 않습니다."),
 
     // 자치회 소속 관련
     ALREADY_IN_COUNCIL(HttpStatus.BAD_REQUEST, "COUNCIL_011", "이미 다른 자치회에 소속되어 있습니다."),

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/council/entity/Council.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/council/entity/Council.java
@@ -91,13 +91,29 @@ public class Council {
         this.profileImageFileId = profileImageFileId;
     }
 
+    // 예산 차감 (활동 후기 작성 시)
     public void decreaseBudget(Long usedBudget) {
         if (usedBudget == null || usedBudget < 0) {
-            throw new IllegalArgumentException("사용 예산은 0 이상이어야 합니다.");
+            throw new CustomException(CouncilErrorCode.INVALID_BUDGET_AMOUNT);
         }
 
-        // 예산 초과 허용, 단 currentBudget은 음수 불가 (0원으로 표시)
-        this.currentBudget = Math.max(0L, this.currentBudget - usedBudget);
+        // 예산 차감
+        this.currentBudget = this.currentBudget - usedBudget;
+
+        // 예산이 음수가 되면 0원으로 표시 (예산 초과 허용)
+        if (this.currentBudget < 0) {
+            this.currentBudget = 0L;
+        }
+    }
+
+    // 예산 복구 (활동 후기 수정/삭제 시)
+    public void increaseBudget(Long refundBudget) {
+        if (refundBudget == null || refundBudget < 0) {
+            throw new CustomException(CouncilErrorCode.INVALID_BUDGET_AMOUNT);
+        }
+
+        // 복구는 총 예산을 초과할 수 없음
+        this.currentBudget = Math.min(this.totalBudget, this.currentBudget + refundBudget);
     }
 
     public boolean isLeader(Long userId) {

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/council/repository/CouncilMemberRepository.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/council/repository/CouncilMemberRepository.java
@@ -24,6 +24,10 @@ public interface CouncilMemberRepository extends JpaRepository<CouncilMember, Lo
     @Query("SELECT cm FROM CouncilMember cm JOIN FETCH cm.user WHERE cm.council = :council ORDER BY cm.role DESC, cm.joinedAt ASC")
     List<CouncilMember> findByCouncilOrderByRoleDescJoinedAtAsc(@Param("council") Council council);
 
+    // 자치회 ID로 멤버 목록 조회
+    @Query("SELECT cm FROM CouncilMember cm JOIN FETCH cm.user WHERE cm.council.councilId = :councilId")
+    List<CouncilMember> findByCouncil_CouncilId(@Param("councilId") Long councilId);
+
     // 사용자로 소속 자치회 조회
     Optional<CouncilMember> findByUser(User user);
 

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/councilreview/code/CouncilReviewErrorCode.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/councilreview/code/CouncilReviewErrorCode.java
@@ -1,0 +1,43 @@
+package com.solif.backend.domain.councilreview.code;
+
+import com.solif.backend.global.common.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum CouncilReviewErrorCode implements ErrorCode {
+
+    // 활동 후기 관련
+    COUNCIL_REVIEW_POST_NOT_FOUND(HttpStatus.NOT_FOUND, "COUNCIL_REVIEW_001", "존재하지 않는 활동 후기입니다."),
+    COUNCIL_REVIEW_POST_DELETED(HttpStatus.BAD_REQUEST, "COUNCIL_REVIEW_002", "삭제된 활동 후기입니다."),
+
+    // 권한 관련 (활동 후기)
+    ONLY_LEADER_CAN_CREATE_REVIEW(HttpStatus.FORBIDDEN, "COUNCIL_REVIEW_003", "활동 후기 작성 권한이 없습니다. 리더만 작성 가능합니다."),
+    ONLY_LEADER_CAN_UPDATE_REVIEW(HttpStatus.FORBIDDEN, "COUNCIL_REVIEW_004", "활동 후기 수정 권한이 없습니다. 리더만 수정 가능합니다."),
+    ONLY_LEADER_CAN_DELETE_REVIEW(HttpStatus.FORBIDDEN, "COUNCIL_REVIEW_005", "활동 후기 삭제 권한이 없습니다. 리더만 삭제 가능합니다."),
+
+    // 릴레이 관련
+    RELAY_NOT_FOUND(HttpStatus.NOT_FOUND, "COUNCIL_REVIEW_008", "존재하지 않는 릴레이입니다."),
+    ONLY_WRITER_CAN_UPDATE_RELAY(HttpStatus.FORBIDDEN, "COUNCIL_REVIEW_009", "릴레이 수정 권한이 없습니다. 작성자만 수정 가능합니다."),
+    ONLY_WRITER_CAN_DELETE_RELAY(HttpStatus.FORBIDDEN, "COUNCIL_REVIEW_010", "릴레이 삭제 권한이 없습니다. 작성자만 삭제 가능합니다."),
+
+    // 릴레이 작성 제약
+    NOT_PARTICIPANT(HttpStatus.FORBIDDEN, "COUNCIL_REVIEW_006", "릴레이 작성 권한이 없습니다. 참여자만 작성 가능합니다."),
+    ALREADY_WRITTEN_RELAY(HttpStatus.BAD_REQUEST, "COUNCIL_REVIEW_007", "이미 릴레이를 작성했습니다. 1인 1회만 작성 가능합니다."),
+
+    // 질문 관련
+    QUESTION_NOT_FOUND(HttpStatus.NOT_FOUND, "COUNCIL_REVIEW_011", "존재하지 않는 질문입니다."),
+    QUESTION_NOT_ACTIVE(HttpStatus.BAD_REQUEST, "COUNCIL_REVIEW_012", "비활성화된 질문입니다."),
+    QUESTION_ALREADY_USED(HttpStatus.BAD_REQUEST, "COUNCIL_REVIEW_013", "이미 사용된 질문입니다. 중복 사용할 수 없습니다."),
+    NO_AVAILABLE_QUESTIONS(HttpStatus.BAD_REQUEST, "COUNCIL_REVIEW_016", "사용 가능한 질문이 없습니다."),
+
+    // 참여자 관련
+    PARTICIPANT_NOT_COUNCIL_MEMBER(HttpStatus.BAD_REQUEST, "COUNCIL_REVIEW_014", "참여자 중 자치회 멤버가 아닌 사용자가 있습니다."),
+    PARTICIPANT_LIST_EMPTY(HttpStatus.BAD_REQUEST, "COUNCIL_REVIEW_015", "참여자 명단이 비어있습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/councilreview/code/CouncilReviewSuccessCode.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/councilreview/code/CouncilReviewSuccessCode.java
@@ -1,0 +1,32 @@
+package com.solif.backend.domain.councilreview.code;
+
+import com.solif.backend.global.common.response.SuccessCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum CouncilReviewSuccessCode implements SuccessCode {
+
+    // 활동 후기 조회
+    COUNCIL_REVIEW_LIST_SUCCESS(HttpStatus.OK, "COUNCIL_REVIEW_200", "활동 후기 목록 조회에 성공했습니다."),
+    COUNCIL_REVIEW_DETAIL_SUCCESS(HttpStatus.OK, "COUNCIL_REVIEW_201", "활동 후기 상세 조회에 성공했습니다."),
+
+    // 활동 후기 생성/수정/삭제
+    COUNCIL_REVIEW_CREATE_SUCCESS(HttpStatus.CREATED, "COUNCIL_REVIEW_202", "활동 후기 생성에 성공했습니다."),
+    COUNCIL_REVIEW_UPDATE_SUCCESS(HttpStatus.OK, "COUNCIL_REVIEW_203", "활동 후기 수정에 성공했습니다."),
+    COUNCIL_REVIEW_DELETE_SUCCESS(HttpStatus.OK, "COUNCIL_REVIEW_204", "활동 후기 삭제에 성공했습니다."),
+
+    // 릴레이 작성/수정/삭제
+    COUNCIL_REVIEW_RELAY_CREATE_SUCCESS(HttpStatus.CREATED, "COUNCIL_REVIEW_205", "릴레이 작성에 성공했습니다."),
+    COUNCIL_REVIEW_RELAY_UPDATE_SUCCESS(HttpStatus.OK, "COUNCIL_REVIEW_206", "릴레이 수정에 성공했습니다."),
+    COUNCIL_REVIEW_RELAY_DELETE_SUCCESS(HttpStatus.OK, "COUNCIL_REVIEW_207", "릴레이 삭제에 성공했습니다."),
+
+    // 질문 조회
+    COUNCIL_REVIEW_QUESTION_RANDOM_SUCCESS(HttpStatus.OK, "COUNCIL_REVIEW_208", "랜덤 질문 조회에 성공했습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/councilreview/controller/CouncilReviewPostController.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/councilreview/controller/CouncilReviewPostController.java
@@ -51,12 +51,12 @@ public class CouncilReviewPostController {
             description = "활동 후기 상세 정보 및 모든 릴레이 글을 조회합니다. 조회수가 1 증가합니다. 모든 인증 사용자가 조회 가능합니다.",
             security = @SecurityRequirement(name = "bearerAuth")
     )
-    @GetMapping("/council-review-posts/{postId}")
+    @GetMapping("/council-review-posts/{councilReviewPostId}")
     public ResponseEntity<SuccessResponse<CouncilReviewPostDetailResponse>> getCouncilReviewPostDetail(
             @AuthenticationPrincipal Long userId,
-            @PathVariable Long postId
+            @PathVariable Long councilReviewPostId
     ) {
-        CouncilReviewPostDetailResponse post = reviewPostService.getCouncilReviewPostDetail(userId, postId);
+        CouncilReviewPostDetailResponse post = reviewPostService.getCouncilReviewPostDetail(userId, councilReviewPostId);
         return ResponseFactory.success(CouncilReviewSuccessCode.COUNCIL_REVIEW_DETAIL_SUCCESS, post);
     }
 
@@ -82,13 +82,13 @@ public class CouncilReviewPostController {
             description = "리더가 활동 후기 메타 정보를 수정합니다 (제목, 날짜, 장소, 비용, 이미지, 참여자). 리더만 수정 가능합니다. 예산이 재계산됩니다.",
             security = @SecurityRequirement(name = "bearerAuth")
     )
-    @PatchMapping("/council-review-posts/{postId}")
+    @PatchMapping("/council-review-posts/{councilReviewPostId}")
     public ResponseEntity<SuccessResponse<Void>> updateCouncilReviewPost(
             @AuthenticationPrincipal Long userId,
-            @PathVariable Long postId,
+            @PathVariable Long councilReviewPostId,
             @Valid @RequestBody CouncilReviewPostUpdateRequest request
     ) {
-        reviewPostService.updateCouncilReviewPost(userId, postId, request);
+        reviewPostService.updateCouncilReviewPost(userId, councilReviewPostId, request);
         return ResponseFactory.success(CouncilReviewSuccessCode.COUNCIL_REVIEW_UPDATE_SUCCESS);
     }
 
@@ -97,12 +97,12 @@ public class CouncilReviewPostController {
             description = "리더가 활동 후기 전체를 삭제합니다 (Soft Delete). 리더만 삭제 가능합니다. 모든 릴레이와 참여자 정보가 함께 삭제되고 예산이 복구됩니다.",
             security = @SecurityRequirement(name = "bearerAuth")
     )
-    @DeleteMapping("/council-review-posts/{postId}")
+    @DeleteMapping("/council-review-posts/{councilReviewPostId}")
     public ResponseEntity<SuccessResponse<Void>> deleteCouncilReviewPost(
             @AuthenticationPrincipal Long userId,
-            @PathVariable Long postId
+            @PathVariable Long councilReviewPostId
     ) {
-        reviewPostService.deleteCouncilReviewPost(userId, postId);
+        reviewPostService.deleteCouncilReviewPost(userId, councilReviewPostId);
         return ResponseFactory.success(CouncilReviewSuccessCode.COUNCIL_REVIEW_DELETE_SUCCESS);
     }
 }

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/councilreview/controller/CouncilReviewPostController.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/councilreview/controller/CouncilReviewPostController.java
@@ -1,0 +1,108 @@
+package com.solif.backend.domain.councilreview.controller;
+
+import com.solif.backend.domain.councilreview.code.CouncilReviewSuccessCode;
+import com.solif.backend.domain.councilreview.dto.request.CouncilReviewPostCreateRequest;
+import com.solif.backend.domain.councilreview.dto.request.CouncilReviewPostUpdateRequest;
+import com.solif.backend.domain.councilreview.dto.response.CouncilReviewPostCreateResponse;
+import com.solif.backend.domain.councilreview.dto.response.CouncilReviewPostDetailResponse;
+import com.solif.backend.domain.councilreview.dto.response.CouncilReviewPostListResponse;
+import com.solif.backend.domain.councilreview.service.CouncilReviewPostService;
+import com.solif.backend.global.common.response.ResponseFactory;
+import com.solif.backend.global.common.response.SuccessResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "자치회 활동 후기", description = "자치회 활동 후기 API")
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+public class CouncilReviewPostController {
+
+    private final CouncilReviewPostService reviewPostService;
+
+    @Operation(
+            summary = "자치회 활동 후기 목록 조회",
+            description = "특정 자치회의 활동 후기 목록을 페이징하여 조회합니다. 모든 인증 사용자가 조회 가능합니다.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @GetMapping("/councils/{councilId}/review-posts")
+    public ResponseEntity<SuccessResponse<Slice<CouncilReviewPostListResponse>>> getCouncilReviewPosts(
+            @PathVariable Long councilId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size
+    ) {
+        Pageable pageable = PageRequest.of(page, size, Sort.by("createdAt").descending());
+        Slice<CouncilReviewPostListResponse> posts = reviewPostService.getCouncilReviewPosts(councilId, pageable);
+        return ResponseFactory.success(CouncilReviewSuccessCode.COUNCIL_REVIEW_LIST_SUCCESS, posts);
+    }
+
+    @Operation(
+            summary = "자치회 활동 후기 상세 조회",
+            description = "활동 후기 상세 정보 및 모든 릴레이 글을 조회합니다. 조회수가 1 증가합니다. 모든 인증 사용자가 조회 가능합니다.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @GetMapping("/council-review-posts/{postId}")
+    public ResponseEntity<SuccessResponse<CouncilReviewPostDetailResponse>> getCouncilReviewPostDetail(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long postId
+    ) {
+        CouncilReviewPostDetailResponse post = reviewPostService.getCouncilReviewPostDetail(userId, postId);
+        return ResponseFactory.success(CouncilReviewSuccessCode.COUNCIL_REVIEW_DETAIL_SUCCESS, post);
+    }
+
+    @Operation(
+            summary = "자치회 활동 후기 생성",
+            description = "리더가 활동 후기를 생성하고 첫 번째 릴레이 글을 작성합니다. 리더만 생성 가능합니다. 예산이 자동으로 차감됩니다.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @PostMapping("/councils/{councilId}/review-posts")
+    public ResponseEntity<SuccessResponse<CouncilReviewPostCreateResponse>> createCouncilReviewPost(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long councilId,
+            @Valid @RequestBody CouncilReviewPostCreateRequest request
+    ) {
+        CouncilReviewPostCreateResponse response = reviewPostService.createCouncilReviewPost(
+                userId, councilId, request
+        );
+        return ResponseFactory.success(CouncilReviewSuccessCode.COUNCIL_REVIEW_CREATE_SUCCESS, response);
+    }
+
+    @Operation(
+            summary = "자치회 활동 후기 수정",
+            description = "리더가 활동 후기 메타 정보를 수정합니다 (제목, 날짜, 장소, 비용, 이미지, 참여자). 리더만 수정 가능합니다. 예산이 재계산됩니다.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @PatchMapping("/council-review-posts/{postId}")
+    public ResponseEntity<SuccessResponse<Void>> updateCouncilReviewPost(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long postId,
+            @Valid @RequestBody CouncilReviewPostUpdateRequest request
+    ) {
+        reviewPostService.updateCouncilReviewPost(userId, postId, request);
+        return ResponseFactory.success(CouncilReviewSuccessCode.COUNCIL_REVIEW_UPDATE_SUCCESS);
+    }
+
+    @Operation(
+            summary = "자치회 활동 후기 삭제",
+            description = "리더가 활동 후기 전체를 삭제합니다 (Soft Delete). 리더만 삭제 가능합니다. 모든 릴레이와 참여자 정보가 함께 삭제되고 예산이 복구됩니다.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @DeleteMapping("/council-review-posts/{postId}")
+    public ResponseEntity<SuccessResponse<Void>> deleteCouncilReviewPost(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long postId
+    ) {
+        reviewPostService.deleteCouncilReviewPost(userId, postId);
+        return ResponseFactory.success(CouncilReviewSuccessCode.COUNCIL_REVIEW_DELETE_SUCCESS);
+    }
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/councilreview/controller/CouncilReviewRelayController.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/councilreview/controller/CouncilReviewRelayController.java
@@ -1,0 +1,88 @@
+package com.solif.backend.domain.councilreview.controller;
+
+import com.solif.backend.domain.councilreview.code.CouncilReviewSuccessCode;
+import com.solif.backend.domain.councilreview.dto.request.CouncilReviewRelayCreateRequest;
+import com.solif.backend.domain.councilreview.dto.request.CouncilReviewRelayUpdateRequest;
+import com.solif.backend.domain.councilreview.dto.response.CouncilReviewQuestionResponse;
+import com.solif.backend.domain.councilreview.service.CouncilReviewQuestionService;
+import com.solif.backend.domain.councilreview.service.CouncilReviewRelayService;
+import com.solif.backend.global.common.response.ResponseFactory;
+import com.solif.backend.global.common.response.SuccessResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Map;
+
+@Tag(name = "자치회 활동 후기 릴레이", description = "자치회 활동 후기 릴레이 및 질문 API")
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+public class CouncilReviewRelayController {
+
+    private final CouncilReviewRelayService relayService;
+    private final CouncilReviewQuestionService questionService;
+
+    @Operation(
+            summary = "릴레이 작성",
+            description = "자치회 멤버가 활동 후기에 릴레이 글을 이어쓰기합니다. 참여자만 작성 가능하며 1인 1회 제한입니다. 질문은 중복 사용할 수 없습니다.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @PostMapping("/council-review-posts/{postId}/relays")
+    public ResponseEntity<SuccessResponse<Map<String, Object>>> createRelay(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long postId,
+            @Valid @RequestBody CouncilReviewRelayCreateRequest request
+    ) {
+        Map<String, Object> response = relayService.createRelay(userId, postId, request);
+        return ResponseFactory.success(CouncilReviewSuccessCode.COUNCIL_REVIEW_RELAY_CREATE_SUCCESS, response);
+    }
+
+    @Operation(
+            summary = "릴레이 수정",
+            description = "본인이 작성한 릴레이 글을 수정합니다. 작성자만 수정 가능하며 질문은 수정할 수 없습니다.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @PatchMapping("/council-review-relays/{relayId}")
+    public ResponseEntity<SuccessResponse<Void>> updateRelay(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long relayId,
+            @Valid @RequestBody CouncilReviewRelayUpdateRequest request
+    ) {
+        relayService.updateRelay(userId, relayId, request);
+        return ResponseFactory.success(CouncilReviewSuccessCode.COUNCIL_REVIEW_RELAY_UPDATE_SUCCESS);
+    }
+
+    @Operation(
+            summary = "릴레이 삭제",
+            description = "본인이 작성한 릴레이 글을 삭제합니다 (Hard Delete). 작성자만 삭제 가능하며 삭제 후 relay_order가 자동으로 재정렬됩니다.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @DeleteMapping("/council-review-relays/{relayId}")
+    public ResponseEntity<SuccessResponse<Void>> deleteRelay(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long relayId
+    ) {
+        relayService.deleteRelay(userId, relayId);
+        return ResponseFactory.success(CouncilReviewSuccessCode.COUNCIL_REVIEW_RELAY_DELETE_SUCCESS);
+    }
+
+    @Operation(
+            summary = "랜덤 질문 조회",
+            description = "활성화된 질문 중 랜덤으로 1개를 조회합니다. 이미 사용된 질문 ID 목록을 제외할 수 있습니다. 작성 시 질문 새로고침 기능에 사용됩니다.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @GetMapping("/council-review-questions/random")
+    public ResponseEntity<SuccessResponse<CouncilReviewQuestionResponse>> getRandomQuestion(
+            @RequestParam(required = false) List<Long> excludeQuestionIds
+    ) {
+        CouncilReviewQuestionResponse question = questionService.getRandomQuestion(excludeQuestionIds);
+        return ResponseFactory.success(CouncilReviewSuccessCode.COUNCIL_REVIEW_QUESTION_RANDOM_SUCCESS, question);
+    }
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/councilreview/controller/CouncilReviewRelayController.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/councilreview/controller/CouncilReviewRelayController.java
@@ -34,13 +34,13 @@ public class CouncilReviewRelayController {
             description = "자치회 멤버가 활동 후기에 릴레이 글을 이어쓰기합니다. 참여자만 작성 가능하며 1인 1회 제한입니다. 질문은 중복 사용할 수 없습니다.",
             security = @SecurityRequirement(name = "bearerAuth")
     )
-    @PostMapping("/council-review-posts/{postId}/relays")
+    @PostMapping("/council-review-posts/{councilReviewPostId}/relays")
     public ResponseEntity<SuccessResponse<Map<String, Object>>> createRelay(
             @AuthenticationPrincipal Long userId,
-            @PathVariable Long postId,
+            @PathVariable Long councilReviewPostId,
             @Valid @RequestBody CouncilReviewRelayCreateRequest request
     ) {
-        Map<String, Object> response = relayService.createRelay(userId, postId, request);
+        Map<String, Object> response = relayService.createRelay(userId, councilReviewPostId, request);
         return ResponseFactory.success(CouncilReviewSuccessCode.COUNCIL_REVIEW_RELAY_CREATE_SUCCESS, response);
     }
 

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/councilreview/dto/request/CouncilReviewPostCreateRequest.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/councilreview/dto/request/CouncilReviewPostCreateRequest.java
@@ -1,0 +1,49 @@
+package com.solif.backend.domain.councilreview.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@Schema(description = "자치회 활동 후기 생성 요청")
+public class CouncilReviewPostCreateRequest {
+
+    @NotBlank(message = "제목은 필수입니다.")
+    @Size(max = 255, message = "제목은 255자 이하여야 합니다.")
+    @Schema(description = "게시글 제목", example = "우리들의 첫 만남")
+    private String postTitle;
+
+    @NotNull(message = "활동 날짜는 필수입니다.")
+    @Schema(description = "활동 날짜", example = "2026-02-10")
+    private LocalDate activityDate;
+
+    @NotBlank(message = "활동 장소는 필수입니다.")
+    @Size(max = 255, message = "활동 장소는 255자 이하여야 합니다.")
+    @Schema(description = "활동 장소", example = "별마당 도서관")
+    private String activityLocation;
+
+    @NotNull(message = "지출 총액은 필수입니다.")
+    @Min(value = 0, message = "지출 총액은 0원 이상이어야 합니다.")
+    @Schema(description = "지출 총액", example = "120380")
+    private Long totalCost;
+
+    @NotEmpty(message = "참여자는 최소 1명 이상이어야 합니다.")
+    @Schema(description = "참여자 사용자 ID 목록", example = "[1, 2, 3, 4, 5, 6]")
+    private List<Long> participantUserIds;
+
+    @Schema(description = "이미지 파일 ID 목록 (선택)", example = "[10, 11, 12]")
+    private List<Long> imageFileIds;
+
+    @NotNull(message = "질문 ID는 필수입니다.")
+    @Schema(description = "리더가 선택한 질문 ID", example = "5")
+    private Long questionId;
+
+    @NotBlank(message = "릴레이 내용은 필수입니다.")
+    @Schema(description = "리더의 첫 번째 릴레이 내용", example = "등촌 한국수를 먹으며 마음까지 따뜻해지는 시간을 보냈습니다...")
+    private String relayContent;
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/councilreview/dto/request/CouncilReviewPostUpdateRequest.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/councilreview/dto/request/CouncilReviewPostUpdateRequest.java
@@ -1,0 +1,41 @@
+package com.solif.backend.domain.councilreview.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@Schema(description = "자치회 활동 후기 수정 요청")
+public class CouncilReviewPostUpdateRequest {
+
+    @NotBlank(message = "제목은 필수입니다.")
+    @Size(max = 255, message = "제목은 255자 이하여야 합니다.")
+    @Schema(description = "게시글 제목", example = "우리들의 첫 만남 (수정)")
+    private String postTitle;
+
+    @NotNull(message = "활동 날짜는 필수입니다.")
+    @Schema(description = "활동 날짜", example = "2026-02-11")
+    private LocalDate activityDate;
+
+    @NotBlank(message = "활동 장소는 필수입니다.")
+    @Size(max = 255, message = "활동 장소는 255자 이하여야 합니다.")
+    @Schema(description = "활동 장소", example = "별마당 도서관 2층")
+    private String activityLocation;
+
+    @NotNull(message = "지출 총액은 필수입니다.")
+    @Min(value = 0, message = "지출 총액은 0원 이상이어야 합니다.")
+    @Schema(description = "지출 총액", example = "150000")
+    private Long totalCost;
+
+    @NotEmpty(message = "참여자는 최소 1명 이상이어야 합니다.")
+    @Schema(description = "참여자 사용자 ID 목록", example = "[1, 2, 3, 4, 5, 6, 7]")
+    private List<Long> participantUserIds;
+
+    @Schema(description = "이미지 파일 ID 목록 (선택)", example = "[10, 11, 12, 13]")
+    private List<Long> imageFileIds;
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/councilreview/dto/request/CouncilReviewRelayCreateRequest.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/councilreview/dto/request/CouncilReviewRelayCreateRequest.java
@@ -1,0 +1,21 @@
+package com.solif.backend.domain.councilreview.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@Schema(description = "자치회 활동 후기 릴레이 작성 요청")
+public class CouncilReviewRelayCreateRequest {
+
+    @NotNull(message = "질문 ID는 필수입니다.")
+    @Schema(description = "선택한 질문 ID", example = "7")
+    private Long questionId;
+
+    @NotBlank(message = "릴레이 내용은 필수입니다.")
+    @Schema(description = "릴레이 내용", example = "가장 즐거웠던 순간은 친구들과 공유할 즐거움을 알려주세요...")
+    private String relayContent;
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/councilreview/dto/request/CouncilReviewRelayUpdateRequest.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/councilreview/dto/request/CouncilReviewRelayUpdateRequest.java
@@ -1,0 +1,16 @@
+package com.solif.backend.domain.councilreview.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@Schema(description = "자치회 활동 후기 릴레이 수정 요청")
+public class CouncilReviewRelayUpdateRequest {
+
+    @NotBlank(message = "릴레이 내용은 필수입니다.")
+    @Schema(description = "수정할 릴레이 내용", example = "수정된 릴레이 내용...")
+    private String relayContent;
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/councilreview/dto/response/CouncilReviewParticipantResponse.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/councilreview/dto/response/CouncilReviewParticipantResponse.java
@@ -1,0 +1,25 @@
+package com.solif.backend.domain.councilreview.dto.response;
+
+import com.solif.backend.domain.councilreview.entity.CouncilReviewParticipant;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@Schema(description = "자치회 활동 참여자 응답")
+public class CouncilReviewParticipantResponse {
+
+    @Schema(description = "참여자 사용자 ID", example = "1")
+    private Long userId;
+
+    @Schema(description = "참여자 이름", example = "김선한")
+    private String userName;
+
+    public static CouncilReviewParticipantResponse from(CouncilReviewParticipant participant) {
+        return CouncilReviewParticipantResponse.builder()
+                .userId(participant.getUser().getUserId())
+                .userName(participant.getUser().getName())
+                .build();
+    }
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/councilreview/dto/response/CouncilReviewPostCreateResponse.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/councilreview/dto/response/CouncilReviewPostCreateResponse.java
@@ -1,0 +1,24 @@
+package com.solif.backend.domain.councilreview.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@Schema(description = "자치회 활동 후기 생성 응답")
+public class CouncilReviewPostCreateResponse {
+
+    @Schema(description = "활동 후기 게시글 ID", example = "1")
+    private Long councilReviewPostId;
+
+    @Schema(description = "통합 게시글 ID (Post)", example = "100")
+    private Long postId;
+
+    public static CouncilReviewPostCreateResponse of(Long councilReviewPostId, Long postId) {
+        return CouncilReviewPostCreateResponse.builder()
+                .councilReviewPostId(councilReviewPostId)
+                .postId(postId)
+                .build();
+    }
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/councilreview/dto/response/CouncilReviewPostDetailResponse.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/councilreview/dto/response/CouncilReviewPostDetailResponse.java
@@ -1,0 +1,102 @@
+package com.solif.backend.domain.councilreview.dto.response;
+
+import com.solif.backend.domain.councilreview.entity.CouncilReviewPost;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+@Schema(description = "자치회 활동 후기 상세 응답")
+public class CouncilReviewPostDetailResponse {
+
+    @Schema(description = "활동 후기 게시글 ID", example = "1")
+    private Long councilReviewPostId;
+
+    @Schema(description = "통합 게시글 ID", example = "100")
+    private Long postId;
+
+    @Schema(description = "자치회 ID", example = "10")
+    private Long councilId;
+
+    @Schema(description = "자치회 이름", example = "재주자치회")
+    private String councilName;
+
+    @Schema(description = "게시글 제목", example = "우리들의 첫 만남")
+    private String postTitle;
+
+    @Schema(description = "활동 날짜", example = "2026-02-10")
+    private LocalDate activityDate;
+
+    @Schema(description = "활동 장소", example = "별마당 도서관")
+    private String activityLocation;
+
+    @Schema(description = "지출 총액", example = "120380")
+    private Long totalCost;
+
+    @Schema(description = "활동 이미지 URL 목록")
+    private List<String> imageUrls;
+
+    @Schema(description = "참여자 목록")
+    private List<CouncilReviewParticipantResponse> participants;
+
+    @Schema(description = "릴레이 목록")
+    private List<CouncilReviewRelayResponse> relays;
+
+    @Schema(description = "조회수", example = "21")
+    private Integer viewCount;
+
+    @Schema(description = "좋아요 수", example = "7")
+    private Long likeCount;
+
+    @Schema(description = "댓글 수", example = "10")
+    private Long commentCount;
+
+    @Schema(description = "내가 좋아요 눌렀는지 여부", example = "false")
+    private Boolean isLikedByMe;
+
+    @Schema(description = "내가 리더인지 여부", example = "true")
+    private Boolean isLeader;
+
+    @Schema(description = "작성 시간", example = "2026-02-10T15:30:00")
+    private LocalDateTime createdAt;
+
+    @Schema(description = "수정 시간", example = "null")
+    private LocalDateTime updatedAt;
+
+    public static CouncilReviewPostDetailResponse of(
+            CouncilReviewPost post,
+            List<String> imageUrls,
+            List<CouncilReviewParticipantResponse> participants,
+            List<CouncilReviewRelayResponse> relays,
+            Long likeCount,
+            Long commentCount,
+            Boolean isLikedByMe,
+            Boolean isLeader
+    ) {
+        return CouncilReviewPostDetailResponse.builder()
+                .councilReviewPostId(post.getCouncilReviewPostId())
+                .postId(post.getPost().getPostId())
+                .councilId(post.getCouncil().getCouncilId())
+                .councilName(post.getCouncil().getCouncilName())
+                .postTitle(post.getPost().getPostTitle())
+                .activityDate(post.getActivityDate())
+                .activityLocation(post.getActivityLocation())
+                .totalCost(post.getTotalCost())
+                .imageUrls(imageUrls)
+                .participants(participants)
+                .relays(relays)
+                .viewCount(post.getPost().getViewCount())
+                .likeCount(likeCount)
+                .commentCount(commentCount)
+                .isLikedByMe(isLikedByMe)
+                .isLeader(isLeader)
+                .createdAt(post.getCreatedAt())
+                .updatedAt(post.getUpdatedAt())
+                .build();
+    }
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/councilreview/dto/response/CouncilReviewPostListResponse.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/councilreview/dto/response/CouncilReviewPostListResponse.java
@@ -1,0 +1,79 @@
+package com.solif.backend.domain.councilreview.dto.response;
+
+import com.solif.backend.domain.councilreview.entity.CouncilReviewPost;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@Schema(description = "자치회 활동 후기 목록 응답")
+public class CouncilReviewPostListResponse {
+
+    @Schema(description = "활동 후기 게시글 ID", example = "1")
+    private Long councilReviewPostId;
+
+    @Schema(description = "통합 게시글 ID", example = "100")
+    private Long postId;
+
+    @Schema(description = "게시글 제목", example = "우리들의 첫 만남")
+    private String postTitle;
+
+    @Schema(description = "활동 날짜", example = "2026-02-10")
+    private LocalDate activityDate;
+
+    @Schema(description = "활동 장소", example = "별마당 도서관")
+    private String activityLocation;
+
+    @Schema(description = "지출 총액", example = "120380")
+    private Long totalCost;
+
+    @Schema(description = "참여 인원 수", example = "6")
+    private Long participantCount;
+
+    @Schema(description = "릴레이 개수", example = "3")
+    private Long relayCount;
+
+    @Schema(description = "조회수", example = "21")
+    private Integer viewCount;
+
+    @Schema(description = "좋아요 수", example = "7")
+    private Long likeCount;
+
+    @Schema(description = "댓글 수", example = "10")
+    private Long commentCount;
+
+    @Schema(description = "썸네일 이미지 URL (첫 번째 이미지)", example = "https://...")
+    private String thumbnailImageUrl;
+
+    @Schema(description = "작성 시간", example = "2026-02-10T15:30:00")
+    private LocalDateTime createdAt;
+
+    public static CouncilReviewPostListResponse from(
+            CouncilReviewPost post,
+            Long participantCount,
+            Long relayCount,
+            Long likeCount,
+            Long commentCount,
+            String thumbnailImageUrl
+    ) {
+        return CouncilReviewPostListResponse.builder()
+                .councilReviewPostId(post.getCouncilReviewPostId())
+                .postId(post.getPost().getPostId())
+                .postTitle(post.getPost().getPostTitle())
+                .activityDate(post.getActivityDate())
+                .activityLocation(post.getActivityLocation())
+                .totalCost(post.getTotalCost())
+                .participantCount(participantCount)
+                .relayCount(relayCount)
+                .viewCount(post.getPost().getViewCount())
+                .likeCount(likeCount)
+                .commentCount(commentCount)
+                .thumbnailImageUrl(thumbnailImageUrl)
+                .createdAt(post.getCreatedAt())
+                .build();
+    }
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/councilreview/dto/response/CouncilReviewQuestionResponse.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/councilreview/dto/response/CouncilReviewQuestionResponse.java
@@ -1,0 +1,25 @@
+package com.solif.backend.domain.councilreview.dto.response;
+
+import com.solif.backend.domain.councilreview.entity.CouncilReviewQuestion;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@Schema(description = "자치회 활동 후기 질문 응답")
+public class CouncilReviewQuestionResponse {
+
+    @Schema(description = "질문 ID", example = "5")
+    private Long questionId;
+
+    @Schema(description = "질문 내용", example = "오늘 먹은 음식은요?")
+    private String questionText;
+
+    public static CouncilReviewQuestionResponse from(CouncilReviewQuestion question) {
+        return CouncilReviewQuestionResponse.builder()
+                .questionId(question.getCouncilReviewQuestionId())
+                .questionText(question.getQuestionText())
+                .build();
+    }
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/councilreview/dto/response/CouncilReviewRelayResponse.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/councilreview/dto/response/CouncilReviewRelayResponse.java
@@ -1,0 +1,58 @@
+package com.solif.backend.domain.councilreview.dto.response;
+
+import com.solif.backend.domain.councilreview.entity.CouncilReviewRelay;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@Schema(description = "자치회 활동 후기 릴레이 응답")
+public class CouncilReviewRelayResponse {
+
+    @Schema(description = "릴레이 ID", example = "1")
+    private Long councilReviewRelayId;
+
+    @Schema(description = "작성자 사용자 ID", example = "1")
+    private Long writerUserId;
+
+    @Schema(description = "작성자 이름", example = "김선한")
+    private String writerUserName;
+
+    @Schema(description = "릴레이 순서", example = "1")
+    private Integer relayOrder;
+
+    @Schema(description = "질문 내용", example = "오늘 먹은 음식은요?")
+    private String questionText;
+
+    @Schema(description = "릴레이 내용", example = "등촌 한국수를 먹으며...")
+    private String relayContent;
+
+    @Schema(description = "내가 작성한 릴레이인지 여부", example = "true")
+    private Boolean isMyRelay;
+
+    @Schema(description = "작성 시간", example = "2026-02-10T15:30:00")
+    private LocalDateTime createdAt;
+
+    @Schema(description = "수정 시간", example = "null")
+    private LocalDateTime updatedAt;
+
+    public static CouncilReviewRelayResponse from(
+            CouncilReviewRelay relay,
+            Long currentUserId
+    ) {
+        return CouncilReviewRelayResponse.builder()
+                .councilReviewRelayId(relay.getCouncilReviewRelayId())
+                .writerUserId(relay.getWriterUser().getUserId())
+                .writerUserName(relay.getWriterUser().getName())
+                .relayOrder(relay.getRelayOrder())
+                .questionText(relay.getCouncilReviewQuestion().getQuestionText())
+                .relayContent(relay.getRelayContent())
+                .isMyRelay(relay.isWriter(currentUserId))
+                .createdAt(relay.getCreatedAt())
+                .updatedAt(relay.getUpdatedAt())
+                .build();
+    }
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/councilreview/entity/CouncilReviewParticipant.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/councilreview/entity/CouncilReviewParticipant.java
@@ -1,0 +1,56 @@
+package com.solif.backend.domain.councilreview.entity;
+
+import com.solif.backend.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(
+        name = "council_review_participant",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_council_review_participant",
+                        columnNames = {"council_review_post_id", "user_id"}
+                )
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class CouncilReviewParticipant {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "council_review_participant_id")
+    private Long councilReviewParticipantId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "council_review_post_id", nullable = false)
+    private CouncilReviewPost councilReviewPost;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Builder
+    public CouncilReviewParticipant(CouncilReviewPost councilReviewPost, User user) {
+        this.councilReviewPost = councilReviewPost;
+        this.user = user;
+    }
+
+    // 비즈니스 로직
+    public boolean isParticipant(Long userId) {
+        return this.user.getUserId().equals(userId);
+    }
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/councilreview/entity/CouncilReviewPost.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/councilreview/entity/CouncilReviewPost.java
@@ -1,0 +1,95 @@
+package com.solif.backend.domain.councilreview.entity;
+
+import com.solif.backend.domain.council.entity.Council;
+import com.solif.backend.domain.post.entity.Post;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "council_review_post")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class CouncilReviewPost {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "council_review_post_id")
+    private Long councilReviewPostId;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id", nullable = false)
+    private Post post;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "council_id", nullable = false)
+    private Council council;
+
+    @Column(name = "activity_date", nullable = false)
+    private LocalDate activityDate;
+
+    @Column(name = "activity_location", nullable = false, length = 255)
+    private String activityLocation;
+
+    @Column(name = "total_cost", nullable = false)
+    private Long totalCost = 0L;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+    @Builder
+    public CouncilReviewPost(Post post, Council council, LocalDate activityDate,
+                             String activityLocation, Long totalCost) {
+        this.post = post;
+        this.council = council;
+        this.activityDate = activityDate;
+        this.activityLocation = activityLocation;
+        this.totalCost = totalCost != null ? totalCost : 0L;
+    }
+
+    // 비즈니스 로직
+    public void updateReviewPost(String postTitle, LocalDate activityDate,
+                                 String activityLocation, Long totalCost) {
+        // Post 제목 업데이트
+        this.post.updatePost(postTitle, this.post.getPostContent());
+
+        // 활동 정보 업데이트
+        this.activityDate = activityDate;
+        this.activityLocation = activityLocation;
+        this.totalCost = totalCost;
+    }
+
+    public void softDelete() {
+        this.deletedAt = LocalDateTime.now();
+        this.post.softDelete();
+    }
+
+    public boolean isDeleted() {
+        return this.deletedAt != null;
+    }
+
+    public boolean isLeader(Long userId) {
+        return this.council.isLeader(userId);
+    }
+
+    public Long getOldTotalCost() {
+        return this.totalCost;
+    }
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/councilreview/entity/CouncilReviewQuestion.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/councilreview/entity/CouncilReviewQuestion.java
@@ -1,0 +1,53 @@
+package com.solif.backend.domain.councilreview.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "council_review_question")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class CouncilReviewQuestion {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "council_review_question_id")
+    private Long councilReviewQuestionId;
+
+    @Column(name = "question_text", nullable = false, length = 255)
+    private String questionText;
+
+    @Column(name = "is_active", nullable = false)
+    private Boolean isActive = true;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Builder
+    public CouncilReviewQuestion(String questionText, Boolean isActive) {
+        this.questionText = questionText;
+        this.isActive = isActive != null ? isActive : true;
+    }
+
+    // 비즈니스 로직
+    public void deactivate() {
+        this.isActive = false;
+    }
+
+    public void activate() {
+        this.isActive = true;
+    }
+
+    public boolean isActive() {
+        return this.isActive;
+    }
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/councilreview/entity/CouncilReviewRelay.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/councilreview/entity/CouncilReviewRelay.java
@@ -1,0 +1,81 @@
+package com.solif.backend.domain.councilreview.entity;
+
+import com.solif.backend.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "council_review_relay")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class CouncilReviewRelay {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "council_review_relay_id")
+    private Long councilReviewRelayId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "council_review_post_id", nullable = false)
+    private CouncilReviewPost councilReviewPost;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "council_review_question_id", nullable = false)
+    private CouncilReviewQuestion councilReviewQuestion;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "writer_user_id", nullable = false)
+    private User writerUser;
+
+    @Column(name = "relay_order", nullable = false)
+    private Integer relayOrder;
+
+    @Column(name = "relay_content", nullable = false, columnDefinition = "TEXT")
+    private String relayContent;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Builder
+    public CouncilReviewRelay(CouncilReviewPost councilReviewPost,
+                              CouncilReviewQuestion councilReviewQuestion,
+                              User writerUser, Integer relayOrder,
+                              String relayContent) {
+        this.councilReviewPost = councilReviewPost;
+        this.councilReviewQuestion = councilReviewQuestion;
+        this.writerUser = writerUser;
+        this.relayOrder = relayOrder;
+        this.relayContent = relayContent;
+    }
+
+    // 비즈니스 로직
+    public void updateRelayContent(String relayContent) {
+        this.relayContent = relayContent;
+    }
+
+    public void updateRelayOrder(Integer relayOrder) {
+        this.relayOrder = relayOrder;
+    }
+
+    public boolean isWriter(Long userId) {
+        return this.writerUser.getUserId().equals(userId);
+    }
+
+    public Long getQuestionId() {
+        return this.councilReviewQuestion.getCouncilReviewQuestionId();
+    }
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/councilreview/repository/CouncilReviewParticipantRepository.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/councilreview/repository/CouncilReviewParticipantRepository.java
@@ -1,0 +1,52 @@
+package com.solif.backend.domain.councilreview.repository;
+
+import com.solif.backend.domain.councilreview.entity.CouncilReviewParticipant;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface CouncilReviewParticipantRepository extends JpaRepository<CouncilReviewParticipant, Long> {
+
+    // 특정 활동 후기의 참여자 목록 조회 (User Fetch Join)
+    @Query("SELECT crp FROM CouncilReviewParticipant crp " +
+            "JOIN FETCH crp.user u " +
+            "WHERE crp.councilReviewPost.councilReviewPostId = :postId " +
+            "ORDER BY crp.createdAt ASC")
+    List<CouncilReviewParticipant> findByCouncilReviewPostIdWithUser(@Param("postId") Long postId);
+
+    // 특정 활동 후기의 참여자 수 조회
+    Long countByCouncilReviewPost_CouncilReviewPostId(Long postId);
+
+    // 특정 사용자가 특정 활동 후기의 참여자인지 확인
+    @Query("SELECT COUNT(crp) > 0 FROM CouncilReviewParticipant crp " +
+            "WHERE crp.councilReviewPost.councilReviewPostId = :postId " +
+            "AND crp.user.userId = :userId")
+    boolean existsByCouncilReviewPostIdAndUserId(
+            @Param("postId") Long postId,
+            @Param("userId") Long userId
+    );
+
+    // 특정 활동 후기의 모든 참여자 삭제 (Hard Delete)
+    @Modifying
+    @Query("DELETE FROM CouncilReviewParticipant crp " +
+            "WHERE crp.councilReviewPost.councilReviewPostId = :postId")
+    void deleteByCouncilReviewPostId(@Param("postId") Long postId);
+
+    // 특정 활동 후기에서 특정 사용자 제거 (Hard Delete)
+    @Modifying
+    @Query("DELETE FROM CouncilReviewParticipant crp " +
+            "WHERE crp.councilReviewPost.councilReviewPostId = :postId " +
+            "AND crp.user.userId = :userId")
+    void deleteByCouncilReviewPostIdAndUserId(
+            @Param("postId") Long postId,
+            @Param("userId") Long userId
+    );
+
+    // 특정 활동 후기의 참여자 User ID 목록 조회
+    @Query("SELECT crp.user.userId FROM CouncilReviewParticipant crp " +
+            "WHERE crp.councilReviewPost.councilReviewPostId = :postId")
+    List<Long> findUserIdsByCouncilReviewPostId(@Param("postId") Long postId);
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/councilreview/repository/CouncilReviewPostRepository.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/councilreview/repository/CouncilReviewPostRepository.java
@@ -1,0 +1,39 @@
+package com.solif.backend.domain.councilreview.repository;
+
+import com.solif.backend.domain.councilreview.entity.CouncilReviewPost;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface CouncilReviewPostRepository extends JpaRepository<CouncilReviewPost, Long> {
+
+    // 자치회별 활동 후기 목록 조회 (삭제되지 않은 것만, Post와 Council Fetch Join)
+    @Query("SELECT crp FROM CouncilReviewPost crp " +
+            "JOIN FETCH crp.post p " +
+            "JOIN FETCH p.author " +
+            "JOIN FETCH crp.council c " +
+            "WHERE crp.council.councilId = :councilId " +
+            "AND crp.deletedAt IS NULL " +
+            "ORDER BY crp.createdAt DESC")
+    Slice<CouncilReviewPost> findByCouncilIdWithPostAndCouncil(
+            @Param("councilId") Long councilId,
+            Pageable pageable
+    );
+
+    // 활동 후기 상세 조회 (Post, Council Fetch Join)
+    @Query("SELECT crp FROM CouncilReviewPost crp " +
+            "JOIN FETCH crp.post p " +
+            "JOIN FETCH p.author " +
+            "JOIN FETCH crp.council c " +
+            "WHERE crp.councilReviewPostId = :postId")
+    Optional<CouncilReviewPost> findByIdWithPostAndCouncil(@Param("postId") Long postId);
+
+    // Post ID로 조회
+    @Query("SELECT crp FROM CouncilReviewPost crp " +
+            "WHERE crp.post.postId = :postId")
+    Optional<CouncilReviewPost> findByPostId(@Param("postId") Long postId);
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/councilreview/repository/CouncilReviewQuestionRepository.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/councilreview/repository/CouncilReviewQuestionRepository.java
@@ -1,0 +1,39 @@
+package com.solif.backend.domain.councilreview.repository;
+
+import com.solif.backend.domain.councilreview.entity.CouncilReviewQuestion;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface CouncilReviewQuestionRepository extends JpaRepository<CouncilReviewQuestion, Long> {
+
+    // 활성화된 질문 목록 조회
+    @Query("SELECT q FROM CouncilReviewQuestion q " +
+            "WHERE q.isActive = true " +
+            "ORDER BY q.createdAt ASC")
+    List<CouncilReviewQuestion> findAllActiveQuestions();
+
+    // 활성화된 질문 중 제외 목록을 제외하고 조회
+    @Query("SELECT q FROM CouncilReviewQuestion q " +
+            "WHERE q.isActive = true " +
+            "AND q.councilReviewQuestionId NOT IN :excludeIds " +
+            "ORDER BY q.createdAt ASC")
+    List<CouncilReviewQuestion> findActiveQuestionsExcluding(
+            @Param("excludeIds") List<Long> excludeIds
+    );
+
+    // 특정 질문이 활성화 상태인지 확인
+    @Query("SELECT COUNT(q) > 0 FROM CouncilReviewQuestion q " +
+            "WHERE q.councilReviewQuestionId = :questionId " +
+            "AND q.isActive = true")
+    boolean isActiveQuestion(@Param("questionId") Long questionId);
+
+    // ID로 활성화된 질문 조회
+    @Query("SELECT q FROM CouncilReviewQuestion q " +
+            "WHERE q.councilReviewQuestionId = :questionId " +
+            "AND q.isActive = true")
+    Optional<CouncilReviewQuestion> findActiveQuestionById(@Param("questionId") Long questionId);
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/councilreview/repository/CouncilReviewRelayRepository.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/councilreview/repository/CouncilReviewRelayRepository.java
@@ -1,0 +1,77 @@
+package com.solif.backend.domain.councilreview.repository;
+
+import com.solif.backend.domain.councilreview.entity.CouncilReviewRelay;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface CouncilReviewRelayRepository extends JpaRepository<CouncilReviewRelay, Long> {
+
+    // 특정 활동 후기의 모든 릴레이 조회 (Writer, Question Fetch Join)
+    @Query("SELECT crr FROM CouncilReviewRelay crr " +
+            "JOIN FETCH crr.writerUser u " +
+            "JOIN FETCH crr.councilReviewQuestion q " +
+            "WHERE crr.councilReviewPost.councilReviewPostId = :postId " +
+            "ORDER BY crr.relayOrder ASC")
+    List<CouncilReviewRelay> findByCouncilReviewPostIdWithWriterAndQuestion(
+            @Param("postId") Long postId
+    );
+
+    // 릴레이 상세 조회 (Writer, Post, Question Fetch Join)
+    @Query("SELECT crr FROM CouncilReviewRelay crr " +
+            "JOIN FETCH crr.writerUser u " +
+            "JOIN FETCH crr.councilReviewPost crp " +
+            "JOIN FETCH crr.councilReviewQuestion q " +
+            "WHERE crr.councilReviewRelayId = :relayId")
+    Optional<CouncilReviewRelay> findByIdWithWriterAndPost(@Param("relayId") Long relayId);
+
+    // 특정 활동 후기의 릴레이 개수 조회
+    Long countByCouncilReviewPost_CouncilReviewPostId(Long postId);
+
+    // 특정 사용자가 특정 활동 후기에 이미 릴레이를 작성했는지 확인
+    @Query("SELECT COUNT(crr) > 0 FROM CouncilReviewRelay crr " +
+            "WHERE crr.councilReviewPost.councilReviewPostId = :postId " +
+            "AND crr.writerUser.userId = :userId")
+    boolean existsByCouncilReviewPostIdAndWriterUserId(
+            @Param("postId") Long postId,
+            @Param("userId") Long userId
+    );
+
+    // 특정 활동 후기에서 사용된 질문 ID 목록 조회
+    @Query("SELECT crr.councilReviewQuestion.councilReviewQuestionId " +
+            "FROM CouncilReviewRelay crr " +
+            "WHERE crr.councilReviewPost.councilReviewPostId = :postId")
+    List<Long> findUsedQuestionIdsByPostId(@Param("postId") Long postId);
+
+    // 특정 활동 후기의 최대 relay_order 조회
+    @Query("SELECT COALESCE(MAX(crr.relayOrder), 0) " +
+            "FROM CouncilReviewRelay crr " +
+            "WHERE crr.councilReviewPost.councilReviewPostId = :postId")
+    Integer findMaxRelayOrderByPostId(@Param("postId") Long postId);
+
+    // 특정 활동 후기의 모든 릴레이 삭제 (Hard Delete)
+    @Modifying
+    @Query("DELETE FROM CouncilReviewRelay crr " +
+            "WHERE crr.councilReviewPost.councilReviewPostId = :postId")
+    void deleteByCouncilReviewPostId(@Param("postId") Long postId);
+
+    // 특정 활동 후기에서 특정 사용자의 릴레이 삭제 (참여자 제거 시)
+    @Modifying
+    @Query("DELETE FROM CouncilReviewRelay crr " +
+            "WHERE crr.councilReviewPost.councilReviewPostId = :postId " +
+            "AND crr.writerUser.userId = :userId")
+    void deleteByCouncilReviewPostIdAndWriterUserId(
+            @Param("postId") Long postId,
+            @Param("userId") Long userId
+    );
+
+    // relay_order 기준으로 정렬된 릴레이 목록 조회 (재정렬용)
+    @Query("SELECT crr FROM CouncilReviewRelay crr " +
+            "WHERE crr.councilReviewPost.councilReviewPostId = :postId " +
+            "ORDER BY crr.relayOrder ASC")
+    List<CouncilReviewRelay> findByCouncilReviewPostIdOrderByRelayOrder(@Param("postId") Long postId);
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/councilreview/service/CouncilReviewPostService.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/councilreview/service/CouncilReviewPostService.java
@@ -242,8 +242,8 @@ public class CouncilReviewPostService {
         Long newTotalCost = request.getTotalCost();
 
         Council council = reviewPost.getCouncil();
-        council.decreaseBudget(-oldTotalCost); // 복구 (음수로 차감 = 증가)
-        council.decreaseBudget(newTotalCost);   // 재차감
+        council.increaseBudget(oldTotalCost);    // 복구
+        council.decreaseBudget(newTotalCost);    // 재차감
 
         // 6. 활동 후기 정보 업데이트
         reviewPost.updateReviewPost(
@@ -291,7 +291,7 @@ public class CouncilReviewPostService {
 
         // 7. 예산 복구
         Council council = reviewPost.getCouncil();
-        council.decreaseBudget(-reviewPost.getTotalCost()); // 음수로 차감 = 증가
+        council.increaseBudget(reviewPost.getTotalCost());
 
         log.info("활동 후기 삭제 완료 - postId: {}", councilReviewPostId);
     }

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/councilreview/service/CouncilReviewPostService.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/councilreview/service/CouncilReviewPostService.java
@@ -1,0 +1,409 @@
+package com.solif.backend.domain.councilreview.service;
+
+import com.solif.backend.domain.auth.exception.AuthErrorCode;
+import com.solif.backend.domain.board.code.BoardErrorCode;
+import com.solif.backend.domain.board.entity.Board;
+import com.solif.backend.domain.board.repository.BoardRepository;
+import com.solif.backend.domain.comment.repository.CommentRepository;
+import com.solif.backend.domain.council.code.CouncilErrorCode;
+import com.solif.backend.domain.council.entity.Council;
+import com.solif.backend.domain.council.entity.CouncilMember;
+import com.solif.backend.domain.council.repository.CouncilMemberRepository;
+import com.solif.backend.domain.council.repository.CouncilRepository;
+import com.solif.backend.domain.councilreview.code.CouncilReviewErrorCode;
+import com.solif.backend.domain.councilreview.dto.request.CouncilReviewPostCreateRequest;
+import com.solif.backend.domain.councilreview.dto.request.CouncilReviewPostUpdateRequest;
+import com.solif.backend.domain.councilreview.dto.response.*;
+import com.solif.backend.domain.councilreview.entity.CouncilReviewParticipant;
+import com.solif.backend.domain.councilreview.entity.CouncilReviewPost;
+import com.solif.backend.domain.councilreview.entity.CouncilReviewQuestion;
+import com.solif.backend.domain.councilreview.entity.CouncilReviewRelay;
+import com.solif.backend.domain.councilreview.repository.CouncilReviewParticipantRepository;
+import com.solif.backend.domain.councilreview.repository.CouncilReviewPostRepository;
+import com.solif.backend.domain.councilreview.repository.CouncilReviewRelayRepository;
+import com.solif.backend.domain.post.entity.Post;
+import com.solif.backend.domain.post.repository.PostRepository;
+import com.solif.backend.domain.postlike.repository.PostLikeRepository;
+import com.solif.backend.domain.user.entity.User;
+import com.solif.backend.domain.user.repository.UserRepository;
+import com.solif.backend.global.common.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CouncilReviewPostService {
+
+    private final CouncilReviewPostRepository reviewPostRepository;
+    private final CouncilReviewRelayRepository relayRepository;
+    private final CouncilReviewParticipantRepository participantRepository;
+    private final CouncilReviewQuestionService questionService;
+    private final CouncilReviewRelayService relayService;
+    private final CouncilRepository councilRepository;
+    private final CouncilMemberRepository councilMemberRepository;
+    private final PostRepository postRepository;
+    private final BoardRepository boardRepository;
+    private final UserRepository userRepository;
+    private final CommentRepository commentRepository;
+    private final PostLikeRepository postLikeRepository;
+
+    /**
+     * 자치회별 활동 후기 목록 조회
+     */
+    public Slice<CouncilReviewPostListResponse> getCouncilReviewPosts(Long councilId, Pageable pageable) {
+        log.info("활동 후기 목록 조회 - councilId: {}", councilId);
+
+        // 자치회 존재 확인
+        Council council = councilRepository.findById(councilId)
+                .orElseThrow(() -> new CustomException(CouncilErrorCode.COUNCIL_NOT_FOUND));
+
+        // 활동 후기 목록 조회
+        Slice<CouncilReviewPost> posts = reviewPostRepository.findByCouncilIdWithPostAndCouncil(councilId, pageable);
+
+        // DTO 변환
+        return posts.map(post -> {
+            Long participantCount = participantRepository.countByCouncilReviewPost_CouncilReviewPostId(
+                    post.getCouncilReviewPostId()
+            );
+            Long relayCount = relayRepository.countByCouncilReviewPost_CouncilReviewPostId(
+                    post.getCouncilReviewPostId()
+            );
+            Long likeCount = postLikeRepository.countByPost_PostId(post.getPost().getPostId());
+            Long commentCount = commentRepository.countByPost_PostId(post.getPost().getPostId());
+
+            // TODO: 첫 번째 이미지 URL (file_attachment 연동 후 구현)
+            String thumbnailImageUrl = null;
+
+            return CouncilReviewPostListResponse.from(
+                    post, participantCount, relayCount, likeCount, commentCount, thumbnailImageUrl
+            );
+        });
+    }
+
+    /**
+     * 활동 후기 상세 조회
+     */
+    @Transactional
+    public CouncilReviewPostDetailResponse getCouncilReviewPostDetail(Long userId, Long postId) {
+        log.info("활동 후기 상세 조회 - postId: {}, userId: {}", postId, userId);
+
+        // 1. 활동 후기 조회
+        CouncilReviewPost post = reviewPostRepository.findByIdWithPostAndCouncil(postId)
+                .orElseThrow(() -> new CustomException(CouncilReviewErrorCode.COUNCIL_REVIEW_POST_NOT_FOUND));
+
+        // 2. 삭제된 게시글 체크
+        if (post.isDeleted()) {
+            throw new CustomException(CouncilReviewErrorCode.COUNCIL_REVIEW_POST_DELETED);
+        }
+
+        // 3. 조회수 증가
+        post.getPost().increaseViewCount();
+
+        // 4. 이미지 URL 목록 조회 (TODO: file_attachment 연동)
+        List<String> imageUrls = new ArrayList<>();
+
+        // 5. 참여자 목록 조회
+        List<CouncilReviewParticipant> participants = participantRepository
+                .findByCouncilReviewPostIdWithUser(postId);
+        List<CouncilReviewParticipantResponse> participantResponses = participants.stream()
+                .map(CouncilReviewParticipantResponse::from)
+                .collect(Collectors.toList());
+
+        // 6. 릴레이 목록 조회
+        List<CouncilReviewRelayResponse> relayResponses = relayService.getRelaysByPostId(postId, userId);
+
+        // 7. 좋아요 수, 댓글 수 조회
+        Long likeCount = postLikeRepository.countByPost_PostId(post.getPost().getPostId());
+        Long commentCount = commentRepository.countByPost_PostId(post.getPost().getPostId());
+
+        // 8. 현재 사용자의 좋아요 여부 조회
+        Boolean isLikedByMe = postLikeRepository.existsByUser_UserIdAndPost_PostId(
+                userId, post.getPost().getPostId()
+        );
+
+        // 9. 현재 사용자가 리더인지 확인
+        Boolean isLeader = post.isLeader(userId);
+
+        return CouncilReviewPostDetailResponse.of(
+                post, imageUrls, participantResponses, relayResponses,
+                likeCount, commentCount, isLikedByMe, isLeader
+        );
+    }
+
+    /**
+     * 활동 후기 생성 (리더 전용)
+     */
+    @Transactional
+    public CouncilReviewPostCreateResponse createCouncilReviewPost(
+            Long userId, Long councilId, CouncilReviewPostCreateRequest request
+    ) {
+        log.info("활동 후기 생성 - userId: {}, councilId: {}", userId, councilId);
+
+        // 1. 사용자 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(AuthErrorCode.USER_NOT_FOUND));
+
+        // 2. 자치회 조회
+        Council council = councilRepository.findById(councilId)
+                .orElseThrow(() -> new CustomException(CouncilErrorCode.COUNCIL_NOT_FOUND));
+
+        // 3. 리더 권한 확인
+        if (!council.isLeader(userId)) {
+            throw new CustomException(CouncilReviewErrorCode.ONLY_LEADER_CAN_CREATE_REVIEW);
+        }
+
+        // 4. 참여자 검증 (모두 자치회 멤버여야 함)
+        validateParticipants(councilId, request.getParticipantUserIds());
+
+        // 5. Board 조회 (boardId = 1: 자치회 활동 후기)
+        Board board = boardRepository.findById(1L)
+                .orElseThrow(() -> new CustomException(BoardErrorCode.BOARD_NOT_FOUND));
+
+        // 6. Post 생성 (통합 게시글)
+        Post post = Post.builder()
+                .author(user)
+                .board(board)
+                .postCategory(null) // 자치회 활동 후기는 카테고리 없음
+                .postTitle(request.getPostTitle())
+                .postContent(null) // 활동 후기는 릴레이로 내용 작성
+                .build();
+        Post savedPost = postRepository.save(post);
+
+        // 7. CouncilReviewPost 생성
+        CouncilReviewPost reviewPost = CouncilReviewPost.builder()
+                .post(savedPost)
+                .council(council)
+                .activityDate(request.getActivityDate())
+                .activityLocation(request.getActivityLocation())
+                .totalCost(request.getTotalCost())
+                .build();
+        CouncilReviewPost savedReviewPost = reviewPostRepository.save(reviewPost);
+
+        // 8. 참여자 생성
+        createParticipants(savedReviewPost, request.getParticipantUserIds());
+
+        // 9. 질문 검증
+        CouncilReviewQuestion question = questionService.validateAndGetQuestion(request.getQuestionId());
+
+        // 10. 리더의 첫 번째 릴레이 생성 (relay_order = 1)
+        CouncilReviewRelay leaderRelay = CouncilReviewRelay.builder()
+                .councilReviewPost(savedReviewPost)
+                .councilReviewQuestion(question)
+                .writerUser(user)
+                .relayOrder(1)
+                .relayContent(request.getRelayContent())
+                .build();
+        relayRepository.save(leaderRelay);
+
+        // 11. 예산 차감
+        council.decreaseBudget(request.getTotalCost());
+
+        // 12. TODO: 이미지 첨부 (file_attachment 연동)
+
+        log.info("활동 후기 생성 완료 - reviewPostId: {}, postId: {}",
+                savedReviewPost.getCouncilReviewPostId(), savedPost.getPostId());
+
+        return CouncilReviewPostCreateResponse.of(
+                savedReviewPost.getCouncilReviewPostId(),
+                savedPost.getPostId()
+        );
+    }
+
+    /**
+     * 활동 후기 수정 (리더 전용)
+     */
+    @Transactional
+    public void updateCouncilReviewPost(Long userId, Long postId, CouncilReviewPostUpdateRequest request) {
+        log.info("활동 후기 수정 - userId: {}, postId: {}", userId, postId);
+
+        // 1. 활동 후기 조회
+        CouncilReviewPost reviewPost = reviewPostRepository.findByIdWithPostAndCouncil(postId)
+                .orElseThrow(() -> new CustomException(CouncilReviewErrorCode.COUNCIL_REVIEW_POST_NOT_FOUND));
+
+        // 2. 삭제된 게시글 체크
+        if (reviewPost.isDeleted()) {
+            throw new CustomException(CouncilReviewErrorCode.COUNCIL_REVIEW_POST_DELETED);
+        }
+
+        // 3. 리더 권한 확인
+        if (!reviewPost.isLeader(userId)) {
+            throw new CustomException(CouncilReviewErrorCode.ONLY_LEADER_CAN_UPDATE_REVIEW);
+        }
+
+        // 4. 참여자 검증
+        validateParticipants(reviewPost.getCouncil().getCouncilId(), request.getParticipantUserIds());
+
+        // 5. 예산 재계산 (원래 금액 복구 후 재차감)
+        Long oldTotalCost = reviewPost.getOldTotalCost();
+        Long newTotalCost = request.getTotalCost();
+
+        Council council = reviewPost.getCouncil();
+        council.decreaseBudget(-oldTotalCost); // 복구 (음수로 차감 = 증가)
+        council.decreaseBudget(newTotalCost);   // 재차감
+
+        // 6. 활동 후기 정보 업데이트
+        reviewPost.updateReviewPost(
+                request.getPostTitle(),
+                request.getActivityDate(),
+                request.getActivityLocation(),
+                request.getTotalCost()
+        );
+
+        // 7. 참여자 업데이트
+        updateParticipants(reviewPost, request.getParticipantUserIds());
+
+        // 8. TODO: 이미지 업데이트 (file_attachment 연동)
+
+        log.info("활동 후기 수정 완료 - postId: {}", postId);
+    }
+
+    /**
+     * 활동 후기 삭제 (리더 전용, Soft Delete)
+     */
+    @Transactional
+    public void deleteCouncilReviewPost(Long userId, Long postId) {
+        log.info("활동 후기 삭제 - userId: {}, postId: {}", userId, postId);
+
+        // 1. 활동 후기 조회
+        CouncilReviewPost reviewPost = reviewPostRepository.findByIdWithPostAndCouncil(postId)
+                .orElseThrow(() -> new CustomException(CouncilReviewErrorCode.COUNCIL_REVIEW_POST_NOT_FOUND));
+
+        // 2. 이미 삭제된 게시글 체크
+        if (reviewPost.isDeleted()) {
+            throw new CustomException(CouncilReviewErrorCode.COUNCIL_REVIEW_POST_DELETED);
+        }
+
+        // 3. 리더 권한 확인
+        if (!reviewPost.isLeader(userId)) {
+            throw new CustomException(CouncilReviewErrorCode.ONLY_LEADER_CAN_DELETE_REVIEW);
+        }
+
+        // 4. Soft Delete (council_review_post, post)
+        reviewPost.softDelete();
+
+        // 5. 모든 릴레이 Hard Delete
+        relayRepository.deleteByCouncilReviewPostId(postId);
+
+        // 6. 모든 참여자 Hard Delete
+        participantRepository.deleteByCouncilReviewPostId(postId);
+
+        // 7. 예산 복구
+        Council council = reviewPost.getCouncil();
+        council.decreaseBudget(-reviewPost.getTotalCost()); // 음수로 차감 = 증가
+
+        log.info("활동 후기 삭제 완료 - postId: {}", postId);
+    }
+
+    /**
+     * 참여자 검증 (모두 자치회 멤버여야 함)
+     */
+    private void validateParticipants(Long councilId, List<Long> participantUserIds) {
+        log.info("참여자 검증 - councilId: {}, participantUserIds: {}", councilId, participantUserIds);
+
+        if (participantUserIds == null || participantUserIds.isEmpty()) {
+            throw new CustomException(CouncilReviewErrorCode.PARTICIPANT_LIST_EMPTY);
+        }
+
+        // 자치회 멤버 목록 조회
+        List<CouncilMember> councilMembers = councilMemberRepository.findByCouncil_CouncilId(councilId);
+        Set<Long> memberUserIds = councilMembers.stream()
+                .map(member -> member.getUser().getUserId())
+                .collect(Collectors.toSet());
+
+        // 참여자가 모두 자치회 멤버인지 확인
+        for (Long participantUserId : participantUserIds) {
+            if (!memberUserIds.contains(participantUserId)) {
+                log.warn("자치회 멤버가 아닌 사용자 발견 - userId: {}", participantUserId);
+                throw new CustomException(CouncilReviewErrorCode.PARTICIPANT_NOT_COUNCIL_MEMBER);
+            }
+        }
+
+        log.info("참여자 검증 완료 - 모두 자치회 멤버");
+    }
+
+    /**
+     * 참여자 생성
+     */
+    private void createParticipants(CouncilReviewPost reviewPost, List<Long> participantUserIds) {
+        log.info("참여자 생성 - reviewPostId: {}, count: {}",
+                reviewPost.getCouncilReviewPostId(), participantUserIds.size());
+
+        List<CouncilReviewParticipant> participants = new ArrayList<>();
+
+        for (Long userId : participantUserIds) {
+            User user = userRepository.findById(userId)
+                    .orElseThrow(() -> new CustomException(AuthErrorCode.USER_NOT_FOUND));
+
+            CouncilReviewParticipant participant = CouncilReviewParticipant.builder()
+                    .councilReviewPost(reviewPost)
+                    .user(user)
+                    .build();
+            participants.add(participant);
+        }
+
+        participantRepository.saveAll(participants);
+        log.info("참여자 생성 완료 - {} 명", participants.size());
+    }
+
+    /**
+     * 참여자 업데이트 (추가/제거)
+     */
+    private void updateParticipants(CouncilReviewPost reviewPost, List<Long> newParticipantUserIds) {
+        log.info("참여자 업데이트 - reviewPostId: {}", reviewPost.getCouncilReviewPostId());
+
+        Long postId = reviewPost.getCouncilReviewPostId();
+
+        // 기존 참여자 목록
+        List<Long> oldParticipantUserIds = participantRepository.findUserIdsByCouncilReviewPostId(postId);
+
+        // 추가할 참여자 (new - old)
+        Set<Long> toAdd = new HashSet<>(newParticipantUserIds);
+        toAdd.removeAll(oldParticipantUserIds);
+
+        // 제거할 참여자 (old - new)
+        Set<Long> toRemove = new HashSet<>(oldParticipantUserIds);
+        toRemove.removeAll(newParticipantUserIds);
+
+        // 참여자 추가
+        for (Long userId : toAdd) {
+            User user = userRepository.findById(userId)
+                    .orElseThrow(() -> new CustomException(AuthErrorCode.USER_NOT_FOUND));
+
+            CouncilReviewParticipant participant = CouncilReviewParticipant.builder()
+                    .councilReviewPost(reviewPost)
+                    .user(user)
+                    .build();
+            participantRepository.save(participant);
+        }
+
+        // 참여자 제거 (해당 멤버의 릴레이도 함께 삭제)
+        for (Long userId : toRemove) {
+            participantRepository.deleteByCouncilReviewPostIdAndUserId(postId, userId);
+            relayRepository.deleteByCouncilReviewPostIdAndWriterUserId(postId, userId);
+        }
+
+        // 릴레이 순서 재정렬 (제거된 릴레이가 있으면)
+        if (!toRemove.isEmpty()) {
+            List<CouncilReviewRelay> relays = relayRepository
+                    .findByCouncilReviewPostIdOrderByRelayOrder(postId);
+            for (int i = 0; i < relays.size(); i++) {
+                relays.get(i).updateRelayOrder(i + 1);
+            }
+            relayRepository.saveAll(relays);
+        }
+
+        log.info("참여자 업데이트 완료 - 추가: {} 명, 제거: {} 명", toAdd.size(), toRemove.size());
+    }
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/councilreview/service/CouncilReviewPostService.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/councilreview/service/CouncilReviewPostService.java
@@ -92,11 +92,11 @@ public class CouncilReviewPostService {
 
     // 활동 후기 상세 조회
     @Transactional
-    public CouncilReviewPostDetailResponse getCouncilReviewPostDetail(Long userId, Long postId) {
-        log.info("활동 후기 상세 조회 - postId: {}, userId: {}", postId, userId);
+    public CouncilReviewPostDetailResponse getCouncilReviewPostDetail(Long userId, Long councilReviewPostId) {
+        log.info("활동 후기 상세 조회 - postId: {}, userId: {}", councilReviewPostId, userId);
 
         // 1. 활동 후기 조회
-        CouncilReviewPost post = reviewPostRepository.findByIdWithPostAndCouncil(postId)
+        CouncilReviewPost post = reviewPostRepository.findByIdWithPostAndCouncil(councilReviewPostId)
                 .orElseThrow(() -> new CustomException(CouncilReviewErrorCode.COUNCIL_REVIEW_POST_NOT_FOUND));
 
         // 2. 삭제된 게시글 체크
@@ -112,13 +112,13 @@ public class CouncilReviewPostService {
 
         // 5. 참여자 목록 조회
         List<CouncilReviewParticipant> participants = participantRepository
-                .findByCouncilReviewPostIdWithUser(postId);
+                .findByCouncilReviewPostIdWithUser(councilReviewPostId);
         List<CouncilReviewParticipantResponse> participantResponses = participants.stream()
                 .map(CouncilReviewParticipantResponse::from)
                 .collect(Collectors.toList());
 
         // 6. 릴레이 목록 조회
-        List<CouncilReviewRelayResponse> relayResponses = relayService.getRelaysByPostId(postId, userId);
+        List<CouncilReviewRelayResponse> relayResponses = relayService.getRelaysByPostId(councilReviewPostId, userId);
 
         // 7. 좋아요 수, 댓글 수 조회
         Long likeCount = postLikeRepository.countByPost_PostId(post.getPost().getPostId());
@@ -217,11 +217,11 @@ public class CouncilReviewPostService {
 
     // 활동 후기 수정 (리더 전용)
     @Transactional
-    public void updateCouncilReviewPost(Long userId, Long postId, CouncilReviewPostUpdateRequest request) {
-        log.info("활동 후기 수정 - userId: {}, postId: {}", userId, postId);
+    public void updateCouncilReviewPost(Long userId, Long councilReviewPostId, CouncilReviewPostUpdateRequest request) {
+        log.info("활동 후기 수정 - userId: {}, postId: {}", userId, councilReviewPostId);
 
         // 1. 활동 후기 조회
-        CouncilReviewPost reviewPost = reviewPostRepository.findByIdWithPostAndCouncil(postId)
+        CouncilReviewPost reviewPost = reviewPostRepository.findByIdWithPostAndCouncil(councilReviewPostId)
                 .orElseThrow(() -> new CustomException(CouncilReviewErrorCode.COUNCIL_REVIEW_POST_NOT_FOUND));
 
         // 2. 삭제된 게시글 체크
@@ -258,16 +258,16 @@ public class CouncilReviewPostService {
 
         // 8. TODO: 이미지 업데이트 (file_attachment 연동)
 
-        log.info("활동 후기 수정 완료 - postId: {}", postId);
+        log.info("활동 후기 수정 완료 - postId: {}", councilReviewPostId);
     }
 
     // 활동 후기 삭제 (리더 전용, Soft Delete)
     @Transactional
-    public void deleteCouncilReviewPost(Long userId, Long postId) {
-        log.info("활동 후기 삭제 - userId: {}, postId: {}", userId, postId);
+    public void deleteCouncilReviewPost(Long userId, Long councilReviewPostId) {
+        log.info("활동 후기 삭제 - userId: {}, postId: {}", userId, councilReviewPostId);
 
         // 1. 활동 후기 조회
-        CouncilReviewPost reviewPost = reviewPostRepository.findByIdWithPostAndCouncil(postId)
+        CouncilReviewPost reviewPost = reviewPostRepository.findByIdWithPostAndCouncil(councilReviewPostId)
                 .orElseThrow(() -> new CustomException(CouncilReviewErrorCode.COUNCIL_REVIEW_POST_NOT_FOUND));
 
         // 2. 이미 삭제된 게시글 체크
@@ -284,16 +284,16 @@ public class CouncilReviewPostService {
         reviewPost.softDelete();
 
         // 5. 모든 릴레이 Hard Delete
-        relayRepository.deleteByCouncilReviewPostId(postId);
+        relayRepository.deleteByCouncilReviewPostId(councilReviewPostId);
 
         // 6. 모든 참여자 Hard Delete
-        participantRepository.deleteByCouncilReviewPostId(postId);
+        participantRepository.deleteByCouncilReviewPostId(councilReviewPostId);
 
         // 7. 예산 복구
         Council council = reviewPost.getCouncil();
         council.decreaseBudget(-reviewPost.getTotalCost()); // 음수로 차감 = 증가
 
-        log.info("활동 후기 삭제 완료 - postId: {}", postId);
+        log.info("활동 후기 삭제 완료 - postId: {}", councilReviewPostId);
     }
 
     // 참여자 검증 (모두 자치회 멤버여야 함)

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/councilreview/service/CouncilReviewPostService.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/councilreview/service/CouncilReviewPostService.java
@@ -59,9 +59,7 @@ public class CouncilReviewPostService {
     private final CommentRepository commentRepository;
     private final PostLikeRepository postLikeRepository;
 
-    /**
-     * 자치회별 활동 후기 목록 조회
-     */
+    // 자치회별 활동 후기 목록 조회
     public Slice<CouncilReviewPostListResponse> getCouncilReviewPosts(Long councilId, Pageable pageable) {
         log.info("활동 후기 목록 조회 - councilId: {}", councilId);
 
@@ -92,9 +90,7 @@ public class CouncilReviewPostService {
         });
     }
 
-    /**
-     * 활동 후기 상세 조회
-     */
+    // 활동 후기 상세 조회
     @Transactional
     public CouncilReviewPostDetailResponse getCouncilReviewPostDetail(Long userId, Long postId) {
         log.info("활동 후기 상세 조회 - postId: {}, userId: {}", postId, userId);
@@ -142,9 +138,7 @@ public class CouncilReviewPostService {
         );
     }
 
-    /**
-     * 활동 후기 생성 (리더 전용)
-     */
+    // 활동 후기 생성 (리더 전용)
     @Transactional
     public CouncilReviewPostCreateResponse createCouncilReviewPost(
             Long userId, Long councilId, CouncilReviewPostCreateRequest request
@@ -221,9 +215,7 @@ public class CouncilReviewPostService {
         );
     }
 
-    /**
-     * 활동 후기 수정 (리더 전용)
-     */
+    // 활동 후기 수정 (리더 전용)
     @Transactional
     public void updateCouncilReviewPost(Long userId, Long postId, CouncilReviewPostUpdateRequest request) {
         log.info("활동 후기 수정 - userId: {}, postId: {}", userId, postId);
@@ -269,9 +261,7 @@ public class CouncilReviewPostService {
         log.info("활동 후기 수정 완료 - postId: {}", postId);
     }
 
-    /**
-     * 활동 후기 삭제 (리더 전용, Soft Delete)
-     */
+    // 활동 후기 삭제 (리더 전용, Soft Delete)
     @Transactional
     public void deleteCouncilReviewPost(Long userId, Long postId) {
         log.info("활동 후기 삭제 - userId: {}, postId: {}", userId, postId);
@@ -306,9 +296,7 @@ public class CouncilReviewPostService {
         log.info("활동 후기 삭제 완료 - postId: {}", postId);
     }
 
-    /**
-     * 참여자 검증 (모두 자치회 멤버여야 함)
-     */
+    // 참여자 검증 (모두 자치회 멤버여야 함)
     private void validateParticipants(Long councilId, List<Long> participantUserIds) {
         log.info("참여자 검증 - councilId: {}, participantUserIds: {}", councilId, participantUserIds);
 
@@ -333,9 +321,7 @@ public class CouncilReviewPostService {
         log.info("참여자 검증 완료 - 모두 자치회 멤버");
     }
 
-    /**
-     * 참여자 생성
-     */
+    // 참여자 생성
     private void createParticipants(CouncilReviewPost reviewPost, List<Long> participantUserIds) {
         log.info("참여자 생성 - reviewPostId: {}, count: {}",
                 reviewPost.getCouncilReviewPostId(), participantUserIds.size());
@@ -357,9 +343,7 @@ public class CouncilReviewPostService {
         log.info("참여자 생성 완료 - {} 명", participants.size());
     }
 
-    /**
-     * 참여자 업데이트 (추가/제거)
-     */
+    // 참여자 업데이트 (추가/제거)
     private void updateParticipants(CouncilReviewPost reviewPost, List<Long> newParticipantUserIds) {
         log.info("참여자 업데이트 - reviewPostId: {}", reviewPost.getCouncilReviewPostId());
 

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/councilreview/service/CouncilReviewQuestionService.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/councilreview/service/CouncilReviewQuestionService.java
@@ -1,0 +1,72 @@
+package com.solif.backend.domain.councilreview.service;
+
+import com.solif.backend.domain.councilreview.code.CouncilReviewErrorCode;
+import com.solif.backend.domain.councilreview.dto.response.CouncilReviewQuestionResponse;
+import com.solif.backend.domain.councilreview.entity.CouncilReviewQuestion;
+import com.solif.backend.domain.councilreview.repository.CouncilReviewQuestionRepository;
+import com.solif.backend.global.common.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Random;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CouncilReviewQuestionService {
+
+    private final CouncilReviewQuestionRepository questionRepository;
+    private final Random random = new Random();
+
+    /**
+     * 랜덤 질문 조회
+     * 이미 사용된 질문을 제외하고 활성화된 질문 중 랜덤으로 1개 조회
+     */
+    public CouncilReviewQuestionResponse getRandomQuestion(List<Long> excludeQuestionIds) {
+        log.info("랜덤 질문 조회 - excludeQuestionIds: {}", excludeQuestionIds);
+
+        // 활성화된 질문 목록 조회 (제외 목록 제외)
+        List<CouncilReviewQuestion> availableQuestions;
+
+        if (excludeQuestionIds == null || excludeQuestionIds.isEmpty()) {
+            availableQuestions = questionRepository.findAllActiveQuestions();
+        } else {
+            availableQuestions = questionRepository.findActiveQuestionsExcluding(excludeQuestionIds);
+        }
+
+        // 사용 가능한 질문이 없으면 예외
+        if (availableQuestions.isEmpty()) {
+            throw new CustomException(CouncilReviewErrorCode.NO_AVAILABLE_QUESTIONS);
+        }
+
+        // 랜덤으로 1개 선택
+        int randomIndex = random.nextInt(availableQuestions.size());
+        CouncilReviewQuestion selectedQuestion = availableQuestions.get(randomIndex);
+
+        log.info("선택된 질문 ID: {}, 내용: {}", selectedQuestion.getCouncilReviewQuestionId(), selectedQuestion.getQuestionText());
+
+        return CouncilReviewQuestionResponse.from(selectedQuestion);
+    }
+
+    /**
+     * 질문 검증 (활성화 여부 확인)
+     */
+    public CouncilReviewQuestion validateAndGetQuestion(Long questionId) {
+        log.info("질문 검증 - questionId: {}", questionId);
+
+        // 질문 존재 확인
+        CouncilReviewQuestion question = questionRepository.findById(questionId)
+                .orElseThrow(() -> new CustomException(CouncilReviewErrorCode.QUESTION_NOT_FOUND));
+
+        // 활성화 여부 확인
+        if (!question.isActive()) {
+            throw new CustomException(CouncilReviewErrorCode.QUESTION_NOT_ACTIVE);
+        }
+
+        return question;
+    }
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/councilreview/service/CouncilReviewRelayService.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/councilreview/service/CouncilReviewRelayService.java
@@ -35,9 +35,7 @@ public class CouncilReviewRelayService {
     private final CouncilReviewQuestionService questionService;
     private final UserRepository userRepository;
 
-    /**
-     * 릴레이 작성
-     */
+    // 릴레이 후기 작성
     @Transactional
     public Map<String, Object> createRelay(Long userId, Long postId, CouncilReviewRelayCreateRequest request) {
         log.info("릴레이 작성 - userId: {}, postId: {}, questionId: {}", userId, postId, request.getQuestionId());
@@ -99,9 +97,7 @@ public class CouncilReviewRelayService {
         );
     }
 
-    /**
-     * 릴레이 수정
-     */
+    // 릴레이 수정
     @Transactional
     public void updateRelay(Long userId, Long relayId, CouncilReviewRelayUpdateRequest request) {
         log.info("릴레이 수정 - userId: {}, relayId: {}", userId, relayId);
@@ -121,9 +117,7 @@ public class CouncilReviewRelayService {
         log.info("릴레이 수정 완료 - relayId: {}", relayId);
     }
 
-    /**
-     * 릴레이 삭제
-     */
+    // 릴레이 삭제
     @Transactional
     public void deleteRelay(Long userId, Long relayId) {
         log.info("릴레이 삭제 - userId: {}, relayId: {}", userId, relayId);
@@ -167,9 +161,7 @@ public class CouncilReviewRelayService {
         log.info("relay_order 재정렬 완료 - postId: {}, 총 릴레이 수: {}", postId, relays.size());
     }
 
-    /**
-     * 특정 활동 후기의 모든 릴레이 조회 (상세 조회용)
-     */
+    // 특정 활동 후기의 모든 릴레이 조회 (상세 조회용)
     public List<CouncilReviewRelayResponse> getRelaysByPostId(Long postId, Long currentUserId) {
         log.info("릴레이 목록 조회 - postId: {}", postId);
 

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/councilreview/service/CouncilReviewRelayService.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/councilreview/service/CouncilReviewRelayService.java
@@ -1,0 +1,182 @@
+package com.solif.backend.domain.councilreview.service;
+
+import com.solif.backend.domain.auth.exception.AuthErrorCode;
+import com.solif.backend.domain.councilreview.code.CouncilReviewErrorCode;
+import com.solif.backend.domain.councilreview.dto.request.CouncilReviewRelayCreateRequest;
+import com.solif.backend.domain.councilreview.dto.request.CouncilReviewRelayUpdateRequest;
+import com.solif.backend.domain.councilreview.dto.response.CouncilReviewRelayResponse;
+import com.solif.backend.domain.councilreview.entity.CouncilReviewPost;
+import com.solif.backend.domain.councilreview.entity.CouncilReviewQuestion;
+import com.solif.backend.domain.councilreview.entity.CouncilReviewRelay;
+import com.solif.backend.domain.councilreview.repository.CouncilReviewParticipantRepository;
+import com.solif.backend.domain.councilreview.repository.CouncilReviewPostRepository;
+import com.solif.backend.domain.councilreview.repository.CouncilReviewRelayRepository;
+import com.solif.backend.domain.user.entity.User;
+import com.solif.backend.domain.user.repository.UserRepository;
+import com.solif.backend.global.common.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CouncilReviewRelayService {
+
+    private final CouncilReviewRelayRepository relayRepository;
+    private final CouncilReviewPostRepository postRepository;
+    private final CouncilReviewParticipantRepository participantRepository;
+    private final CouncilReviewQuestionService questionService;
+    private final UserRepository userRepository;
+
+    /**
+     * 릴레이 작성
+     */
+    @Transactional
+    public Map<String, Object> createRelay(Long userId, Long postId, CouncilReviewRelayCreateRequest request) {
+        log.info("릴레이 작성 - userId: {}, postId: {}, questionId: {}", userId, postId, request.getQuestionId());
+
+        // 1. 사용자 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(AuthErrorCode.USER_NOT_FOUND));
+
+        // 2. 활동 후기 조회
+        CouncilReviewPost post = postRepository.findById(postId)
+                .orElseThrow(() -> new CustomException(CouncilReviewErrorCode.COUNCIL_REVIEW_POST_NOT_FOUND));
+
+        // 3. 삭제된 게시글 체크
+        if (post.isDeleted()) {
+            throw new CustomException(CouncilReviewErrorCode.COUNCIL_REVIEW_POST_DELETED);
+        }
+
+        // 4. 참여자 권한 확인
+        boolean isParticipant = participantRepository.existsByCouncilReviewPostIdAndUserId(postId, userId);
+        if (!isParticipant) {
+            throw new CustomException(CouncilReviewErrorCode.NOT_PARTICIPANT);
+        }
+
+        // 5. 이미 작성했는지 확인 (1인 1회 제한)
+        boolean alreadyWritten = relayRepository.existsByCouncilReviewPostIdAndWriterUserId(postId, userId);
+        if (alreadyWritten) {
+            throw new CustomException(CouncilReviewErrorCode.ALREADY_WRITTEN_RELAY);
+        }
+
+        // 6. 질문 검증 및 조회
+        CouncilReviewQuestion question = questionService.validateAndGetQuestion(request.getQuestionId());
+
+        // 7. 질문 중복 체크 (같은 활동 후기 내에서 중복 불가)
+        List<Long> usedQuestionIds = relayRepository.findUsedQuestionIdsByPostId(postId);
+        if (usedQuestionIds.contains(request.getQuestionId())) {
+            throw new CustomException(CouncilReviewErrorCode.QUESTION_ALREADY_USED);
+        }
+
+        // 8. relay_order 자동 배정 (MAX + 1)
+        Integer maxOrder = relayRepository.findMaxRelayOrderByPostId(postId);
+        Integer newOrder = maxOrder + 1;
+
+        // 9. 릴레이 생성
+        CouncilReviewRelay relay = CouncilReviewRelay.builder()
+                .councilReviewPost(post)
+                .councilReviewQuestion(question)
+                .writerUser(user)
+                .relayOrder(newOrder)
+                .relayContent(request.getRelayContent())
+                .build();
+
+        CouncilReviewRelay savedRelay = relayRepository.save(relay);
+
+        log.info("릴레이 작성 완료 - relayId: {}, relayOrder: {}", savedRelay.getCouncilReviewRelayId(), newOrder);
+
+        return Map.of(
+                "councilReviewRelayId", savedRelay.getCouncilReviewRelayId(),
+                "relayOrder", newOrder
+        );
+    }
+
+    /**
+     * 릴레이 수정
+     */
+    @Transactional
+    public void updateRelay(Long userId, Long relayId, CouncilReviewRelayUpdateRequest request) {
+        log.info("릴레이 수정 - userId: {}, relayId: {}", userId, relayId);
+
+        // 1. 릴레이 조회
+        CouncilReviewRelay relay = relayRepository.findByIdWithWriterAndPost(relayId)
+                .orElseThrow(() -> new CustomException(CouncilReviewErrorCode.RELAY_NOT_FOUND));
+
+        // 2. 작성자 권한 확인
+        if (!relay.isWriter(userId)) {
+            throw new CustomException(CouncilReviewErrorCode.ONLY_WRITER_CAN_UPDATE_RELAY);
+        }
+
+        // 3. 릴레이 내용 수정
+        relay.updateRelayContent(request.getRelayContent());
+
+        log.info("릴레이 수정 완료 - relayId: {}", relayId);
+    }
+
+    /**
+     * 릴레이 삭제
+     */
+    @Transactional
+    public void deleteRelay(Long userId, Long relayId) {
+        log.info("릴레이 삭제 - userId: {}, relayId: {}", userId, relayId);
+
+        // 1. 릴레이 조회
+        CouncilReviewRelay relay = relayRepository.findByIdWithWriterAndPost(relayId)
+                .orElseThrow(() -> new CustomException(CouncilReviewErrorCode.RELAY_NOT_FOUND));
+
+        // 2. 작성자 권한 확인
+        if (!relay.isWriter(userId)) {
+            throw new CustomException(CouncilReviewErrorCode.ONLY_WRITER_CAN_DELETE_RELAY);
+        }
+
+        Long postId = relay.getCouncilReviewPost().getCouncilReviewPostId();
+
+        // 3. 릴레이 Hard Delete
+        relayRepository.delete(relay);
+
+        // 4. relay_order 재정렬
+        reorderRelays(postId);
+
+        log.info("릴레이 삭제 완료 - relayId: {}", relayId);
+    }
+
+    /**
+     * relay_order 재정렬
+     * 릴레이 삭제 후 순서를 1, 2, 3, ... 으로 재정렬
+     */
+    private void reorderRelays(Long postId) {
+        log.info("relay_order 재정렬 시작 - postId: {}", postId);
+
+        List<CouncilReviewRelay> relays = relayRepository.findByCouncilReviewPostIdOrderByRelayOrder(postId);
+
+        // 순서 재배정
+        for (int i = 0; i < relays.size(); i++) {
+            relays.get(i).updateRelayOrder(i + 1);
+        }
+
+        relayRepository.saveAll(relays);
+
+        log.info("relay_order 재정렬 완료 - postId: {}, 총 릴레이 수: {}", postId, relays.size());
+    }
+
+    /**
+     * 특정 활동 후기의 모든 릴레이 조회 (상세 조회용)
+     */
+    public List<CouncilReviewRelayResponse> getRelaysByPostId(Long postId, Long currentUserId) {
+        log.info("릴레이 목록 조회 - postId: {}", postId);
+
+        List<CouncilReviewRelay> relays = relayRepository.findByCouncilReviewPostIdWithWriterAndQuestion(postId);
+
+        return relays.stream()
+                .map(relay -> CouncilReviewRelayResponse.from(relay, currentUserId))
+                .collect(Collectors.toList());
+    }
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/councilreview/service/CouncilReviewRelayService.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/councilreview/service/CouncilReviewRelayService.java
@@ -37,15 +37,15 @@ public class CouncilReviewRelayService {
 
     // 릴레이 후기 작성
     @Transactional
-    public Map<String, Object> createRelay(Long userId, Long postId, CouncilReviewRelayCreateRequest request) {
-        log.info("릴레이 작성 - userId: {}, postId: {}, questionId: {}", userId, postId, request.getQuestionId());
+    public Map<String, Object> createRelay(Long userId, Long councilReviewPostId, CouncilReviewRelayCreateRequest request) {
+        log.info("릴레이 작성 - userId: {}, postId: {}, questionId: {}", userId, councilReviewPostId, request.getQuestionId());
 
         // 1. 사용자 조회
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(AuthErrorCode.USER_NOT_FOUND));
 
         // 2. 활동 후기 조회
-        CouncilReviewPost post = postRepository.findById(postId)
+        CouncilReviewPost post = postRepository.findById(councilReviewPostId)
                 .orElseThrow(() -> new CustomException(CouncilReviewErrorCode.COUNCIL_REVIEW_POST_NOT_FOUND));
 
         // 3. 삭제된 게시글 체크
@@ -54,13 +54,13 @@ public class CouncilReviewRelayService {
         }
 
         // 4. 참여자 권한 확인
-        boolean isParticipant = participantRepository.existsByCouncilReviewPostIdAndUserId(postId, userId);
+        boolean isParticipant = participantRepository.existsByCouncilReviewPostIdAndUserId(councilReviewPostId, userId);
         if (!isParticipant) {
             throw new CustomException(CouncilReviewErrorCode.NOT_PARTICIPANT);
         }
 
         // 5. 이미 작성했는지 확인 (1인 1회 제한)
-        boolean alreadyWritten = relayRepository.existsByCouncilReviewPostIdAndWriterUserId(postId, userId);
+        boolean alreadyWritten = relayRepository.existsByCouncilReviewPostIdAndWriterUserId(councilReviewPostId, userId);
         if (alreadyWritten) {
             throw new CustomException(CouncilReviewErrorCode.ALREADY_WRITTEN_RELAY);
         }
@@ -69,13 +69,13 @@ public class CouncilReviewRelayService {
         CouncilReviewQuestion question = questionService.validateAndGetQuestion(request.getQuestionId());
 
         // 7. 질문 중복 체크 (같은 활동 후기 내에서 중복 불가)
-        List<Long> usedQuestionIds = relayRepository.findUsedQuestionIdsByPostId(postId);
+        List<Long> usedQuestionIds = relayRepository.findUsedQuestionIdsByPostId(councilReviewPostId);
         if (usedQuestionIds.contains(request.getQuestionId())) {
             throw new CustomException(CouncilReviewErrorCode.QUESTION_ALREADY_USED);
         }
 
         // 8. relay_order 자동 배정 (MAX + 1)
-        Integer maxOrder = relayRepository.findMaxRelayOrderByPostId(postId);
+        Integer maxOrder = relayRepository.findMaxRelayOrderByPostId(councilReviewPostId);
         Integer newOrder = maxOrder + 1;
 
         // 9. 릴레이 생성

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/post/dto/PostListResponse.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/post/dto/PostListResponse.java
@@ -25,6 +25,15 @@ public class PostListResponse {
     @Schema(description = "게시글 제목", example = "부모님과 고등학교 문제로 다투었어요")
     private String postTitle;
 
+    @Schema(description = "게시글 내용 미리보기 (100자)", example = "제주 지역 자치회 구성원들이 처음으로...")
+    private String postContentPreview;
+
+    @Schema(description = "썸네일 이미지 URL", example = "https://...")
+    private String thumbnailImageUrl;
+
+    @Schema(description = "자치회 이름 (자치회 활동 후기인 경우)", example = "제주 자치회", nullable = true)
+    private String councilName;
+
     @Schema(description = "작성자 이름 (익명일 경우 '익명')", example = "홍길동")
     private String authorName;
 
@@ -37,16 +46,30 @@ public class PostListResponse {
     @Schema(description = "작성 일시", example = "2026-01-28T14:30:00")
     private LocalDateTime createdAt;
 
-    public static PostListResponse from(Post post, Long commentCount, boolean isAnonymous) {
+    public static PostListResponse from(Post post, Long commentCount, boolean isAnonymous,
+                                        String councilName, String thumbnailImageUrl) {
+        // 내용 미리보기 (100자)
+        String contentPreview = post.getPostContent() != null && post.getPostContent().length() > 100
+                ? post.getPostContent().substring(0, 100) + "..."
+                : post.getPostContent();
+
         return PostListResponse.builder()
                 .postId(post.getPostId())
                 .boardId(post.getBoard().getBoardId())
                 .postCategory(post.getPostCategory())
                 .postTitle(post.getPostTitle())
+                .postContentPreview(contentPreview)
+                .thumbnailImageUrl(thumbnailImageUrl)
                 .authorName(isAnonymous ? "익명" : post.getAuthor().getName())
+                .councilName(councilName)
                 .viewCount(post.getViewCount())
                 .commentCount(commentCount)
                 .createdAt(post.getCreatedAt())
                 .build();
+    }
+
+    // 기존 호환성을 위한 오버로드 메서드
+    public static PostListResponse from(Post post, Long commentCount, boolean isAnonymous) {
+        return from(post, commentCount, isAnonymous, null, null);
     }
 }

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/post/service/PostService.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/post/service/PostService.java
@@ -6,6 +6,8 @@ import com.solif.backend.domain.board.entity.Board;
 import com.solif.backend.domain.board.repository.BoardRepository;
 import com.solif.backend.domain.comment.dto.PostCommentCount;
 import com.solif.backend.domain.comment.repository.CommentRepository;
+import com.solif.backend.domain.councilreview.entity.CouncilReviewPost;
+import com.solif.backend.domain.councilreview.repository.CouncilReviewPostRepository;
 import com.solif.backend.domain.post.dto.*;
 import com.solif.backend.domain.post.entity.Post;
 import com.solif.backend.domain.post.entity.PostCategory;
@@ -37,6 +39,7 @@ public class PostService {
     private final CommentRepository commentRepository;
     private final UserRepository userRepository;
     private final PostLikeRepository postLikeRepository;
+    private final CouncilReviewPostRepository councilReviewPostRepository;
 
     // 게시글 목록 조회
     public Slice<PostListResponse> getPosts(Long boardId, PostCategory category, Pageable pageable) {
@@ -100,8 +103,25 @@ public class PostService {
 
         // Post -> PostListResponse 변환
         return posts.map(post -> {
-            Long commentCount = commentCounts.getOrDefault(post.getPostId(), 0L);
-            return PostListResponse.from(post, commentCount, isAnonymous);
+            Long commentCount = commentRepository.countByPost_PostId(post.getPostId());
+
+            // 자치회 활동 후기인 경우 추가 정보 조회
+            String councilName = null;
+            String thumbnailImageUrl = null;
+
+            if (boardId == 1L) { // 자치회 활동 후기
+                CouncilReviewPost reviewPost = councilReviewPostRepository
+                        .findByPostId(post.getPostId())
+                        .orElse(null);
+
+                if (reviewPost != null) {
+                    councilName = reviewPost.getCouncil().getCouncilName();
+                    // TODO: 첫 번째 이미지 조회 (file_attachment 연동 후)
+                    thumbnailImageUrl = null;
+                }
+            }
+
+            return PostListResponse.from(post, commentCount, isAnonymous, councilName, thumbnailImageUrl);
         });
     }
 

--- a/blue-sol-backend/src/main/java/com/solif/backend/global/config/CouncilReviewQuestionDataInitializer.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/global/config/CouncilReviewQuestionDataInitializer.java
@@ -1,0 +1,55 @@
+package com.solif.backend.global.config;
+
+import com.solif.backend.domain.councilreview.entity.CouncilReviewQuestion;
+import com.solif.backend.domain.councilreview.repository.CouncilReviewQuestionRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class CouncilReviewQuestionDataInitializer implements CommandLineRunner {
+
+    private final CouncilReviewQuestionRepository questionRepository;
+
+    @Override
+    public void run(String... args) throws Exception {
+        // 이미 질문 데이터가 있으면 스킵
+        if (questionRepository.count() > 0) {
+            log.info("자치회 후기 질문 데이터가 이미 존재합니다. 초기화를 건너뜁니다.");
+            return;
+        }
+
+        log.info("자치회 후기 질문 초기 데이터 삽입 시작");
+
+        List<String> questions = List.of(
+                "오늘 여러분의 마음을 채워준 한 끼는 무엇이었나요?",
+                "오늘의 날씨와 모임의 분위기는 잘 어울렸나요?",
+                "함께한 시간 중 가장 웃음이 터졌던 순간은 언제였나요?",
+                "오늘 찍은 사진에 담긴 이야기를 들려주세요.",
+                "오늘 나눈 대화 중 가장 공감되었던 이야기는 무엇이었나요?",
+                "서로의 고민을 나누며 발견한 우리의 공통점은 무엇이었나요?",
+                "오늘 만난 서로에게서 발견한 멋진 점은 무엇이었나요?",
+                "오늘의 만남이 내 꿈에 어떤 작은 영감을 주었나요?",
+                "오늘 대화를 통해 새롭게 다짐한 목표가 생겼나요?",
+                "다음 만남을 기약하며 꼭 해보고 싶은 활동이 있다면 무엇인가요?",
+                "오늘 함께한 동료들에게 보내는 짧은 응원의 한마디를 남겨주세요.",
+                "1년 뒤 우리는 서로에게 어떤 모습으로 기억될까요?",
+                "오늘의 에너지를 받아 내일 바로 실천하고 싶은 작은 행동은 무엇인가요?"
+        );
+
+        questions.forEach(questionText -> {
+            CouncilReviewQuestion question = CouncilReviewQuestion.builder()
+                    .questionText(questionText)
+                    .isActive(true)
+                    .build();
+            questionRepository.save(question);
+        });
+
+        log.info("자치회 후기 질문 초기 데이터 삽입 완료: {} 개", questions.size());
+    }
+}


### PR DESCRIPTION
## 🔍 개요
자치회 활동 후기 글쓰기 기능을 위해 활동 후기 CRUD, 릴레이 작성/수정/삭제, 랜덤 질문 조회 API를 구현했습니다.
도메인 구조는 councilReview 하위로 분리했고, 요청/응답 DTO 및 성공/에러 코드를 포함합니다.

## ✨ 변경 사항
- 자치회 활동 후기(Review Post) API 구현
- 릴레이(Relay) API 구현
- 랜덤 질문(Random Question) API 구현

## 🧪 테스트
- [x] 로컬 테스트 완료
- [x] API 테스트 완료
- [ ] 테스트 코드 작성 (해당 시)

## 📎 관련 이슈
Closes: #58 

## ⚠️ 참고 사항
권한/인증 기준이 엔드포인트별로 다름
- 활동 후기 목록/상세/랜덤 질문: 인증 사용자
- 활동 후기 생성/수정/삭제: 리더
- 릴레이: 멤버+참여자(작성)/작성자(수정/삭제)

OCR(영수증 금액 추출)은 이번 PR 범위에서 제외했고, 글쓰기 기능 안정화 후 별도 이슈로 분리 예정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 자치회 활동 후기 작성, 조회, 수정, 삭제 기능 추가
  * 활동 후기에 대한 릴레이(연쇄 참여) 기능 제공
  * 후기 작성 시 무작위 질문 선택 기능 추가
  * 예산 관리 기능 개선으로 증액/감액 처리 추강

* **개선**
  * 게시물 목록 조회 시 자치회명 및 썸네일 정보 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->