### PR TITLE
feat: 자치회 영수증 OCR 금액 추출 API 추가

### DIFF
--- a/.github/workflows/deploy-stg.yml
+++ b/.github/workflows/deploy-stg.yml
@@ -26,20 +26,24 @@ jobs:
         working-directory: blue-sol-backend
         run: ./gradlew clean build -x test
 
+      - name: Create Google Vision credential file
+        working-directory: blue-sol-backend
+        run: |
+          mkdir -p secrets
+          echo "${{ secrets.GCP_VISION_CREDENTIALS }}" > secrets/gcp-vision.json
+
       - name: Login to DockerHub
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      # ✅ (1) 멀티아키 빌드 준비
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      # ✅ (2) 멀티아키로 build+push (EC2 amd64에서 pull 가능해짐)
       - name: Build and push Docker image (STG)
         run: |
           docker buildx build \
@@ -69,6 +73,7 @@ jobs:
             REDIS_PORT=${{ secrets.REDIS_PORT }}
             S3_ACCESS_KEY=${{secrets.S3_ACCESS_KEY}}
             S3_SECRET_KEY=${{secrets.S3_SECRET_KEY}}
+            GOOGLE_APPLICATION_CREDENTIALS=/app/secrets/gcp-vision.json
             EOF
 
             docker compose pull backend-stg

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,20 +26,24 @@ jobs:
         working-directory: blue-sol-backend
         run: ./gradlew clean build -x test
 
+      - name: Create Google Vision credential file
+        working-directory: blue-sol-backend
+        run: |
+          mkdir -p secrets
+          echo "${{ secrets.GCP_VISION_CREDENTIALS }}" > secrets/gcp-vision.json
+
       - name: Login to DockerHub
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      # ✅ (1) 멀티아키 빌드 준비
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      # ✅ (2) 멀티아키로 build+push (EC2 amd64에서 pull 가능)
       - name: Build and push Docker image (PROD)
         run: |
           docker buildx build \
@@ -69,6 +73,7 @@ jobs:
             REDIS_PORT=${{ secrets.REDIS_PORT }}
             S3_ACCESS_KEY=${{secrets.S3_ACCESS_KEY}}
             S3_SECRET_KEY=${{secrets.S3_SECRET_KEY}}
+            GOOGLE_APPLICATION_CREDENTIALS=/app/secrets/gcp-vision.json
             EOF
 
             docker compose pull backend-prod

