### PR TITLE
chore: File 연동 및 OCR 포함 통합 테스트

### DIFF
--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/councilreview/dto/request/CouncilReviewPostCreateRequest.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/councilreview/dto/request/CouncilReviewPostCreateRequest.java
@@ -36,8 +36,12 @@ public class CouncilReviewPostCreateRequest {
     @Schema(description = "참여자 사용자 ID 목록", example = "[1, 2, 3, 4, 5, 6]")
     private List<Long> participantUserIds;
 
-    @Schema(description = "이미지 파일 ID 목록 (선택)", example = "[10, 11, 12]")
-    private List<Long> imageFileIds;
+    @Schema(description = "일반 이미지 파일 ID 목록", nullable = true)
+    private List<Long> fileIds;
+
+    @NotNull(message = "영수증은 필수입니다.")
+    @Schema(description = "영수증 파일 ID (OCR용)")
+    private Long receiptFileId;
 
     @NotNull(message = "질문 ID는 필수입니다.")
     @Schema(description = "리더가 선택한 질문 ID", example = "5")

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/councilreview/dto/request/CouncilReviewPostUpdateRequest.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/councilreview/dto/request/CouncilReviewPostUpdateRequest.java
@@ -39,7 +39,6 @@ public class CouncilReviewPostUpdateRequest {
     @Schema(description = "일반 이미지 파일 ID 목록 (null=변경없음)", nullable = true)
     private List<Long> fileIds;
 
-    @NotNull(message = "영수증은 필수입니다.")
-    @Schema(description = "영수증 파일 ID (null=변경없음)")
+    @Schema(description = "영수증 파일 ID (null=변경없음)", nullable = true)
     private Long receiptFileId;
 }

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/councilreview/dto/request/CouncilReviewPostUpdateRequest.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/councilreview/dto/request/CouncilReviewPostUpdateRequest.java
@@ -36,6 +36,10 @@ public class CouncilReviewPostUpdateRequest {
     @Schema(description = "참여자 사용자 ID 목록", example = "[1, 2, 3, 4, 5, 6, 7]")
     private List<Long> participantUserIds;
 
-    @Schema(description = "이미지 파일 ID 목록 (선택)", example = "[10, 11, 12, 13]")
-    private List<Long> imageFileIds;
+    @Schema(description = "일반 이미지 파일 ID 목록 (null=변경없음)", nullable = true)
+    private List<Long> fileIds;
+
+    @NotNull(message = "영수증은 필수입니다.")
+    @Schema(description = "영수증 파일 ID (null=변경없음)")
+    private Long receiptFileId;
 }

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/councilreview/service/CouncilReviewPostService.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/councilreview/service/CouncilReviewPostService.java
@@ -101,6 +101,20 @@ public class CouncilReviewPostService {
         Map<Long, Long> likeCounts = postLikeRepository.countByPostIds(postIds);
         Map<Long, Long> commentCounts = commentRepository.countByPostIdsAsMap(postIds);
 
+        // N+1 해결: 대표 이미지를 배치로 조회
+        Map<Long, String> thumbnailUrlMap = fileAttachmentRepository
+                .findByFileTargetTypeAndTargetIdInAndSortOrderAndPurpose(
+                        FileTargetType.COUNCIL_POST,
+                        councilReviewPostIds,
+                        1,
+                        AttachmentPurpose.POST_ATTACHMENT
+                )
+                .stream()
+                .collect(Collectors.toMap(
+                        FileAttachment::getTargetId,
+                        attachment -> attachment.getFile().getUrl(region)
+                ));
+
         // DTO 변환
         return posts.map(post -> {
             Long participantCount = participantCounts.getOrDefault(post.getCouncilReviewPostId(), 0L);
@@ -108,16 +122,8 @@ public class CouncilReviewPostService {
             Long likeCount = likeCounts.getOrDefault(post.getPost().getPostId(), 0L);
             Long commentCount = commentCounts.getOrDefault(post.getPost().getPostId(), 0L);
 
-            // 대표 이미지 조회 (sortOrder=1, POST_ATTACHMENT만)
-            String thumbnailImageUrl = fileAttachmentRepository
-                    .findByFileTargetTypeAndTargetIdAndSortOrderAndPurpose(
-                            FileTargetType.COUNCIL_POST,
-                            post.getCouncilReviewPostId(),
-                            1,
-                            AttachmentPurpose.POST_ATTACHMENT
-                    )
-                    .map(attachment -> attachment.getFile().getUrl(region))
-                    .orElse(null);
+            // 대표 이미지 조회 (Map에서 O(1) 조회)
+            String thumbnailImageUrl = thumbnailUrlMap.get(post.getCouncilReviewPostId());
 
             return CouncilReviewPostListResponse.from(
                     post, participantCount, relayCount, likeCount, commentCount, thumbnailImageUrl

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/councilreview/service/CouncilReviewPostService.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/councilreview/service/CouncilReviewPostService.java
@@ -112,7 +112,8 @@ public class CouncilReviewPostService {
                 .stream()
                 .collect(Collectors.toMap(
                         FileAttachment::getTargetId,
-                        attachment -> attachment.getFile().getUrl(region)
+                        attachment -> attachment.getFile().getUrl(region),
+                        (existing, replacement) -> existing  // 중복 키 처리
                 ));
 
         // DTO 변환
@@ -322,7 +323,7 @@ public class CouncilReviewPostService {
 
         // 8. 일반 이미지 파일 처리
         if (request.getFileIds() != null) {
-            // 기존 일반 이미지 삭제
+            // 기존 일반 이미지 조회
             List<FileAttachment> existingImages = fileAttachmentRepository
                     .findByFileTargetTypeAndTargetId(
                             FileTargetType.COUNCIL_POST,
@@ -337,34 +338,34 @@ public class CouncilReviewPostService {
                     .map(attachment -> attachment.getFile().getFileId())
                     .toList();
 
-            // 삭제할 파일 ID
+            // 삭제할 파일 ID (기존에는 있지만 요청에는 없는 파일)
             List<Long> fileIdsToDelete = existingFileIds.stream()
                     .filter(fileId -> !request.getFileIds().contains(fileId))
                     .toList();
 
-            // 삭제 대상 파일 완전 삭제
+            // 새로 추가할 파일 ID (요청에는 있지만 기존에는 없는 TEMP 파일)
+            List<Long> fileIdsToAdd = request.getFileIds().stream()
+                    .filter(fileId -> !existingFileIds.contains(fileId))
+                    .toList();
+
+            // 삭제 대상 파일 완전 삭제 (File + S3)
             for (FileAttachment attachment : existingImages) {
                 if (fileIdsToDelete.contains(attachment.getFile().getFileId())) {
                     fileService.detachFile(attachment.getFileAttachmentId());
                 }
             }
 
-            // 유지할 파일의 Attachment만 삭제
-            for (FileAttachment attachment : existingImages) {
-                if (!fileIdsToDelete.contains(attachment.getFile().getFileId())) {
-                    fileAttachmentRepository.delete(attachment);
-                }
-            }
-
-            // 새 파일 확정
-            if (!request.getFileIds().isEmpty()) {
+            // 새 파일만 확정 (TEMP → PERMANENT)
+            if (!fileIdsToAdd.isEmpty()) {
                 fileService.confirmFiles(
-                        request.getFileIds(),
+                        fileIdsToAdd,
                         FileTargetType.COUNCIL_POST,
                         councilReviewPostId,
                         AttachmentPurpose.POST_ATTACHMENT
                 );
             }
+
+            // 유지되는 PERMANENT 파일은 Attachment 그대로 유지
         }
 
         // 9. 영수증 파일 처리

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/councilreview/service/CouncilReviewPostService.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/councilreview/service/CouncilReviewPostService.java
@@ -21,6 +21,11 @@ import com.solif.backend.domain.councilreview.entity.CouncilReviewRelay;
 import com.solif.backend.domain.councilreview.repository.CouncilReviewParticipantRepository;
 import com.solif.backend.domain.councilreview.repository.CouncilReviewPostRepository;
 import com.solif.backend.domain.councilreview.repository.CouncilReviewRelayRepository;
+import com.solif.backend.domain.file.entity.AttachmentPurpose;
+import com.solif.backend.domain.file.entity.FileAttachment;
+import com.solif.backend.domain.file.entity.FileTargetType;
+import com.solif.backend.domain.file.repository.FileAttachmentRepository;
+import com.solif.backend.domain.file.service.FileService;
 import com.solif.backend.domain.post.entity.Post;
 import com.solif.backend.domain.post.repository.PostRepository;
 import com.solif.backend.domain.postlike.repository.PostLikeRepository;
@@ -29,6 +34,7 @@ import com.solif.backend.domain.user.repository.UserRepository;
 import com.solif.backend.global.common.exception.CustomException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
@@ -55,6 +61,11 @@ public class CouncilReviewPostService {
     private final UserRepository userRepository;
     private final CommentRepository commentRepository;
     private final PostLikeRepository postLikeRepository;
+    private final FileService fileService;
+    private final FileAttachmentRepository fileAttachmentRepository;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
 
     // 자치회별 활동 후기 목록 조회
     public Slice<CouncilReviewPostListResponse> getCouncilReviewPosts(Long councilId, Pageable pageable) {
@@ -97,8 +108,16 @@ public class CouncilReviewPostService {
             Long likeCount = likeCounts.getOrDefault(post.getPost().getPostId(), 0L);
             Long commentCount = commentCounts.getOrDefault(post.getPost().getPostId(), 0L);
 
-            // TODO: 첫 번째 이미지 URL (file_attachment 연동 후 구현)
-            String thumbnailImageUrl = null;
+            // 대표 이미지 조회 (sortOrder=1, POST_ATTACHMENT만)
+            String thumbnailImageUrl = fileAttachmentRepository
+                    .findByFileTargetTypeAndTargetIdAndSortOrderAndPurpose(
+                            FileTargetType.COUNCIL_POST,
+                            post.getCouncilReviewPostId(),
+                            1,
+                            AttachmentPurpose.POST_ATTACHMENT
+                    )
+                    .map(attachment -> attachment.getFile().getUrl(region))
+                    .orElse(null);
 
             return CouncilReviewPostListResponse.from(
                     post, participantCount, relayCount, likeCount, commentCount, thumbnailImageUrl
@@ -118,8 +137,17 @@ public class CouncilReviewPostService {
         // 2. 조회수 증가
         post.getPost().increaseViewCount();
 
-        // 3. 이미지 URL 목록 조회 (TODO: file_attachment 연동)
-        List<String> imageUrls = new ArrayList<>();
+        // 3. 이미지 URL 목록 조회
+        List<FileAttachment> attachments = fileAttachmentRepository
+                .findByFileTargetTypeAndTargetIdOrderBySortOrder(
+                        FileTargetType.COUNCIL_POST,
+                        councilReviewPostId
+                );
+
+        List<String> imageUrls = attachments.stream()
+                .filter(attachment -> attachment.getPurpose() == AttachmentPurpose.POST_ATTACHMENT)
+                .map(attachment -> attachment.getFile().getUrl(region))
+                .toList();
 
         // 4. 참여자 목록 조회
         List<CouncilReviewParticipant> participants = participantRepository
@@ -215,7 +243,26 @@ public class CouncilReviewPostService {
         // 11. 예산 차감
         council.decreaseBudget(request.getTotalCost());
 
-        // 12. TODO: 이미지 첨부 (file_attachment 연동)
+        // 12. 이미지 첨부
+        // 파일 확정 (일반 이미지)
+        if (request.getFileIds() != null && !request.getFileIds().isEmpty()) {
+            fileService.confirmFiles(
+                    request.getFileIds(),
+                    FileTargetType.COUNCIL_POST,
+                    savedReviewPost.getCouncilReviewPostId(),
+                    AttachmentPurpose.POST_ATTACHMENT
+            );
+        }
+
+        // 파일 확정 (영수증)
+        if (request.getReceiptFileId() != null) {
+            fileService.confirmFiles(
+                    List.of(request.getReceiptFileId()),
+                    FileTargetType.COUNCIL_POST,
+                    savedReviewPost.getCouncilReviewPostId(),
+                    AttachmentPurpose.RECEIPT
+            );
+        }
 
         log.info("활동 후기 생성 완료 - reviewPostId: {}, postId: {}",
                 savedReviewPost.getCouncilReviewPostId(), savedPost.getPostId());
@@ -267,7 +314,77 @@ public class CouncilReviewPostService {
         // 7. 참여자 업데이트
         updateParticipants(reviewPost, request.getParticipantUserIds());
 
-        // 8. TODO: 이미지 업데이트 (file_attachment 연동)
+        // 8. 일반 이미지 파일 처리
+        if (request.getFileIds() != null) {
+            // 기존 일반 이미지 삭제
+            List<FileAttachment> existingImages = fileAttachmentRepository
+                    .findByFileTargetTypeAndTargetId(
+                            FileTargetType.COUNCIL_POST,
+                            councilReviewPostId
+                    )
+                    .stream()
+                    .filter(attachment -> attachment.getPurpose() == AttachmentPurpose.POST_ATTACHMENT)
+                    .toList();
+
+            // 기존 파일 ID 목록
+            List<Long> existingFileIds = existingImages.stream()
+                    .map(attachment -> attachment.getFile().getFileId())
+                    .toList();
+
+            // 삭제할 파일 ID
+            List<Long> fileIdsToDelete = existingFileIds.stream()
+                    .filter(fileId -> !request.getFileIds().contains(fileId))
+                    .toList();
+
+            // 삭제 대상 파일 완전 삭제
+            for (FileAttachment attachment : existingImages) {
+                if (fileIdsToDelete.contains(attachment.getFile().getFileId())) {
+                    fileService.detachFile(attachment.getFileAttachmentId());
+                }
+            }
+
+            // 유지할 파일의 Attachment만 삭제
+            for (FileAttachment attachment : existingImages) {
+                if (!fileIdsToDelete.contains(attachment.getFile().getFileId())) {
+                    fileAttachmentRepository.delete(attachment);
+                }
+            }
+
+            // 새 파일 확정
+            if (!request.getFileIds().isEmpty()) {
+                fileService.confirmFiles(
+                        request.getFileIds(),
+                        FileTargetType.COUNCIL_POST,
+                        councilReviewPostId,
+                        AttachmentPurpose.POST_ATTACHMENT
+                );
+            }
+        }
+
+        // 9. 영수증 파일 처리
+        if (request.getReceiptFileId() != null) {
+            // 기존 영수증 삭제
+            List<FileAttachment> existingReceipts = fileAttachmentRepository
+                    .findByFileTargetTypeAndTargetId(
+                            FileTargetType.COUNCIL_POST,
+                            councilReviewPostId
+                    )
+                    .stream()
+                    .filter(attachment -> attachment.getPurpose() == AttachmentPurpose.RECEIPT)
+                    .toList();
+
+            for (FileAttachment attachment : existingReceipts) {
+                fileService.detachFile(attachment.getFileAttachmentId());
+            }
+
+            // 새 영수증 확정
+            fileService.confirmFiles(
+                    List.of(request.getReceiptFileId()),
+                    FileTargetType.COUNCIL_POST,
+                    councilReviewPostId,
+                    AttachmentPurpose.RECEIPT
+            );
+        }
 
         log.info("활동 후기 수정 완료 - postId: {}", councilReviewPostId);
     }

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/file/entity/AttachmentPurpose.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/file/entity/AttachmentPurpose.java
@@ -1,7 +1,8 @@
 package com.solif.backend.domain.file.entity;
 
 public enum AttachmentPurpose {
-    PROFILE_IMAGE,
-    BADGE_MEMORY_IMAGE,
-    POST_ATTACHMENT
+    PROFILE_IMAGE,           // 프로필 이미지
+    PINECONE_MEMORY_IMAGE,   // 솔방울 추억 이미지
+    POST_ATTACHMENT,         // 게시글 첨부 이미지
+    RECEIPT                  // 영수증 (OCR용)
 }

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/file/entity/FileTargetType.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/file/entity/FileTargetType.java
@@ -1,8 +1,8 @@
 package com.solif.backend.domain.file.entity;
 
 public enum FileTargetType {
-    COUNCIL_POST,
+    POST,              // 통합 게시글
+    COUNCIL_POST,      // 자치회 활동 후기
     USER_PROFILE,
-    BADGE_MEMORY,
-    MENTORING
+    PINECONE_MEMORY
 }

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/file/repository/FileAttachmentRepository.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/file/repository/FileAttachmentRepository.java
@@ -34,5 +34,14 @@ public interface FileAttachmentRepository extends JpaRepository<FileAttachment, 
             AttachmentPurpose purpose
     );
 
+    // 여러 대상의 대표 이미지를 한 번에 조회 (배치 쿼리)
+    @EntityGraph(attributePaths = {"file"})
+    List<FileAttachment> findByFileTargetTypeAndTargetIdInAndSortOrderAndPurpose(
+            FileTargetType fileTargetType,
+            List<Long> targetIds,
+            Integer sortOrder,
+            AttachmentPurpose purpose
+    );
+
     boolean existsByFileFileId(Long fileId);
 }

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/file/repository/FileAttachmentRepository.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/file/repository/FileAttachmentRepository.java
@@ -1,5 +1,6 @@
 package com.solif.backend.domain.file.repository;
 
+import com.solif.backend.domain.file.entity.AttachmentPurpose;
 import com.solif.backend.domain.file.entity.FileAttachment;
 import com.solif.backend.domain.file.entity.FileTargetType;
 import org.springframework.data.jpa.repository.EntityGraph;
@@ -10,6 +11,7 @@ import java.util.Optional;
 
 public interface FileAttachmentRepository extends JpaRepository<FileAttachment, Long> {
 
+    // 특정 타입과 대상 ID로 파일 조회 (sortOrder 순서대로)
     @EntityGraph(attributePaths = {"file"})
     List<FileAttachment> findByFileTargetTypeAndTargetIdOrderBySortOrder(
             FileTargetType fileTargetType, Long targetId);
@@ -18,10 +20,19 @@ public interface FileAttachmentRepository extends JpaRepository<FileAttachment, 
     List<FileAttachment> findByFileTargetTypeAndTargetId(
             FileTargetType fileTargetType, Long targetId);
 
-    // 대표 이미지 조회 (sortOrder=1)
+    // 대표 이미지 조회 (sortOrder 기반)
     @EntityGraph(attributePaths = {"file"})
     Optional<FileAttachment> findByFileTargetTypeAndTargetIdAndSortOrder(
             FileTargetType fileTargetType, Long targetId, Integer sortOrder);
+
+    // 대표 이미지 조회 (sortOrder + purpose 기반)
+    @EntityGraph(attributePaths = {"file"})
+    Optional<FileAttachment> findByFileTargetTypeAndTargetIdAndSortOrderAndPurpose(
+            FileTargetType fileTargetType,
+            Long targetId,
+            Integer sortOrder,
+            AttachmentPurpose purpose
+    );
 
     boolean existsByFileFileId(Long fileId);
 }

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/file/repository/FileAttachmentRepository.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/file/repository/FileAttachmentRepository.java
@@ -6,12 +6,22 @@ import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface FileAttachmentRepository extends JpaRepository<FileAttachment, Long> {
 
     @EntityGraph(attributePaths = {"file"})
     List<FileAttachment> findByFileTargetTypeAndTargetIdOrderBySortOrder(
             FileTargetType fileTargetType, Long targetId);
+
+    // 파일 전체 조회 (삭제용)
+    List<FileAttachment> findByFileTargetTypeAndTargetId(
+            FileTargetType fileTargetType, Long targetId);
+
+    // 대표 이미지 조회 (sortOrder=1)
+    @EntityGraph(attributePaths = {"file"})
+    Optional<FileAttachment> findByFileTargetTypeAndTargetIdAndSortOrder(
+            FileTargetType fileTargetType, Long targetId, Integer sortOrder);
 
     boolean existsByFileFileId(Long fileId);
 }

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/file/service/FileService.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/file/service/FileService.java
@@ -107,7 +107,7 @@ public class FileService {
      */
     @Transactional
     public List<FileAttachmentResponse> confirmFiles(List<Long> fileIds, FileTargetType fileTargetType,
-                                                      Long targetId, AttachmentPurpose purpose) {
+                                                     Long targetId, AttachmentPurpose purpose) {
         if (fileIds == null || fileIds.isEmpty()) {
             return new ArrayList<>();
         }
@@ -122,11 +122,10 @@ public class FileService {
         int sortOrder = 1;
 
         for (File file : files) {
-            // 파일 상태검증 추가
-            if (!file.isTemp()) {
-                throw new FileException(FILE_ALREADY_CONFIRMED);
+            // TEMP 파일만 PERMANENT로 변경 (이미 PERMANENT면 스킵)
+            if (file.isTemp()) {
+                file.confirm();
             }
-            file.confirm();
 
             FileAttachment attachment = FileAttachment.builder()
                     .file(file)

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/post/dto/PostCreateRequest.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/post/dto/PostCreateRequest.java
@@ -8,6 +8,8 @@ import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
+
 @Getter
 @NoArgsConstructor
 @Schema(description = "게시글 작성 요청")
@@ -32,4 +34,7 @@ public class PostCreateRequest {
 
     @Schema(description = "멘토링 요청 ID (멘토링 후기 작성 시)", nullable = true)
     private Long mentoringRequestId;
+
+    @Schema(description = "첨부 파일 ID 목록", nullable = true)
+    private List<Long> fileIds;
 }

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/post/dto/PostDetailResponse.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/post/dto/PostDetailResponse.java
@@ -7,6 +7,7 @@ import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Getter
 @Builder
@@ -27,6 +28,9 @@ public class PostDetailResponse {
 
     @Schema(description = "게시글 내용")
     private String postContent;
+
+    @Schema(description = "첨부 이미지 URL 목록")
+    private List<String> imageUrls;
 
     @Schema(description = "작성자 ID (익명일 경우 null)", example = "1", nullable = true)
     private Long authorId;
@@ -52,13 +56,16 @@ public class PostDetailResponse {
     @Schema(description = "수정 일시", example = "2026-01-28T15:00:00", nullable = true)
     private LocalDateTime updatedAt;
 
-    public static PostDetailResponse from(Post post, Long commentCount, Long likeCount, Boolean isLikedByUser, boolean isAnonymous) {
+    public static PostDetailResponse from(Post post, Long commentCount, Long likeCount,
+                                          Boolean isLikedByUser, boolean isAnonymous,
+                                          List<String> imageUrls) {
         return PostDetailResponse.builder()
                 .postId(post.getPostId())
                 .boardId(post.getBoard().getBoardId())
                 .postCategory(post.getPostCategory())
                 .postTitle(post.getPostTitle())
                 .postContent(post.getPostContent())
+                .imageUrls(imageUrls)
                 .authorId(isAnonymous ? null : post.getAuthor().getUserId())
                 .authorName(isAnonymous ? "익명" : post.getAuthor().getName())
                 .viewCount(post.getViewCount())
@@ -68,5 +75,11 @@ public class PostDetailResponse {
                 .createdAt(post.getCreatedAt())
                 .updatedAt(post.getUpdatedAt())
                 .build();
+    }
+
+    // 기존 호환성을 위한 오버로드 메서드
+    public static PostDetailResponse from(Post post, Long commentCount, Long likeCount,
+                                          Boolean isLikedByUser, boolean isAnonymous) {
+        return from(post, commentCount, likeCount, isLikedByUser, isAnonymous, List.of());
     }
 }

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/post/dto/PostUpdateRequest.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/post/dto/PostUpdateRequest.java
@@ -6,6 +6,8 @@ import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
+
 @Getter
 @NoArgsConstructor
 @Schema(description = "게시글 수정 요청")
@@ -19,4 +21,7 @@ public class PostUpdateRequest {
     @NotBlank(message = "내용은 필수입니다.")
     @Schema(description = "게시글 내용")
     private String postContent;
+
+    @Schema(description = "첨부 파일 ID 목록 (null=변경없음, []=전체삭제, [1,2,3]=교체)", nullable = true)
+    private List<Long> fileIds;
 }

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/post/service/PostService.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/post/service/PostService.java
@@ -137,7 +137,8 @@ public class PostService {
                         .stream()
                         .collect(Collectors.toMap(
                                 FileAttachment::getTargetId,
-                                attachment -> attachment.getFile().getUrl(region)
+                                attachment -> attachment.getFile().getUrl(region),
+                                (existing, replacement) -> existing  // 중복 키 처리
                         ));
             }
         } else {
@@ -153,7 +154,8 @@ public class PostService {
                         .stream()
                         .collect(Collectors.toMap(
                                 FileAttachment::getTargetId,
-                                attachment -> attachment.getFile().getUrl(region)
+                                attachment -> attachment.getFile().getUrl(region),
+                                (existing, replacement) -> existing  // 중복 키 처리
                         ));
             }
         }
@@ -312,29 +314,29 @@ public class PostService {
                     .filter(fileId -> !request.getFileIds().contains(fileId))
                     .toList();
 
-            // 4. 삭제할 파일은 완전 삭제 (File + S3)
+            // 4. 새로 추가할 파일 ID (요청에는 있지만 기존에는 없는 TEMP 파일)
+            List<Long> fileIdsToAdd = request.getFileIds().stream()
+                    .filter(fileId -> !existingFileIds.contains(fileId))
+                    .toList();
+
+            // 5. 삭제할 파일은 완전 삭제 (File + S3)
             for (FileAttachment attachment : existingAttachments) {
                 if (fileIdsToDelete.contains(attachment.getFile().getFileId())) {
                     fileService.detachFile(attachment.getFileAttachmentId());
                 }
             }
 
-            // 5. 유지할 파일의 Attachment만 삭제 (File은 유지)
-            for (FileAttachment attachment : existingAttachments) {
-                if (!fileIdsToDelete.contains(attachment.getFile().getFileId())) {
-                    fileAttachmentRepository.delete(attachment);
-                }
-            }
-
-            // 6. 새 파일 확정 (TEMP + PERMANENT 모두 처리)
-            if (!request.getFileIds().isEmpty()) {
+            // 6. 새 파일만 확정 (TEMP → PERMANENT)
+            if (!fileIdsToAdd.isEmpty()) {
                 fileService.confirmFiles(
-                        request.getFileIds(),
+                        fileIdsToAdd,
                         FileTargetType.POST,
                         postId,
                         AttachmentPurpose.POST_ATTACHMENT
                 );
             }
+
+            // 유지되는 PERMANENT 파일은 Attachment 그대로 유지
         }
         // fileIds가 null이면 파일 변경 없음 (기존 파일 유지)
 

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/post/service/PostService.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/post/service/PostService.java
@@ -130,10 +130,11 @@ public class PostService {
 
                     // 자치회 후기의 대표 이미지 조회 (COUNCIL_POST)
                     thumbnailImageUrl = fileAttachmentRepository
-                            .findByFileTargetTypeAndTargetIdAndSortOrder(
+                            .findByFileTargetTypeAndTargetIdAndSortOrderAndPurpose(
                                     FileTargetType.COUNCIL_POST,
                                     reviewPost.getCouncilReviewPostId(),
-                                    1
+                                    1,
+                                    AttachmentPurpose.POST_ATTACHMENT
                             )
                             .map(attachment -> attachment.getFile().getUrl(region))
                             .orElse(null);
@@ -141,10 +142,11 @@ public class PostService {
             } else {
                 // 통합 게시글의 대표 이미지 조회 (POST)
                 thumbnailImageUrl = fileAttachmentRepository
-                        .findByFileTargetTypeAndTargetIdAndSortOrder(
+                        .findByFileTargetTypeAndTargetIdAndSortOrderAndPurpose(
                                 FileTargetType.POST,
                                 post.getPostId(),
-                                1
+                                1,
+                                AttachmentPurpose.POST_ATTACHMENT
                         )
                         .map(attachment -> attachment.getFile().getUrl(region))
                         .orElse(null);

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/post/service/PostService.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/post/service/PostService.java
@@ -30,8 +30,10 @@ import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -112,6 +114,53 @@ public class PostService {
                         PostCommentCount::getCommentCount
                 ));
 
+        // N+1 해결: 대표 이미지를 배치로 조회
+        Map<Long, String> thumbnailUrlMap = new HashMap<>();
+
+        if (boardId == 1L) {
+            // 자치회 활동 후기: councilReviewPostId 수집
+            List<Long> councilReviewPostIds = posts.getContent().stream()
+                    .map(Post::getPostId)
+                    .map(postId -> councilReviewPostRepository.findByPostId(postId).orElse(null))
+                    .filter(Objects::nonNull)
+                    .map(CouncilReviewPost::getCouncilReviewPostId)
+                    .toList();
+
+            if (!councilReviewPostIds.isEmpty()) {
+                thumbnailUrlMap = fileAttachmentRepository
+                        .findByFileTargetTypeAndTargetIdInAndSortOrderAndPurpose(
+                                FileTargetType.COUNCIL_POST,
+                                councilReviewPostIds,
+                                1,
+                                AttachmentPurpose.POST_ATTACHMENT
+                        )
+                        .stream()
+                        .collect(Collectors.toMap(
+                                FileAttachment::getTargetId,
+                                attachment -> attachment.getFile().getUrl(region)
+                        ));
+            }
+        } else {
+            // 통합 게시글: postId 수집
+            if (!postIds.isEmpty()) {
+                thumbnailUrlMap = fileAttachmentRepository
+                        .findByFileTargetTypeAndTargetIdInAndSortOrderAndPurpose(
+                                FileTargetType.POST,
+                                postIds,
+                                1,
+                                AttachmentPurpose.POST_ATTACHMENT
+                        )
+                        .stream()
+                        .collect(Collectors.toMap(
+                                FileAttachment::getTargetId,
+                                attachment -> attachment.getFile().getUrl(region)
+                        ));
+            }
+        }
+
+        // 최종 thumbnailUrlMap 변수를 람다에서 사용하기 위해 final로 선언
+        final Map<Long, String> finalThumbnailUrlMap = thumbnailUrlMap;
+
         // Post -> PostListResponse 변환
         return posts.map(post -> {
             Long commentCount = commentCounts.getOrDefault(post.getPostId(), 0L);
@@ -127,29 +176,11 @@ public class PostService {
 
                 if (reviewPost != null) {
                     councilName = reviewPost.getCouncil().getCouncilName();
-
-                    // 자치회 후기의 대표 이미지 조회 (COUNCIL_POST)
-                    thumbnailImageUrl = fileAttachmentRepository
-                            .findByFileTargetTypeAndTargetIdAndSortOrderAndPurpose(
-                                    FileTargetType.COUNCIL_POST,
-                                    reviewPost.getCouncilReviewPostId(),
-                                    1,
-                                    AttachmentPurpose.POST_ATTACHMENT
-                            )
-                            .map(attachment -> attachment.getFile().getUrl(region))
-                            .orElse(null);
+                    thumbnailImageUrl = finalThumbnailUrlMap.get(reviewPost.getCouncilReviewPostId());
                 }
             } else {
-                // 통합 게시글의 대표 이미지 조회 (POST)
-                thumbnailImageUrl = fileAttachmentRepository
-                        .findByFileTargetTypeAndTargetIdAndSortOrderAndPurpose(
-                                FileTargetType.POST,
-                                post.getPostId(),
-                                1,
-                                AttachmentPurpose.POST_ATTACHMENT
-                        )
-                        .map(attachment -> attachment.getFile().getUrl(region))
-                        .orElse(null);
+                // Map에서 조회 (O(1))
+                thumbnailImageUrl = finalThumbnailUrlMap.get(post.getPostId());
             }
 
             return PostListResponse.from(post, commentCount, isAnonymous, councilName, thumbnailImageUrl);

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/post/service/PostService.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/post/service/PostService.java
@@ -8,6 +8,11 @@ import com.solif.backend.domain.comment.dto.PostCommentCount;
 import com.solif.backend.domain.comment.repository.CommentRepository;
 import com.solif.backend.domain.councilreview.entity.CouncilReviewPost;
 import com.solif.backend.domain.councilreview.repository.CouncilReviewPostRepository;
+import com.solif.backend.domain.file.entity.AttachmentPurpose;
+import com.solif.backend.domain.file.entity.FileAttachment;
+import com.solif.backend.domain.file.entity.FileTargetType;
+import com.solif.backend.domain.file.repository.FileAttachmentRepository;
+import com.solif.backend.domain.file.service.FileService;
 import com.solif.backend.domain.post.dto.*;
 import com.solif.backend.domain.post.entity.Post;
 import com.solif.backend.domain.post.entity.PostCategory;
@@ -19,6 +24,7 @@ import com.solif.backend.domain.user.repository.UserRepository;
 import com.solif.backend.global.common.exception.CustomException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
@@ -40,6 +46,11 @@ public class PostService {
     private final UserRepository userRepository;
     private final PostLikeRepository postLikeRepository;
     private final CouncilReviewPostRepository councilReviewPostRepository;
+    private final FileService fileService;
+    private final FileAttachmentRepository fileAttachmentRepository;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
 
     // 게시글 목록 조회
     public Slice<PostListResponse> getPosts(Long boardId, PostCategory category, Pageable pageable) {
@@ -103,7 +114,7 @@ public class PostService {
 
         // Post -> PostListResponse 변환
         return posts.map(post -> {
-            Long commentCount = commentRepository.countByPost_PostId(post.getPostId());
+            Long commentCount = commentCounts.getOrDefault(post.getPostId(), 0L);
 
             // 자치회 활동 후기인 경우 추가 정보 조회
             String councilName = null;
@@ -116,9 +127,27 @@ public class PostService {
 
                 if (reviewPost != null) {
                     councilName = reviewPost.getCouncil().getCouncilName();
-                    // TODO: 첫 번째 이미지 조회 (file_attachment 연동 후)
-                    thumbnailImageUrl = null;
+
+                    // 자치회 후기의 대표 이미지 조회 (COUNCIL_POST)
+                    thumbnailImageUrl = fileAttachmentRepository
+                            .findByFileTargetTypeAndTargetIdAndSortOrder(
+                                    FileTargetType.COUNCIL_POST,
+                                    reviewPost.getCouncilReviewPostId(),
+                                    1
+                            )
+                            .map(attachment -> attachment.getFile().getUrl(region))
+                            .orElse(null);
                 }
+            } else {
+                // 통합 게시글의 대표 이미지 조회 (POST)
+                thumbnailImageUrl = fileAttachmentRepository
+                        .findByFileTargetTypeAndTargetIdAndSortOrder(
+                                FileTargetType.POST,
+                                post.getPostId(),
+                                1
+                        )
+                        .map(attachment -> attachment.getFile().getUrl(region))
+                        .orElse(null);
             }
 
             return PostListResponse.from(post, commentCount, isAnonymous, councilName, thumbnailImageUrl);
@@ -154,7 +183,15 @@ public class PostService {
         // 현재 사용자의 좋아요 여부 조회
         Boolean isLikedByUser = postLikeRepository.existsByUser_UserIdAndPost_PostId(userId, postId);
 
-        return PostDetailResponse.from(post, commentCount, likeCount, isLikedByUser, isAnonymous);
+        // 첨부 이미지 조회
+        List<FileAttachment> attachments = fileAttachmentRepository
+                .findByFileTargetTypeAndTargetIdOrderBySortOrder(FileTargetType.POST, postId);
+
+        List<String> imageUrls = attachments.stream()
+                .map(attachment -> attachment.getFile().getUrl(region))
+                .toList();
+
+        return PostDetailResponse.from(post, commentCount, likeCount, isLikedByUser, isAnonymous, imageUrls);
     }
 
     // 게시글 작성
@@ -184,6 +221,16 @@ public class PostService {
 
         // 저장
         Post savedPost = postRepository.save(post);
+
+        // 파일 확정 (fileIds가 있으면)
+        if (request.getFileIds() != null && !request.getFileIds().isEmpty()) {
+            fileService.confirmFiles(
+                    request.getFileIds(),
+                    FileTargetType.POST,
+                    savedPost.getPostId(),
+                    AttachmentPurpose.POST_ATTACHMENT
+            );
+        }
 
         // TODO: mentoringRequestId 처리 (나중에 멘토링 도메인 구현 시)
         // if (request.getMentoringRequestId() != null) {
@@ -215,6 +262,50 @@ public class PostService {
 
         // 게시글 수정
         post.updatePost(request.getPostTitle(), request.getPostContent());
+
+        // 파일 처리 (fileIds가 null이 아닐 때만)
+        if (request.getFileIds() != null) {
+            // 1. 기존 FileAttachment 조회
+            List<FileAttachment> existingAttachments = fileAttachmentRepository
+                    .findByFileTargetTypeAndTargetId(FileTargetType.POST, postId);
+
+            // 2. 기존 파일 ID 목록
+            List<Long> existingFileIds = existingAttachments.stream()
+                    .map(attachment -> attachment.getFile().getFileId())
+                    .toList();
+
+            // 3. 삭제할 파일 ID (기존에는 있지만 요청에는 없는 파일)
+            List<Long> fileIdsToDelete = existingFileIds.stream()
+                    .filter(fileId -> !request.getFileIds().contains(fileId))
+                    .toList();
+
+            // 4. 삭제할 파일은 완전 삭제 (File + S3)
+            for (FileAttachment attachment : existingAttachments) {
+                if (fileIdsToDelete.contains(attachment.getFile().getFileId())) {
+                    fileService.detachFile(attachment.getFileAttachmentId());
+                }
+            }
+
+            // 5. 유지할 파일의 Attachment만 삭제 (File은 유지)
+            for (FileAttachment attachment : existingAttachments) {
+                if (!fileIdsToDelete.contains(attachment.getFile().getFileId())) {
+                    fileAttachmentRepository.delete(attachment);
+                }
+            }
+
+            // 6. 새 파일 확정 (TEMP + PERMANENT 모두 처리)
+            if (!request.getFileIds().isEmpty()) {
+                fileService.confirmFiles(
+                        request.getFileIds(),
+                        FileTargetType.POST,
+                        postId,
+                        AttachmentPurpose.POST_ATTACHMENT
+                );
+            }
+        }
+        // fileIds가 null이면 파일 변경 없음 (기존 파일 유지)
+
+        log.info("게시글 수정 완료 - postId: {}", postId);
     }
 
     // 게시글 삭제 (Soft Delete)


### PR DESCRIPTION
## 🔍 개요
기존에 구현된 File 업로드(S3 저장) 및 File-도메인 연결 로직을
자치회 활동 후기 서비스 및 OCR 기능에 실제로 연동하고 통합 테스트를 진행했다.

## ✨ 변경 사항
- 자치회 활동 후기 Service에 fileId 연동 로직 추가
- OCR API에서 fileId 기반으로 S3 이미지 조회 및 처리 흐름 검증
- File 상태(TEMP → USED) 전환 로직 연동 확인
- File 업로드 → 도메인 연결 → OCR 처리 전체 플로우 통합 테스트

## 🧪 테스트
- [x] 로컬 테스트 완료
- [x] API 테스트 완료
- [ ] 테스트 코드 작성 (해당 시)

## 📎 관련 이슈
Closes: #77 

## ⚠️ 참고 사항
- File 업로드 API 및 S3 설정은 기존 구현을 그대로 사용합니다.
- OCR 기능은 File 기반 부가기능으로 동작하며,
  활동 후기 작성 로직과는 직접적으로 결합되지 않습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# 릴리스 노트

* **New Features**
  * 게시물 및 의회 검토 게시물에 파일(이미지/영수증) 첨부 등록 및 관리 기능 추가
  * 의회 검토 작성 시 영수증 파일 ID 필수화(영수증 OCR 연동)
  * 게시물·의회 상세에서 이미지 URL 및 목록 표시, 목록에서 썸네일 노출 개선

* **Refactor**
  * 파일 첨부 확인/연결/해제 흐름 통합 및 첨부 관련 처리 최적화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->