### PR TITLE
fix: 파일 status 추가 및 로직변경

### DIFF
--- a/blue-sol-backend/src/main/java/com/solif/backend/BlueSolBackendApplication.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/BlueSolBackendApplication.java
@@ -4,11 +4,13 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication(exclude = {
 		io.awspring.cloud.autoconfigure.s3.S3AutoConfiguration.class})
-@EnableJpaAuditing  // JPA Auditing 활성화
-@EnableAsync         // 비동기 이벤트 처리 활성화
+@EnableJpaAuditing
+@EnableAsync
+@EnableScheduling
 public class BlueSolBackendApplication {
 
 	public static void main(String[] args) {

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/file/code/FileException.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/file/code/FileException.java
@@ -1,6 +1,7 @@
 package com.solif.backend.domain.file.code;
 
 import lombok.Getter;
+import org.springframework.http.HttpStatus;
 
 @Getter
 public class FileException extends RuntimeException {
@@ -18,7 +19,8 @@ public class FileException extends RuntimeException {
         FILE_UPLOAD_FAILED("파일 업로드에 실패했습니다"),
         FILE_DELETE_FAILED("파일 삭제에 실패했습니다"),
         INVALID_FILE_TYPE("지원하지 않는 파일 형식입니다"),
-        FILE_SIZE_EXCEEDED("파일 크기가 제한을 초과했습니다");
+        FILE_SIZE_EXCEEDED("파일 크기가 제한을 초과했습니다"),
+        FILE_ALREADY_CONFIRMED("이미 확정된 파일입니다.");
 
         private final String message;
 

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/file/controller/FileController.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/file/controller/FileController.java
@@ -3,7 +3,8 @@ package com.solif.backend.domain.file.controller;
 import com.solif.backend.domain.file.dto.request.FileAttachRequest;
 import com.solif.backend.domain.file.dto.response.FileAttachmentResponse;
 import com.solif.backend.domain.file.dto.response.FileUploadResponse;
-import com.solif.backend.domain.file.entity.TargetType;
+import com.solif.backend.domain.file.entity.FileFolder;
+import com.solif.backend.domain.file.entity.FileTargetType;
 import com.solif.backend.domain.file.service.FileService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -31,7 +32,7 @@ public class FileController {
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<List<FileUploadResponse>> uploadFiles(
             @RequestParam("files") List<MultipartFile> files,
-            @RequestParam(value = "folder", defaultValue = "uploads") String folder) {
+            @RequestParam("folder") FileFolder folder) {
 
         List<FileUploadResponse> responses = fileService.uploadFiles(files, folder);
         return ResponseEntity.ok(responses);
@@ -70,10 +71,10 @@ public class FileController {
             security = @SecurityRequirement(name = "Bearer Authentication"))
     @GetMapping("/attachments")
     public ResponseEntity<List<FileAttachmentResponse>> getAttachments(
-            @RequestParam TargetType targetType,
+            @RequestParam FileTargetType fileTargetType,
             @RequestParam Long targetId) {
 
-        List<FileAttachmentResponse> responses = fileService.getAttachments(targetType, targetId);
+        List<FileAttachmentResponse> responses = fileService.getAttachments(fileTargetType, targetId);
         return ResponseEntity.ok(responses);
     }
 }

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/file/dto/request/FileAttachRequest.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/file/dto/request/FileAttachRequest.java
@@ -1,7 +1,7 @@
 package com.solif.backend.domain.file.dto.request;
 
 import com.solif.backend.domain.file.entity.AttachmentPurpose;
-import com.solif.backend.domain.file.entity.TargetType;
+import com.solif.backend.domain.file.entity.FileTargetType;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -14,7 +14,7 @@ public class FileAttachRequest {
     private Long fileId;
 
     @NotNull(message = "타겟 타입은 필수입니다")
-    private TargetType targetType;
+    private FileTargetType fileTargetType;
 
     @NotNull(message = "타겟 ID는 필수입니다")
     private Long targetId;

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/file/dto/response/FileAttachmentResponse.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/file/dto/response/FileAttachmentResponse.java
@@ -2,7 +2,7 @@ package com.solif.backend.domain.file.dto.response;
 
 import com.solif.backend.domain.file.entity.AttachmentPurpose;
 import com.solif.backend.domain.file.entity.FileAttachment;
-import com.solif.backend.domain.file.entity.TargetType;
+import com.solif.backend.domain.file.entity.FileTargetType;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -13,7 +13,7 @@ public class FileAttachmentResponse {
     private Long fileId;
     private String originalName;
     private String url;
-    private TargetType targetType;
+    private FileTargetType fileTargetType;
     private Long targetId;
     private AttachmentPurpose purpose;
     private Integer sortOrder;
@@ -24,7 +24,7 @@ public class FileAttachmentResponse {
                 .fileId(attachment.getFile().getFileId())
                 .originalName(attachment.getFile().getOriginalName())
                 .url(attachment.getFile().getUrl(region))
-                .targetType(attachment.getTargetType())
+                .fileTargetType(attachment.getFileTargetType())
                 .targetId(attachment.getTargetId())
                 .purpose(attachment.getPurpose())
                 .sortOrder(attachment.getSortOrder())

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/file/entity/File.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/file/entity/File.java
@@ -11,7 +11,9 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "file")
+@Table(name = "file", indexes = {
+        @Index(name = "idx_file_status_created_at", columnList = "status, created_at")
+})
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @EntityListeners(AuditingEntityListener.class)
@@ -37,21 +39,34 @@ public class File {
     @Column(name = "size_bytes")
     private Long sizeBytes;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 20)
+    private FileStatus status;
+
     @CreatedDate
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
     @Builder
     public File(String bucket, String objectKey, String originalName,
-                String contentType, Long sizeBytes) {
+                String contentType, Long sizeBytes, FileStatus status) {
         this.bucket = bucket;
         this.objectKey = objectKey;
         this.originalName = originalName;
         this.contentType = contentType;
         this.sizeBytes = sizeBytes;
+        this.status = status != null ? status : FileStatus.TEMP;
     }
 
     public String getUrl(String region) {
         return String.format("https://%s.s3.%s.amazonaws.com/%s", bucket, region, objectKey);
+    }
+
+    public void confirm() {
+        this.status = FileStatus.PERMANENT;
+    }
+
+    public boolean isTemp() {
+        return this.status == FileStatus.TEMP;
     }
 }

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/file/entity/FileAttachment.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/file/entity/FileAttachment.java
@@ -28,7 +28,7 @@ public class FileAttachment {
 
     @Enumerated(EnumType.STRING)
     @Column(name = "target_type", nullable = false, length = 50)
-    private TargetType targetType;
+    private FileTargetType fileTargetType;
 
     @Column(name = "target_id", nullable = false)
     private Long targetId;
@@ -45,10 +45,10 @@ public class FileAttachment {
     private LocalDateTime createdAt;
 
     @Builder
-    public FileAttachment(File file, TargetType targetType, Long targetId,
+    public FileAttachment(File file, FileTargetType fileTargetType, Long targetId,
                           AttachmentPurpose purpose, Integer sortOrder) {
         this.file = file;
-        this.targetType = targetType;
+        this.fileTargetType = fileTargetType;
         this.targetId = targetId;
         this.purpose = purpose;
         this.sortOrder = sortOrder != null ? sortOrder : 1;

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/file/entity/FileFolder.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/file/entity/FileFolder.java
@@ -1,0 +1,14 @@
+package com.solif.backend.domain.file.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum FileFolder {
+    COUNCIL_REVIEW("council-review"),   // 자치회 활동 후기
+    POST("post"),                        // 게시판
+    MENTORING("mentoring");              // 멘토링
+
+    private final String folderName;
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/file/entity/FileStatus.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/file/entity/FileStatus.java
@@ -1,0 +1,6 @@
+package com.solif.backend.domain.file.entity;
+
+public enum FileStatus {
+    TEMP,       // 임시 업로드 (24시간 후 삭제 대상)
+    PERMANENT   // 확정됨 (게시글 등에 연결됨)
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/file/entity/FileTargetType.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/file/entity/FileTargetType.java
@@ -1,7 +1,8 @@
 package com.solif.backend.domain.file.entity;
 
-public enum TargetType {
+public enum FileTargetType {
     COUNCIL_POST,
     USER_PROFILE,
-    BADGE_MEMORY
+    BADGE_MEMORY,
+    MENTORING
 }

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/file/repository/FileAttachmentRepository.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/file/repository/FileAttachmentRepository.java
@@ -1,7 +1,7 @@
 package com.solif.backend.domain.file.repository;
 
 import com.solif.backend.domain.file.entity.FileAttachment;
-import com.solif.backend.domain.file.entity.TargetType;
+import com.solif.backend.domain.file.entity.FileTargetType;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -10,8 +10,8 @@ import java.util.List;
 public interface FileAttachmentRepository extends JpaRepository<FileAttachment, Long> {
 
     @EntityGraph(attributePaths = {"file"})
-    List<FileAttachment> findByTargetTypeAndTargetIdOrderBySortOrder(
-            TargetType targetType, Long targetId);
+    List<FileAttachment> findByFileTargetTypeAndTargetIdOrderBySortOrder(
+            FileTargetType fileTargetType, Long targetId);
 
     boolean existsByFileFileId(Long fileId);
 }

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/file/repository/FileRepository.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/file/repository/FileRepository.java
@@ -1,7 +1,21 @@
 package com.solif.backend.domain.file.repository;
 
 import com.solif.backend.domain.file.entity.File;
+import com.solif.backend.domain.file.entity.FileStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 public interface FileRepository extends JpaRepository<File, Long> {
+
+    @Query("SELECT f FROM File f WHERE f.status = :status AND f.createdAt < :expiredTime")
+    List<File> findExpiredTempFiles(
+            @Param("status") FileStatus status,
+            @Param("expiredTime") LocalDateTime expiredTime
+    );
+
+    List<File> findAllByFileIdIn(List<Long> fileIds);
 }

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/file/scheduler/TempFileCleanupScheduler.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/file/scheduler/TempFileCleanupScheduler.java
@@ -1,0 +1,32 @@
+package com.solif.backend.domain.file.scheduler;
+
+import com.solif.backend.domain.file.service.FileService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class TempFileCleanupScheduler {
+
+    private final FileService fileService;
+
+    private static final int TEMP_FILE_EXPIRY_HOURS = 24;
+
+    /**
+     * 매일 새벽 3시에 만료된 임시 파일 정리
+     */
+    @Scheduled(cron = "0 0 3 * * *")
+    public void cleanupExpiredTempFiles() {
+        log.info("=== 임시 파일 정리 스케줄러 시작 ===");
+
+        try {
+            int deletedCount = fileService.cleanupExpiredTempFiles(TEMP_FILE_EXPIRY_HOURS);
+            log.info("=== 임시 파일 정리 완료: {}개 삭제 ===", deletedCount);
+        } catch (Exception e) {
+            log.error("=== 임시 파일 정리 중 오류 발생 ===", e);
+        }
+    }
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/file/scheduler/TempFileCleanupScheduler.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/file/scheduler/TempFileCleanupScheduler.java
@@ -18,7 +18,7 @@ public class TempFileCleanupScheduler {
     /**
      * 매일 새벽 3시에 만료된 임시 파일 정리
      */
-    @Scheduled(cron = "0 0 3 * * *")
+    @Scheduled(cron = "0 0 3 * * *", zone = "Asia/Seoul")
     public void cleanupExpiredTempFiles() {
         log.info("=== 임시 파일 정리 스케줄러 시작 ===");
 

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/file/service/FileService.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/file/service/FileService.java
@@ -117,6 +117,10 @@ public class FileService {
         int sortOrder = 1;
 
         for (File file : files) {
+            // 파일 상태검증 추가
+            if (!file.isTemp()) {
+                throw new FileException(FILE_ALREADY_CONFIRMED);
+            }
             file.confirm();
 
             FileAttachment attachment = FileAttachment.builder()

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/file/service/FileService.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/file/service/FileService.java
@@ -3,8 +3,13 @@ package com.solif.backend.domain.file.service;
 import com.solif.backend.domain.file.dto.request.FileAttachRequest;
 import com.solif.backend.domain.file.dto.response.FileAttachmentResponse;
 import com.solif.backend.domain.file.dto.response.FileUploadResponse;
-import com.solif.backend.domain.file.entity.*;
-import com.solif.backend.domain.file.exception.FileException;
+import com.solif.backend.domain.file.entity.AttachmentPurpose;
+import com.solif.backend.domain.file.entity.File;
+import com.solif.backend.domain.file.entity.FileAttachment;
+import com.solif.backend.domain.file.entity.FileFolder;
+import com.solif.backend.domain.file.entity.FileStatus;
+import com.solif.backend.domain.file.entity.FileTargetType;
+import com.solif.backend.domain.file.code.FileException;
 import com.solif.backend.domain.file.repository.FileAttachmentRepository;
 import com.solif.backend.domain.file.repository.FileRepository;
 import com.solif.backend.global.common.exception.CustomException;
@@ -21,7 +26,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
-import static com.solif.backend.domain.file.exception.FileException.FileErrorCode.*;
+import static com.solif.backend.domain.file.code.FileException.FileErrorCode.*;
 
 @Slf4j
 @Service
@@ -101,7 +106,7 @@ public class FileService {
      * - FileAttachment 생성
      */
     @Transactional
-    public List<FileAttachmentResponse> confirmFiles(List<Long> fileIds, TargetType targetType,
+    public List<FileAttachmentResponse> confirmFiles(List<Long> fileIds, FileTargetType fileTargetType,
                                                       Long targetId, AttachmentPurpose purpose) {
         if (fileIds == null || fileIds.isEmpty()) {
             return new ArrayList<>();
@@ -125,7 +130,7 @@ public class FileService {
 
             FileAttachment attachment = FileAttachment.builder()
                     .file(file)
-                    .targetType(targetType)
+                    .fileTargetType(fileTargetType)
                     .targetId(targetId)
                     .purpose(purpose)
                     .sortOrder(sortOrder++)
@@ -136,7 +141,7 @@ public class FileService {
         }
 
         log.info("{}개의 파일 확정 완료 - targetType: {}, targetId: {}",
-                files.size(), targetType, targetId);
+                files.size(), fileTargetType, targetId);
         return responses;
     }
 
@@ -177,7 +182,7 @@ public class FileService {
 
         FileAttachment attachment = FileAttachment.builder()
                 .file(file)
-                .targetType(request.getTargetType())
+                .fileTargetType(request.getFileTargetType())
                 .targetId(request.getTargetId())
                 .purpose(request.getPurpose())
                 .sortOrder(request.getSortOrder())
@@ -209,9 +214,9 @@ public class FileService {
     /**
      * 특정 엔티티의 첨부파일 조회
      */
-    public List<FileAttachmentResponse> getAttachments(TargetType targetType, Long targetId) {
+    public List<FileAttachmentResponse> getAttachments(FileTargetType fileTargetType, Long targetId) {
         List<FileAttachment> attachments = fileAttachmentRepository
-                .findByTargetTypeAndTargetIdOrderBySortOrder(targetType, targetId);
+                .findByFileTargetTypeAndTargetIdOrderBySortOrder(fileTargetType, targetId);
 
         return attachments.stream()
                 .map(attachment -> FileAttachmentResponse.from(attachment, region))

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/file/service/FileService.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/file/service/FileService.java
@@ -3,10 +3,8 @@ package com.solif.backend.domain.file.service;
 import com.solif.backend.domain.file.dto.request.FileAttachRequest;
 import com.solif.backend.domain.file.dto.response.FileAttachmentResponse;
 import com.solif.backend.domain.file.dto.response.FileUploadResponse;
-import com.solif.backend.domain.file.entity.File;
-import com.solif.backend.domain.file.entity.FileAttachment;
-import com.solif.backend.domain.file.entity.TargetType;
-import com.solif.backend.domain.file.code.FileException;
+import com.solif.backend.domain.file.entity.*;
+import com.solif.backend.domain.file.exception.FileException;
 import com.solif.backend.domain.file.repository.FileAttachmentRepository;
 import com.solif.backend.domain.file.repository.FileRepository;
 import com.solif.backend.global.common.exception.CustomException;
@@ -18,11 +16,12 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
-import static com.solif.backend.domain.file.code.FileException.FileErrorCode.*;
+import static com.solif.backend.domain.file.exception.FileException.FileErrorCode.*;
 
 @Slf4j
 @Service
@@ -41,26 +40,28 @@ public class FileService {
     private String region;
 
     /**
-     * 단일/다중 파일 업로드
+     * 파일 업로드
+     * - S3 업로드 후 status=TEMP로 저장
+     * - 글쓰기 완료 시 confirmFiles()로 PERMANENT 변경
      */
     @Transactional
-    public List<FileUploadResponse> uploadFiles(List<MultipartFile> files, String folder) {
+    public List<FileUploadResponse> uploadFiles(List<MultipartFile> files, FileFolder folder) {
         List<FileUploadResponse> responses = new ArrayList<>();
-        List<String> uploadedKeys = new ArrayList<>(); // 2. 원자성 확보를 위한 업로드 목록 추적
+        List<String> uploadedKeys = new ArrayList<>();
+
+        String folderName = folder.getFolderName();
 
         try {
             for (MultipartFile multipartFile : files) {
                 String originalName = multipartFile.getOriginalFilename();
                 String fileName = UUID.randomUUID() + extractExtension(originalName);
                 String contentType = multipartFile.getContentType();
-                String objectKey = folder + "/" + fileName;
+                String objectKey = folderName + "/" + fileName;
 
-                // 1. S3Service에서 이미 CustomException을 던지므로 중복 래핑 없이 호출
-                s3Service.upload(folder, fileName, multipartFile.getBytes(), contentType);
-                uploadedKeys.add(objectKey); // 업로드 성공 시 키 기록
+                s3Service.upload(folderName, fileName, multipartFile.getBytes(), contentType);
+                uploadedKeys.add(objectKey);
 
-                // 3. 로그 보강: 업로드된 파일 정보 기록
-                log.info("S3 업로드 진행 중 - OriginalName: {}, Key: {}", originalName, objectKey);
+                log.info("파일 S3 업로드 - Folder: {}, OriginalName: {}, Key: {}", folderName, originalName, objectKey);
 
                 File file = File.builder()
                         .bucket(bucket)
@@ -68,36 +69,98 @@ public class FileService {
                         .originalName(originalName)
                         .contentType(contentType)
                         .sizeBytes(multipartFile.getSize())
+                        .status(FileStatus.TEMP)
                         .build();
 
                 fileRepository.save(file);
                 responses.add(FileUploadResponse.from(file, region));
             }
 
-            log.info("총 {}개의 파일 업로드 및 DB 저장 완료", responses.size());
+            log.info("총 {}개의 파일 업로드 완료 - Folder: {}, status=TEMP", responses.size(), folderName);
             return responses;
 
         } catch (Exception e) {
-            // 2. 원자성 확보: 실패 시 이미 S3에 올라간 파일들 삭제 (Cleanup)
-            log.error("파일 업로드 과정 중 에러 발생. 이미 업로드된 파일 {}개를 삭제합니다.", uploadedKeys.size());
+            log.error("파일 업로드 실패. 롤백 중... 삭제할 파일: {}개", uploadedKeys.size());
             for (String key : uploadedKeys) {
                 try {
                     s3Service.delete(key);
                 } catch (Exception ignore) {
-                    log.warn("Cleanup 중 파일 삭제 실패 - Key: {}", key);
+                    log.warn("Cleanup 실패 - Key: {}", key);
                 }
             }
 
-            // 1. 예외 일관성 해결: 명시적 형변환으로 에러 해결
-            if (e instanceof FileException) {
-                throw (FileException) e;
-            }
-            if (e instanceof CustomException) {
-                throw (CustomException) e;
-            }
-
+            if (e instanceof FileException) throw (FileException) e;
+            if (e instanceof CustomException) throw (CustomException) e;
             throw new FileException(FILE_UPLOAD_FAILED);
         }
+    }
+
+    /**
+     * 파일 확정 (글쓰기 API 내부에서 호출)
+     * - TEMP → PERMANENT 상태 변경
+     * - FileAttachment 생성
+     */
+    @Transactional
+    public List<FileAttachmentResponse> confirmFiles(List<Long> fileIds, TargetType targetType,
+                                                      Long targetId, AttachmentPurpose purpose) {
+        if (fileIds == null || fileIds.isEmpty()) {
+            return new ArrayList<>();
+        }
+
+        List<File> files = fileRepository.findAllByFileIdIn(fileIds);
+
+        if (files.size() != fileIds.size()) {
+            throw new FileException(FILE_NOT_FOUND);
+        }
+
+        List<FileAttachmentResponse> responses = new ArrayList<>();
+        int sortOrder = 1;
+
+        for (File file : files) {
+            file.confirm();
+
+            FileAttachment attachment = FileAttachment.builder()
+                    .file(file)
+                    .targetType(targetType)
+                    .targetId(targetId)
+                    .purpose(purpose)
+                    .sortOrder(sortOrder++)
+                    .build();
+
+            fileAttachmentRepository.save(attachment);
+            responses.add(FileAttachmentResponse.from(attachment, region));
+        }
+
+        log.info("{}개의 파일 확정 완료 - targetType: {}, targetId: {}",
+                files.size(), targetType, targetId);
+        return responses;
+    }
+
+    /**
+     * 만료된 임시 파일 삭제 (스케줄러용)
+     * - 모든 폴더의 TEMP 파일을 일괄 삭제
+     */
+    @Transactional
+    public int cleanupExpiredTempFiles(int hoursToExpire) {
+        LocalDateTime expiredTime = LocalDateTime.now().minusHours(hoursToExpire);
+        List<File> expiredFiles = fileRepository.findExpiredTempFiles(FileStatus.TEMP, expiredTime);
+
+        int deletedCount = 0;
+        for (File file : expiredFiles) {
+            try {
+                s3Service.delete(file.getObjectKey());
+                fileRepository.delete(file);
+                deletedCount++;
+                log.info("만료된 임시 파일 삭제 - fileId: {}, key: {}",
+                        file.getFileId(), file.getObjectKey());
+            } catch (Exception e) {
+                log.error("임시 파일 삭제 실패 - fileId: {}, error: {}",
+                        file.getFileId(), e.getMessage());
+            }
+        }
+
+        log.info("임시 파일 정리 완료 - 삭제: {}개 / 대상: {}개", deletedCount, expiredFiles.size());
+        return deletedCount;
     }
 
     /**
@@ -126,18 +189,15 @@ public class FileService {
      */
     @Transactional
     public void detachFile(Long fileAttachmentId) {
-        // 1. 첨부 정보 조회
         FileAttachment attachment = fileAttachmentRepository.findById(fileAttachmentId)
                 .orElseThrow(() -> new FileException(FILE_ATTACHMENT_NOT_FOUND));
 
         File file = attachment.getFile();
-        String objectKey = file.getObjectKey(); // S3 삭제에 필요한 Key
+        String objectKey = file.getObjectKey();
 
-        // 2. DB 레코드 삭제 (연결 정보 및 파일 정보)
         fileAttachmentRepository.delete(attachment);
         fileRepository.delete(file);
 
-        // 3. S3 실제 파일 삭제 (DB 삭제 성공 후 수행)
         s3Service.delete(objectKey);
         log.info("파일 삭제 완료 - ID: {}, S3 Key: {}", file.getFileId(), objectKey);
     }

--- a/blue-sol-backend/src/main/java/com/solif/backend/global/common/exception/GlobalExceptionHandler.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/global/common/exception/GlobalExceptionHandler.java
@@ -13,6 +13,7 @@ import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 import java.sql.SQLException;
 import java.util.HashMap;
@@ -152,7 +153,39 @@ public class GlobalExceptionHandler {
         return CommonErrorCode.INTERNAL_SERVER_ERROR;
     }
 
-    // 5. 일반 예외 처리
+    // 5. Enum 타입 변환 실패 예외 처리 (잘못된 @RequestParam 값)
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<ErrorResponse> handleMethodArgumentTypeMismatchException(
+            MethodArgumentTypeMismatchException e) {
+        
+        String paramName = e.getName();
+        String invalidValue = e.getValue() != null ? e.getValue().toString() : "null";
+        Class<?> requiredType = e.getRequiredType();
+        
+        String message;
+        if (requiredType != null && requiredType.isEnum()) {
+            // Enum 타입인 경우 허용 가능한 값 목록 제공
+            Object[] enumConstants = requiredType.getEnumConstants();
+            String allowedValues = java.util.Arrays.stream(enumConstants)
+                    .map(Object::toString)
+                    .collect(Collectors.joining(", "));
+            message = String.format("'%s' 파라미터의 값 '%s'이(가) 유효하지 않습니다. 허용 값: [%s]",
+                    paramName, invalidValue, allowedValues);
+        } else {
+            message = String.format("'%s' 파라미터의 값 '%s'이(가) 유효하지 않습니다.", 
+                    paramName, invalidValue);
+        }
+        
+        log.warn("MethodArgumentTypeMismatch: param={}, value={}, requiredType={}", 
+                paramName, invalidValue, requiredType);
+        
+        CommonErrorCode errorCode = CommonErrorCode.VALIDATION_ERROR;
+        return ResponseEntity
+                .status(errorCode.getStatus())
+                .body(new ErrorResponse(errorCode.getCode(), message));
+    }
+
+    // 6. 일반 예외 처리
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ErrorResponse> handleGeneralException(Exception e) {
         log.error("Unexpected exception", e);


### PR DESCRIPTION
## 🔍 개요
파일 업로드 시스템에 임시 파일(TEMP) 상태 개념을 도입하여 고아 파일 문제를 해결
사용자가 이미지를 업로드 후 글쓰기를 취소해도 24시간 후 스케줄러가 자동으로 정리

## ✨ 변경 사항
- FileStatus enum 추가 (TEMP, PERMANENT)
- FileFolder enum 추가 (COUNCIL_REVIEW, POST, MENTORING)
- File 엔티티에 status 필드 추가 및 confirm() 메서드 구현
- FileService 수정: 업로드 시 항상 TEMP로 저장, confirmFiles() 메서드 추가
- FileController 수정: 단일 업로드 API로 통합, folder 파라미터 필수화
- TempFileCleanupScheduler 추가: 매일 새벽 3시 24시간 경과 TEMP 파일 자동 삭제
- FileRepository에 만료된 임시 파일 조회 쿼리 추가
- @EnableScheduling 추가

## 🧪 테스트
- [x] 로컬 테스트 완료
- [x] API 테스트 완료
- [ ] 테스트 코드 작성 (해당 시)

## 📎 관련 이슈
Closes: #71 

## ⚠️ 참고 사항
- 운영/스테이징 배포 시 DB 마이그레이션 필요
- 글쓰기 API에서 fileService.confirmFiles() 호출하는 로직은 추후 각 도메인별로 연동 필요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 새로운 기능
- 임시 파일 자동 정리 기능 추가 (24시간 후 자동 삭제)
- 파일 폴더 분류 지원 (의원회-검토, 게시글, 멘토링)
- 파일 확정 기능으로 임시 파일을 영구 파일로 전환

## 개선 사항
- 파일 업로드 시 폴더 선택 방식 개선
- 파일 첨부 유형 확장 (멘토링 지원)
- 잘못된 매개변수에 대한 상세한 오류 메시지 제공
- 데이터베이스 조회 성능 최적화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->