--- a/blue-sol-backend/Dockerfile
+++ b/blue-sol-backend/Dockerfile
@@ -17,6 +17,7 @@ FROM eclipse-temurin:17-jre-jammy
 
 WORKDIR /app
 COPY --from=builder /app/build/libs/*.jar app.jar
+COPY --from=builder /app/secrets /app/secrets
 
 ENV SPRING_PROFILES_ACTIVE=prod
 ENV SERVER_PORT=8080

--- a/blue-sol-backend/build.gradle
+++ b/blue-sol-backend/build.gradle
@@ -45,9 +45,17 @@ dependencies {
 	implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3:3.4.0'
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 
+	// Google Cloud Vision API
+	implementation 'com.google.cloud:google-cloud-vision:3.20.0'
+
 	runtimeOnly 'com.h2database:h2'
 }
 
 tasks.named('test') {
 	useJUnitPlatform()
 }
+
+configurations.all { // listenablefuture:1.0을 강제로 배제 + guava 하나로 통일
+	exclude group: "com.google.guava", module: "listenablefuture"
+}
+

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/ocr/code/OcrErrorCode.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/ocr/code/OcrErrorCode.java
@@ -1,0 +1,29 @@
+package com.solif.backend.domain.ocr.code;
+
+import com.solif.backend.global.common.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum OcrErrorCode implements ErrorCode {
+
+    // 파일 관련
+    FILE_NOT_PROVIDED(HttpStatus.BAD_REQUEST, "OCR_001", "파일이 제공되지 않았습니다."),
+    FILE_READ_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "OCR_002", "파일 읽기에 실패했습니다."),
+    INVALID_FILE_FORMAT(HttpStatus.BAD_REQUEST, "OCR_003", "지원하지 않는 파일 형식입니다. 이미지 파일만 가능합니다."),
+
+    // OCR 처리 관련
+    OCR_PROCESSING_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "OCR_004", "OCR 처리 중 오류가 발생했습니다."),
+    NO_TEXT_DETECTED(HttpStatus.BAD_REQUEST, "OCR_005", "이미지에서 텍스트를 감지할 수 없습니다."),
+    AMOUNT_NOT_FOUND(HttpStatus.BAD_REQUEST, "OCR_006", "영수증에서 금액을 찾을 수 없습니다."),
+
+    // Vision API 관련
+    VISION_API_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "OCR_007", "Google Vision API 호출에 실패했습니다."),
+    VISION_CREDENTIALS_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "OCR_008", "Google Vision API 인증에 실패했습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/ocr/code/OcrSuccessCode.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/ocr/code/OcrSuccessCode.java
@@ -1,0 +1,21 @@
+package com.solif.backend.domain.ocr.code;
+
+import com.solif.backend.global.common.response.SuccessCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum OcrSuccessCode implements SuccessCode {
+
+    // 테스트 OCR
+    OCR_TEST_SUCCESS(HttpStatus.OK, "OCR_200", "OCR 테스트 처리에 성공했습니다."),
+
+    // 운영 OCR
+    OCR_AMOUNT_EXTRACT_SUCCESS(HttpStatus.OK, "OCR_201", "영수증 금액 추출에 성공했습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/ocr/controller/OcrController.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/ocr/controller/OcrController.java
@@ -28,7 +28,7 @@ public class OcrController {
     @Operation(
             summary = "영수증 금액 추출",
             description = "파일 ID를 받아 S3에서 영수증 이미지를 다운로드하고 OCR로 금액을 추출합니다.",
-            security = @SecurityRequirement(name = "bearerAuth")
+            security = @SecurityRequirement(name = "Bearer Authentication")
     )
     @PostMapping("/receipts/ocr")
     public ResponseEntity<SuccessResponse<OcrResponse>> extractReceiptAmount(

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/ocr/controller/OcrController.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/ocr/controller/OcrController.java
@@ -1,0 +1,40 @@
+package com.solif.backend.domain.ocr.controller;
+
+import com.solif.backend.domain.ocr.code.OcrSuccessCode;
+import com.solif.backend.domain.ocr.dto.request.OcrRequest;
+import com.solif.backend.domain.ocr.dto.response.OcrResponse;
+import com.solif.backend.domain.ocr.service.OcrService;
+import com.solif.backend.global.common.response.ResponseFactory;
+import com.solif.backend.global.common.response.SuccessResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "OCR", description = "OCR API")
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+public class OcrController {
+
+    private final OcrService ocrService;
+
+    @Operation(
+            summary = "영수증 금액 추출",
+            description = "파일 ID를 받아 S3에서 영수증 이미지를 다운로드하고 OCR로 금액을 추출합니다.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @PostMapping("/receipts/ocr")
+    public ResponseEntity<SuccessResponse<OcrResponse>> extractReceiptAmount(
+            @Valid @RequestBody OcrRequest request
+    ) {
+        OcrResponse response = ocrService.processOcr(request.getFileId());
+        return ResponseFactory.success(OcrSuccessCode.OCR_AMOUNT_EXTRACT_SUCCESS, response);
+    }
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/ocr/controller/OcrTestController.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/ocr/controller/OcrTestController.java
@@ -1,0 +1,38 @@
+package com.solif.backend.domain.ocr.controller;
+
+import com.solif.backend.domain.ocr.code.OcrSuccessCode;
+import com.solif.backend.domain.ocr.dto.response.OcrTestResponse;
+import com.solif.backend.domain.ocr.service.OcrService;
+import com.solif.backend.global.common.response.ResponseFactory;
+import com.solif.backend.global.common.response.SuccessResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@Tag(name = "OCR 테스트", description = "OCR 테스트 API (개발용)")
+@RestController
+@RequestMapping("/api/test")
+@RequiredArgsConstructor
+public class OcrTestController {
+
+    private final OcrService ocrService;
+
+    @Operation(
+            summary = "OCR 테스트",
+            description = "이미지 파일을 직접 업로드하여 OCR 테스트를 수행합니다. 추출된 텍스트, 금액 후보, 최종 금액을 모두 반환합니다."
+    )
+    @PostMapping(value = "/ocr", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<SuccessResponse<OcrTestResponse>> testOcr(
+            @RequestParam("file") MultipartFile file
+    ) {
+        OcrTestResponse response = ocrService.processOcrTest(file);
+        return ResponseFactory.success(OcrSuccessCode.OCR_TEST_SUCCESS, response);
+    }
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/ocr/dto/request/OcrRequest.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/ocr/dto/request/OcrRequest.java
@@ -1,0 +1,16 @@
+package com.solif.backend.domain.ocr.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@Schema(description = "OCR 요청 (운영용)")
+public class OcrRequest {
+
+    @Schema(description = "파일 ID", example = "123", required = true)
+    @NotNull(message = "파일 ID는 필수입니다.")
+    private Long fileId;
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/ocr/dto/request/OcrRequest.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/ocr/dto/request/OcrRequest.java
@@ -2,6 +2,7 @@ package com.solif.backend.domain.ocr.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -12,5 +13,6 @@ public class OcrRequest {
 
     @Schema(description = "파일 ID", example = "123", required = true)
     @NotNull(message = "파일 ID는 필수입니다.")
+    @Positive(message = "파일 ID는 1 이상이어야 합니다.")
     private Long fileId;
 }

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/ocr/dto/response/OcrResponse.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/ocr/dto/response/OcrResponse.java
@@ -1,0 +1,20 @@
+package com.solif.backend.domain.ocr.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@Schema(description = "OCR 응답 (운영용)")
+public class OcrResponse {
+
+    @Schema(description = "추출된 금액", example = "13200", nullable = true)
+    private Long amount;
+
+    public static OcrResponse of(Long amount) {
+        return OcrResponse.builder()
+                .amount(amount)
+                .build();
+    }
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/ocr/dto/response/OcrTestResponse.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/ocr/dto/response/OcrTestResponse.java
@@ -1,0 +1,30 @@
+package com.solif.backend.domain.ocr.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+@Schema(description = "OCR 테스트 응답 (상세 정보)")
+public class OcrTestResponse {
+
+    @Schema(description = "추출된 최종 금액 (가장 큰 값)", example = "13200", nullable = true)
+    private Long amount;
+
+    @Schema(description = "추출된 모든 금액 후보", example = "[13200, 13000]")
+    private List<Long> candidates;
+
+    @Schema(description = "OCR로 추출된 전체 텍스트", example = "합계 13,200원\\n부가세 포함")
+    private String rawText;
+
+    public static OcrTestResponse of(Long amount, List<Long> candidates, String rawText) {
+        return OcrTestResponse.builder()
+                .amount(amount)
+                .candidates(candidates)
+                .rawText(rawText)
+                .build();
+    }
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/ocr/service/GoogleVisionClient.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/ocr/service/GoogleVisionClient.java
@@ -1,0 +1,88 @@
+package com.solif.backend.domain.ocr.service;
+
+import com.google.cloud.vision.v1.*;
+import com.google.protobuf.ByteString;
+import com.solif.backend.domain.ocr.code.OcrErrorCode;
+import com.solif.backend.global.common.exception.CustomException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@Component
+public class GoogleVisionClient {
+
+    /**
+     * Google Vision API를 사용하여 이미지에서 텍스트 추출
+     * @param imageBytes 이미지 바이트 배열
+     * @return 추출된 전체 텍스트
+     */
+    public String extractText(byte[] imageBytes) {
+        // 1. Vision API 클라이언트 생성 (try-with-resources로 자동 close)
+        try (ImageAnnotatorClient visionClient = ImageAnnotatorClient.create()) {
+
+            // 2. 이미지 바이트 배열을 Google Vision 형식으로 변환
+            ByteString byteString = ByteString.copyFrom(imageBytes);
+            Image image = Image.newBuilder().setContent(byteString).build();
+
+            // 3. "TEXT_DETECTION" 기능 요청 설정
+            Feature feature = Feature.newBuilder()
+                    .setType(Feature.Type.TEXT_DETECTION)
+                    .build();
+
+            // 4. 요청 객체 생성
+            AnnotateImageRequest request = AnnotateImageRequest.newBuilder()
+                    .addFeatures(feature)
+                    .setImage(image)
+                    .build();
+
+            List<AnnotateImageRequest> requests = new ArrayList<>();
+            requests.add(request);
+
+            // 5. API 호출 (배치 처리 - 여러 이미지 동시 처리 가능)
+            BatchAnnotateImagesResponse response = visionClient.batchAnnotateImages(requests);
+            List<AnnotateImageResponse> responses = response.getResponsesList();
+
+            if (responses.isEmpty()) {
+                log.error("Google Vision API 응답이 비어있습니다.");
+                throw new CustomException(OcrErrorCode.VISION_API_ERROR);
+            }
+
+            AnnotateImageResponse imageResponse = responses.get(0);
+
+            // 에러 체크
+            if (imageResponse.hasError()) {
+                String errorMessage = imageResponse.getError().getMessage();
+                log.error("Google Vision API 에러: {}", errorMessage);
+                throw new CustomException(OcrErrorCode.VISION_API_ERROR);
+            }
+
+            // 텍스트 추출
+            if (imageResponse.getTextAnnotationsCount() == 0) {
+                log.warn("이미지에서 텍스트를 감지할 수 없습니다.");
+                throw new CustomException(OcrErrorCode.NO_TEXT_DETECTED);
+            }
+
+            // 6. 응답에서 텍스트 추출
+            //    textAnnotations[0] = 전체 텍스트
+            //    textAnnotations[1~N] = 개별 단어들
+            String fullText = imageResponse.getTextAnnotations(0).getDescription();
+            log.info("OCR 추출 완료. 텍스트 길이: {} 자", fullText.length());
+            log.debug("추출된 텍스트: {}", fullText);
+
+            return fullText;
+
+        } catch (IOException e) {
+            log.error("Google Vision Client 생성 실패", e);
+            throw new CustomException(OcrErrorCode.VISION_CREDENTIALS_ERROR);
+        } catch (CustomException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("Google Vision API 호출 중 예외 발생", e);
+            throw new CustomException(OcrErrorCode.VISION_API_ERROR);
+        }
+    }
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/ocr/service/GoogleVisionClient.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/ocr/service/GoogleVisionClient.java
@@ -71,7 +71,6 @@ public class GoogleVisionClient {
             //    textAnnotations[1~N] = 개별 단어들
             String fullText = imageResponse.getTextAnnotations(0).getDescription();
             log.info("OCR 추출 완료. 텍스트 길이: {} 자", fullText.length());
-            log.debug("추출된 텍스트: {}", fullText);
 
             return fullText;
 

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/ocr/service/OcrService.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/ocr/service/OcrService.java
@@ -1,0 +1,112 @@
+package com.solif.backend.domain.ocr.service;
+
+import com.solif.backend.domain.file.entity.File;
+import com.solif.backend.domain.file.exception.FileException;
+import com.solif.backend.domain.file.repository.FileRepository;
+import com.solif.backend.domain.ocr.code.OcrErrorCode;
+import com.solif.backend.domain.ocr.dto.response.OcrResponse;
+import com.solif.backend.domain.ocr.dto.response.OcrTestResponse;
+import com.solif.backend.domain.ocr.util.AmountParser;
+import com.solif.backend.global.common.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.ResponseBytes;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+
+import java.io.IOException;
+import java.util.List;
+
+import static com.solif.backend.domain.file.exception.FileException.FileErrorCode.FILE_NOT_FOUND;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class OcrService {
+
+    private final GoogleVisionClient visionClient;
+    private final FileRepository fileRepository;
+    private final S3Client s3Client;
+
+    // 테스트용 OCR: MultipartFile에서 직접 텍스트 추출
+    public OcrTestResponse processOcrTest(MultipartFile file) {
+        validateFile(file);
+
+        try {
+            // 파일 읽기
+            byte[] imageBytes = file.getBytes();
+
+            // OCR 처리
+            String rawText = visionClient.extractText(imageBytes);
+
+            // 금액 파싱
+            List<Long> candidates = AmountParser.extractAllAmounts(rawText);
+            Long amount = candidates.isEmpty() ? null : candidates.get(candidates.size() - 1);
+
+            return OcrTestResponse.of(amount, candidates, rawText);
+
+        } catch (IOException e) {
+            log.error("파일 읽기 실패", e);
+            throw new CustomException(OcrErrorCode.FILE_READ_FAILED);
+        }
+    }
+
+    // 운영용 OCR: fileId로 S3에서 파일 다운로드 후 금액만 추출
+    public OcrResponse processOcr(Long fileId) {
+        // File 엔티티 조회
+        File file = fileRepository.findById(fileId)
+                .orElseThrow(() -> new FileException(FILE_NOT_FOUND));
+
+        // S3에서 파일 다운로드
+        byte[] imageBytes = downloadFromS3(file);
+
+        // OCR 처리
+        String rawText = visionClient.extractText(imageBytes);
+
+        // 금액 파싱
+        Long amount = AmountParser.extractAmount(rawText);
+
+        if (amount == null) {
+            throw new CustomException(OcrErrorCode.AMOUNT_NOT_FOUND);
+        }
+
+        return OcrResponse.of(amount);
+    }
+
+    // S3에서 파일 다운로드
+    private byte[] downloadFromS3(File file) {
+        try {
+            GetObjectRequest getObjectRequest = GetObjectRequest.builder()
+                    .bucket(file.getBucket())
+                    .key(file.getObjectKey())
+                    .build();
+
+            ResponseBytes<GetObjectResponse> objectBytes = s3Client.getObjectAsBytes(getObjectRequest);
+
+            log.info("S3 파일 다운로드 완료 - Bucket: {}, Key: {}", file.getBucket(), file.getObjectKey());
+
+            return objectBytes.asByteArray();
+
+        } catch (Exception e) {
+            log.error("S3 파일 다운로드 실패 - Bucket: {}, Key: {}", file.getBucket(), file.getObjectKey(), e);
+            throw new CustomException(OcrErrorCode.FILE_READ_FAILED);
+        }
+    }
+
+    // 파일 유효성 검증
+    private void validateFile(MultipartFile file) {
+        if (file == null || file.isEmpty()) {
+            throw new CustomException(OcrErrorCode.FILE_NOT_PROVIDED);
+        }
+
+        String contentType = file.getContentType();
+        if (contentType == null || !contentType.startsWith("image/")) {
+            throw new CustomException(OcrErrorCode.INVALID_FILE_FORMAT);
+        }
+    }
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/ocr/util/AmountParser.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/ocr/util/AmountParser.java
@@ -1,0 +1,84 @@
+package com.solif.backend.domain.ocr.util;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@Slf4j
+public class AmountParser {
+
+    private static final Pattern AMOUNT_PATTERN_WITH_COMMA = Pattern.compile("\\d{1,3}(,\\d{3})+");
+    private static final Pattern AMOUNT_PATTERN_WITH_WON = Pattern.compile("(\\d+)원");
+
+    /**
+     * OCR 텍스트에서 금액 후보들을 추출하고, 가장 큰 값을 반환
+     * @param ocrText OCR로 추출된 텍스트
+     * @return 가장 큰 금액 (없으면 null)
+     */
+    public static Long extractAmount(String ocrText) {
+        List<Long> candidates = extractAllAmounts(ocrText);
+
+        if (candidates.isEmpty()) {
+            log.warn("금액을 찾을 수 없습니다. OCR Text: {}", ocrText);
+            return null;
+        }
+
+        Long maxAmount = candidates.stream()
+                .max(Long::compareTo)
+                .orElse(null);
+
+        log.info("추출된 금액 후보: {}, 최종 금액: {}", candidates, maxAmount);
+        return maxAmount;
+    }
+
+    /**
+     * OCR 텍스트에서 모든 금액 후보들을 추출
+     * @param ocrText OCR로 추출된 텍스트
+     * @return 추출된 모든 금액 리스트
+     */
+    public static List<Long> extractAllAmounts(String ocrText) {
+        List<Long> amounts = new ArrayList<>();
+
+        if (ocrText == null || ocrText.isBlank()) {
+            return amounts;
+        }
+
+        // 패턴 1: 쉼표 포함 숫자 (예: "13,200")
+        Matcher commaMatcher = AMOUNT_PATTERN_WITH_COMMA.matcher(ocrText);
+        while (commaMatcher.find()) {  // ✅ find()로 수정
+            String match = commaMatcher.group();
+            try {
+                Long amount = parseAmount(match);
+                amounts.add(amount);
+            } catch (NumberFormatException e) {
+                log.debug("금액 파싱 실패: {}", match);
+            }
+        }
+
+        // 패턴 2: "원" 포함 숫자 (예: "13200원")
+        Matcher wonMatcher = AMOUNT_PATTERN_WITH_WON.matcher(ocrText);
+        while (wonMatcher.find()) {
+            String match = wonMatcher.group(1);
+            try {
+                Long amount = parseAmount(match);
+                amounts.add(amount);
+            } catch (NumberFormatException e) {
+                log.debug("금액 파싱 실패: {}", match);
+            }
+        }
+
+        return amounts.stream()
+                .distinct()
+                .sorted()
+                .toList();
+    }
+
+    // 쉼표를 제거하고 숫자로 변환
+    private static Long parseAmount(String amountStr) {
+        String cleaned = amountStr.replaceAll(",", "");
+        return Long.parseLong(cleaned);
+    }
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/ocr/util/AmountParser.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/ocr/util/AmountParser.java
@@ -22,7 +22,8 @@ public class AmountParser {
         List<Long> candidates = extractAllAmounts(ocrText);
 
         if (candidates.isEmpty()) {
-            log.warn("금액을 찾을 수 없습니다. OCR Text: {}", ocrText);
+            log.warn("금액을 찾을 수 없습니다. OCR Text 길이: {}",
+                    ocrText != null ? ocrText.length() : 0);
             return null;
         }
 

--- a/blue-sol-backend/src/main/java/com/solif/backend/global/config/SecurityConfig.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/global/config/SecurityConfig.java
@@ -67,9 +67,7 @@ public class SecurityConfig {
                                 "/swagger-ui/**",                 // Swagger UI
                                 "/v3/api-docs/**",                // API 문서
                                 "/h2-console/**" ,                // H2 콘솔 (개발용)
-                                "/api/test/ocr" ,                 // test ocr
-                                "/api/v1/receipts/ocr"            // 운영용 ocr
-
+                                "/api/test/ocr"                   // test ocr
                         ).permitAll()
                         // 그 외 모든 요청은 인증 필요
                         .anyRequest().authenticated()

--- a/blue-sol-backend/src/main/java/com/solif/backend/global/config/SecurityConfig.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/global/config/SecurityConfig.java
@@ -66,7 +66,10 @@ public class SecurityConfig {
                                 "/error",                         // Spring Boot 에러 핸들러
                                 "/swagger-ui/**",                 // Swagger UI
                                 "/v3/api-docs/**",                // API 문서
-                                "/h2-console/**"                  // H2 콘솔 (개발용)
+                                "/h2-console/**" ,                // H2 콘솔 (개발용)
+                                "/api/test/ocr" ,                 // test ocr
+                                "/api/v1/receipts/ocr"            // 운영용 ocr
+
                         ).permitAll()
                         // 그 외 모든 요청은 인증 필요
                         .anyRequest().authenticated()

--- a/blue-sol-backend/src/main/resources/application-prod.yml
+++ b/blue-sol-backend/src/main/resources/application-prod.yml
@@ -19,6 +19,11 @@ spring:
         format_sql: false
     open-in-view: false
 
+  servlet:
+    multipart:
+      max-file-size: 10MB
+      max-request-size: 10MB
+
 logging:
   level:
     root: INFO

--- a/blue-sol-backend/src/main/resources/application-stg.yml
+++ b/blue-sol-backend/src/main/resources/application-stg.yml
@@ -19,6 +19,11 @@ spring:
         format_sql: false
     open-in-view: false
 
+  servlet:
+    multipart:
+      max-file-size: 10MB
+      max-request-size: 10MB
+
 logging:
   level:
     root: INFO


### PR DESCRIPTION
## 🔍 개요
자치회 활동 후기 작성 시, 영수증 이미지를 업로드하면 Google Vision API를 통해 텍스트를 인식하고 총 지출 금액을 추출하는 OCR 기능을 추가했습니다.
프론트에서 “지출내역 자동 입력 + 수기 수정 가능” 플로우를 만들 수 있도록 금액 파싱 유틸/응답 DTO를 함께 제공합니다.

## ✨ 변경 사항
- Google Vision 기반 OCR 기능 추가
- 금액 추출/파싱 유틸리티 구현

## 🧪 테스트
- [x] 로컬 테스트 완료
- [ ] API 테스트 완료
- [ ] 테스트 코드 작성 (해당 시)

## 📎 관련 이슈
Closes: #68 

## ⚠️ 참고 사항
본 PR은 “글쓰기(활동 후기)”와 분리된 OCR 기능 PR입니다.
(활동 후기 작성 API에서는 expenseAmount만 받고, OCR은 사전 단계로 활용)

Google Vision 인증/키 관리
- GOOGLE_APPLICATION_CREDENTIALS 환경변수 또는 서버/배포 환경에서 Secret 주입 방식 사용 필요
- 인증 파일은 레포에 포함되지 않도록 관리(현재 브랜치에 복사 관련 커밋이 있는지 최종 확인 필요)

금액 파싱 로직은 영수증 포맷에 따라 추가 튜닝 가능

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 영수증 이미지에서 금액을 자동 추출하는 OCR 기능 추가
  * 운영용 및 테스트용 OCR API 엔드포인트 제공
  * Google Vision 기반 OCR 연동으로 인식 신뢰도 향상
* **설정 변경**
  * 파일 업로드 크기 제한 설정(최대 10MB)
  * 테스트용 OCR 엔드포인트를 인증 없이 접근 가능하도록 허용
* **기타**
  * OCR 결과의 성공/오류 응답이 표준화됨
<!-- end of auto-generated comment: release notes by coderabbit.ai -->