### PR TITLE
feat: 성장 도메인 API 구현 (미션/배지/활동)

### DIFF
--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/auth/service/AuthService.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/auth/service/AuthService.java
@@ -5,6 +5,7 @@ import com.solif.backend.domain.auth.dto.LoginResponse;
 import com.solif.backend.domain.auth.dto.SignupRequest;
 import com.solif.backend.domain.auth.dto.SignupResponse;
 import com.solif.backend.domain.auth.exception.AuthErrorCode;
+import com.solif.backend.domain.mission.service.MissionService;
 import com.solif.backend.domain.user.entity.User;
 import com.solif.backend.domain.user.repository.UserRepository;
 import com.solif.backend.global.common.exception.CustomException;
@@ -24,6 +25,7 @@ public class AuthService {
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
     private final JwtUtil jwtUtil;
+    private final MissionService missionService;
 
     //회원가입
     @Transactional
@@ -54,6 +56,9 @@ public class AuthService {
                 .build();
 
         User savedUser = userRepository.save(user);
+
+        // 미션 초기화 (9개 미션 생성)
+        missionService.initializeUserMissions(savedUser);
         log.info("회원가입 성공 - userId: {}", savedUser.getUserId());
 
         return SignupResponse.of(savedUser.getUserId(), savedUser.getUserRole(), savedUser.getCreatedAt());

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/auth/service/AuthService.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/auth/service/AuthService.java
@@ -58,7 +58,12 @@ public class AuthService {
         User savedUser = userRepository.save(user);
 
         // 미션 초기화 (9개 미션 생성)
-        missionService.initializeUserMissions(savedUser);
+        try {
+            missionService.initializeUserMissions(savedUser);
+        } catch (Exception e) {
+            log.warn("미션 초기화 실패 - userId: {}, error: {}", savedUser.getUserId(), e.getMessage());
+        }
+
         log.info("회원가입 성공 - userId: {}", savedUser.getUserId());
 
         return SignupResponse.of(savedUser.getUserId(), savedUser.getUserRole(), savedUser.getCreatedAt());

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/comment/repository/CommentRepository.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/comment/repository/CommentRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.repository.query.Param;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
@@ -39,4 +40,7 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
                         PostCommentCount::getCommentCount
                 ));
     }
+
+    // 사용자가 첫 번째 작성한 댓글
+    Optional<Comment> findFirstByUser_UserIdOrderByCreatedAtAsc(Long userId);
 }

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/message/repository/MessageRepository.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/message/repository/MessageRepository.java
@@ -7,6 +7,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.Optional;
+
 public interface MessageRepository extends JpaRepository<Message, Long> {
 
     // 받은 쪽지 목록 (삭제되지 않은 것만)
@@ -22,4 +24,13 @@ public interface MessageRepository extends JpaRepository<Message, Long> {
             "AND m.deletedBySender = false " +
             "ORDER BY m.createdAt DESC")
     Slice<Message> findSentMessages(@Param("userId") Long userId, Pageable pageable);
+
+    // 첫 번째 보낸 쪽지 조회
+    Optional<Message> findFirstBySender_UserIdOrderByCreatedAtAsc(Long senderId);
+
+    // 특정 사용자 간 쪽지 존재 여부
+    boolean existsBySender_UserIdAndReceiver_UserId(Long senderId, Long receiverId);
+
+    // 특정 사용자 간 첫 쪽지 조회
+    Optional<Message> findFirstBySender_UserIdAndReceiver_UserIdOrderByCreatedAtAsc(Long senderId, Long receiverId);
 }

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/mission/code/MissionErrorCode.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/mission/code/MissionErrorCode.java
@@ -1,0 +1,23 @@
+package com.solif.backend.domain.mission.code;
+
+import com.solif.backend.global.common.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum MissionErrorCode implements ErrorCode {
+
+    MISSION_NOT_FOUND(HttpStatus.NOT_FOUND, "MISSION_001", "미션을 찾을 수 없습니다."),
+    USER_MISSION_NOT_FOUND(HttpStatus.NOT_FOUND, "MISSION_002", "사용자 미션을 찾을 수 없습니다."),
+    MISSION_ALREADY_COMPLETED(HttpStatus.BAD_REQUEST, "MISSION_003", "이미 완료된 미션입니다."),
+    PINECONE_NOT_FOUND(HttpStatus.NOT_FOUND, "MISSION_004", "솔방울을 찾을 수 없습니다."),
+    PINECONE_ALREADY_EARNED(HttpStatus.BAD_REQUEST, "MISSION_005", "이미 획득한 솔방울입니다."),
+    CATEGORY_MISSIONS_NOT_COMPLETED(HttpStatus.BAD_REQUEST, "MISSION_006", "해당 카테고리의 모든 미션을 완료해야 솔방울을 받을 수 있습니다."),
+    INVALID_SEASON_KEY(HttpStatus.BAD_REQUEST, "MISSION_007", "유효하지 않은 시즌입니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/mission/code/MissionSuccessCode.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/mission/code/MissionSuccessCode.java
@@ -1,0 +1,21 @@
+package com.solif.backend.domain.mission.code;
+
+import com.solif.backend.global.common.response.SuccessCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum MissionSuccessCode implements SuccessCode {
+
+    MISSION_LIST_SUCCESS(HttpStatus.OK, "MISSION_200", "미션 목록 조회에 성공했습니다."),
+    MISSION_PROGRESS_SUCCESS(HttpStatus.OK, "MISSION_201", "미션 진행 상황 조회에 성공했습니다."),
+    PINECONE_EARNED_SUCCESS(HttpStatus.OK, "MISSION_202", "솔방울 획득에 성공했습니다."),
+    PINECONE_MEMORY_SUCCESS(HttpStatus.OK, "MISSION_203", "솔방울 추억 조회에 성공했습니다."),
+    MISSION_COMPLETED(HttpStatus.OK, "MISSION_204", "미션을 완료했습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/mission/controller/MissionController.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/mission/controller/MissionController.java
@@ -1,0 +1,70 @@
+package com.solif.backend.domain.mission.controller;
+
+import com.solif.backend.domain.mission.code.MissionSuccessCode;
+import com.solif.backend.domain.mission.dto.MissionProgressResponse;
+import com.solif.backend.domain.mission.dto.PineconeEarnResponse;
+import com.solif.backend.domain.mission.dto.PineconeMemoryResponse;
+import com.solif.backend.domain.mission.entity.MissionCategory;
+import com.solif.backend.domain.mission.service.MissionService;
+import com.solif.backend.global.common.response.ResponseFactory;
+import com.solif.backend.global.common.response.SuccessResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "미션 API", description = "성장 페이지 - 미션 시스템 관련 API")
+@RestController
+@RequestMapping("/api/v1/missions")
+@RequiredArgsConstructor
+public class MissionController {
+
+    private final MissionService missionService;
+
+    @Operation(
+            summary = "미션 진행 상황 조회",
+            description = "성장 탭에서 현재 미션 진행 상황을 조회합니다. (솔방울 개수, D-Day, 카테고리별 진행도, 이번주 미션)",
+            security = @SecurityRequirement(name = "Bearer Authentication")
+    )
+    @GetMapping("/progress")
+    public ResponseEntity<SuccessResponse<MissionProgressResponse>> getMissionProgress(
+            @Parameter(hidden = true) @AuthenticationPrincipal Long userId
+    ) {
+        MissionProgressResponse response = missionService.getMissionProgress(userId);
+        return ResponseFactory.success(MissionSuccessCode.MISSION_PROGRESS_SUCCESS, response);
+    }
+
+    @Operation(
+            summary = "솔방울 획득 (받기 버튼)",
+            description = "카테고리별 미션 3개를 모두 완료한 후 솔방울을 획득합니다.",
+            security = @SecurityRequirement(name = "Bearer Authentication")
+    )
+    @PostMapping("/pinecones/{category}")
+    public ResponseEntity<SuccessResponse<PineconeEarnResponse>> earnPinecone(
+            @Parameter(hidden = true) @AuthenticationPrincipal Long userId,
+            @Parameter(description = "카테고리 (CONNECT/GROW/IMPACT)", required = true)
+            @PathVariable MissionCategory category
+    ) {
+        PineconeEarnResponse response = missionService.earnPinecone(userId, category);
+        return ResponseFactory.success(MissionSuccessCode.PINECONE_EARNED_SUCCESS, response);
+    }
+
+    @Operation(
+            summary = "솔방울 추억 회상",
+            description = "획득한 솔방울을 클릭하여 완료한 미션 3개의 추억을 조회합니다.",
+            security = @SecurityRequirement(name = "Bearer Authentication")
+    )
+    @GetMapping("/pinecones/{category}/memories")
+    public ResponseEntity<SuccessResponse<PineconeMemoryResponse>> getPineconeMemory(
+            @Parameter(hidden = true) @AuthenticationPrincipal Long userId,
+            @Parameter(description = "카테고리 (CONNECT/GROW/IMPACT)", required = true)
+            @PathVariable MissionCategory category
+    ) {
+        PineconeMemoryResponse response = missionService.getPineconeMemory(userId, category);
+        return ResponseFactory.success(MissionSuccessCode.PINECONE_MEMORY_SUCCESS, response);
+    }
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/mission/dto/MissionProgressResponse.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/mission/dto/MissionProgressResponse.java
@@ -1,0 +1,88 @@
+package com.solif.backend.domain.mission.dto;
+
+import com.solif.backend.domain.mission.entity.MissionCategory;
+import com.solif.backend.domain.mission.entity.MissionStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+@Schema(description = "성장 탭 - 미션 진행 상황 응답")
+public class MissionProgressResponse {
+
+    @Schema(description = "현재 시즌 (예: 2026-H1)")
+    private String currentSeason;
+
+    @Schema(description = "획득한 솔방울 개수 (0~3)")
+    private Integer earnedPineconeCount;
+
+    @Schema(description = "D-Day (상반기 종료까지 남은 일수)")
+    private Integer daysUntilSeasonEnd;
+
+    @Schema(description = "상반기 미션 리스트 (카테고리별 솔방울 획득 상태)")
+    private List<CategoryProgress> categoryProgress;
+
+    @Schema(description = "이번주 미션 리스트 (최대 3개)")
+    private List<WeeklyMissionCard> weeklyMissions;
+
+    @Getter
+    @Builder
+    @Schema(description = "카테고리별 솔방울 획득 상태")
+    public static class CategoryProgress {
+        @Schema(description = "카테고리 (CONNECT/GROW/IMPACT)")
+        private MissionCategory category;
+
+        @Schema(description = "카테고리명 (연결/성장/기여)")
+        private String categoryName;
+
+        @Schema(description = "완료된 미션 수 (0~3)")
+        private Integer completedCount;
+
+        @Schema(description = "전체 미션 수 (3)")
+        private Integer totalCount;
+
+        @Schema(description = "솔방울 획득 여부")
+        private Boolean isPineconeEarned;
+
+        @Schema(description = "솔방울 수령 가능 여부 (3개 모두 완료 && 아직 미수령)")
+        private Boolean canClaimPinecone;
+    }
+
+    @Getter
+    @Builder
+    @Schema(description = "이번주 미션 카드")
+    public static class WeeklyMissionCard {
+        @Schema(description = "미션 ID")
+        private Long missionId;
+
+        @Schema(description = "카테고리 (CONNECT/GROW/IMPACT)")
+        private MissionCategory category;
+
+        @Schema(description = "카테고리명 (연결/성장/기여)")
+        private String categoryName;
+
+        @Schema(description = "미션 제목")
+        private String missionTitle;
+
+        @Schema(description = "미션 설명")
+        private String description;
+
+        @Schema(description = "진행도 (예: 2/5)")
+        private String progress;
+
+        @Schema(description = "현재 진행 수")
+        private Integer currentCount;
+
+        @Schema(description = "목표 수")
+        private Integer targetCount;
+
+        @Schema(description = "미션 상태 (IN_PROGRESS/COMPLETED)")
+        private MissionStatus status;
+
+        @Schema(description = "완료 여부")
+        private Boolean isCompleted;
+    }
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/mission/dto/PineconeEarnResponse.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/mission/dto/PineconeEarnResponse.java
@@ -1,0 +1,29 @@
+package com.solif.backend.domain.mission.dto;
+
+import com.solif.backend.domain.mission.entity.MissionCategory;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@Schema(description = "솔방울 획득 응답")
+public class PineconeEarnResponse {
+
+    @Schema(description = "솔방울 ID")
+    private Long pineconeId;
+
+    @Schema(description = "카테고리 (CONNECT/GROW/IMPACT)")
+    private MissionCategory category;
+
+    @Schema(description = "카테고리명 (연결/성장/기여)")
+    private String categoryName;
+
+    @Schema(description = "시즌 (예: 2026-H1)")
+    private String seasonKey;
+
+    @Schema(description = "획득 시각")
+    private LocalDateTime earnedAt;
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/mission/dto/PineconeMemoryResponse.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/mission/dto/PineconeMemoryResponse.java
@@ -1,0 +1,57 @@
+package com.solif.backend.domain.mission.dto;
+
+import com.solif.backend.domain.mission.entity.MissionCategory;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+@Schema(description = "솔방울 추억 회상 응답")
+public class PineconeMemoryResponse {
+
+    @Schema(description = "카테고리 (CONNECT/GROW/IMPACT)")
+    private MissionCategory category;
+
+    @Schema(description = "카테고리명 (연결/성장/기여)")
+    private String categoryName;
+
+    @Schema(description = "완료한 미션 3개")
+    private List<CompletedMission> completedMissions;
+
+    @Getter
+    @Builder
+    @Schema(description = "완료한 미션 상세")
+    public static class CompletedMission {
+        @Schema(description = "미션 제목")
+        private String missionTitle;
+
+        @Schema(description = "미션 완료 여부")
+        private Boolean isCompleted;
+
+        @Schema(description = "추억 상세 조회 가능 여부")
+        private Boolean hasMemoryDetail;
+
+        @Schema(description = "추억 상세 (있을 경우)")
+        private MemoryDetail memoryDetail;
+    }
+
+    @Getter
+    @Builder
+    @Schema(description = "추억 상세")
+    public static class MemoryDetail {
+        @Schema(description = "추억 타입 (MESSAGE/POST/COMMENT/MENTORING)")
+        private String memoryType;
+
+        @Schema(description = "추억 제목/내용")
+        private String memoryContent;
+
+        @Schema(description = "추억 관련 사용자명 (있을 경우)")
+        private String relatedUserName;
+
+        @Schema(description = "추억 생성 시각")
+        private String createdAt;
+    }
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/mission/entity/Mission.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/mission/entity/Mission.java
@@ -1,0 +1,59 @@
+package com.solif.backend.domain.mission.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "mission")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class Mission {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "mission_id")
+    private Long missionId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "mission_category", nullable = false, length = 20)
+    private MissionCategory missionCategory;
+
+    @Column(name = "sequence_order", nullable = false)
+    private Integer sequenceOrder;
+
+    @Column(name = "mission_title", nullable = false, length = 100)
+    private String missionTitle;
+
+    @Column(name = "description", nullable = false, columnDefinition = "TEXT")
+    private String description;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "condition_type", nullable = false, length = 50)
+    private MissionConditionType conditionType;
+
+    @Column(name = "condition_value", length = 255)
+    private String conditionValue;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Builder
+    public Mission(MissionCategory missionCategory, Integer sequenceOrder, String missionTitle,
+                   String description, MissionConditionType conditionType, String conditionValue) {
+        this.missionCategory = missionCategory;
+        this.sequenceOrder = sequenceOrder;
+        this.missionTitle = missionTitle;
+        this.description = description;
+        this.conditionType = conditionType;
+        this.conditionValue = conditionValue;
+    }
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/mission/entity/MissionCategory.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/mission/entity/MissionCategory.java
@@ -1,0 +1,7 @@
+package com.solif.backend.domain.mission.entity;
+
+public enum MissionCategory {
+    CONNECT,  // 연결
+    GROW,     // 성장
+    IMPACT    // 기여
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/mission/entity/MissionConditionType.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/mission/entity/MissionConditionType.java
@@ -1,0 +1,13 @@
+package com.solif.backend.domain.mission.entity;
+
+public enum MissionConditionType {
+    PROFILE_VIEW,           // 프로필 조회
+    CONNECTION_ACTION,      // 응원/경험나누기
+    MESSAGE,                // 쪽지 발송
+    PROFILE_COMPLETE,       // 프로필 완성
+    MESSAGE_THREAD,         // 경험나누기 → 쪽지 대화
+    POST_VIEW,              // 재단 소식 조회
+    POST_CREATE,            // 활동 게시글 작성
+    COMMENT_CREATE,         // 댓글 작성
+    MENTORING_COMPLETE      // 멘토링 완료
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/mission/entity/MissionStatus.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/mission/entity/MissionStatus.java
@@ -1,0 +1,6 @@
+package com.solif.backend.domain.mission.entity;
+
+public enum MissionStatus {
+    IN_PROGRESS,  // 진행 중
+    COMPLETED     // 완료
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/mission/entity/PineconeMemory.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/mission/entity/PineconeMemory.java
@@ -1,0 +1,46 @@
+package com.solif.backend.domain.mission.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "pinecone_memory")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class PineconeMemory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "pinecone_memory_id")
+    private Long pineconeMemoryId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_pinecone_id", nullable = false)
+    private UserPinecone userPinecone;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "source_type", nullable = false, length = 50)
+    private PineconeSourceType sourceType;
+
+    @Column(name = "source_id", nullable = false)
+    private Long sourceId;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Builder
+    public PineconeMemory(UserPinecone userPinecone, PineconeSourceType sourceType, Long sourceId) {
+        this.userPinecone = userPinecone;
+        this.sourceType = sourceType;
+        this.sourceId = sourceId;
+    }
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/mission/entity/PineconeMemory.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/mission/entity/PineconeMemory.java
@@ -33,14 +33,20 @@ public class PineconeMemory {
     @Column(name = "source_id", nullable = false)
     private Long sourceId;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "condition_type", nullable = false, length = 50)
+    private MissionConditionType conditionType;
+
     @CreatedDate
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
     @Builder
-    public PineconeMemory(UserPinecone userPinecone, PineconeSourceType sourceType, Long sourceId) {
+    public PineconeMemory(UserPinecone userPinecone, PineconeSourceType sourceType,
+                          Long sourceId, MissionConditionType conditionType) {
         this.userPinecone = userPinecone;
         this.sourceType = sourceType;
         this.sourceId = sourceId;
+        this.conditionType = conditionType;
     }
 }

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/mission/entity/PineconeSourceType.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/mission/entity/PineconeSourceType.java
@@ -1,0 +1,8 @@
+package com.solif.backend.domain.mission.entity;
+
+public enum PineconeSourceType {
+    MESSAGE,      // 쪽지
+    POST,         // 게시글
+    COMMENT,      // 댓글
+    MENTORING     // 멘토링
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/mission/entity/UserMission.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/mission/entity/UserMission.java
@@ -1,0 +1,83 @@
+package com.solif.backend.domain.mission.entity;
+
+import com.solif.backend.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "user_mission",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_user_mission",
+                columnNames = {"user_id", "mission_id"}
+        )
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class UserMission {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_mission_id")
+    private Long userMissionId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "mission_id", nullable = false)
+    private Mission mission;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 20)
+    private MissionStatus status = MissionStatus.IN_PROGRESS;
+
+    @Column(name = "started_at", nullable = false)
+    private LocalDateTime startedAt;
+
+    @Column(name = "completed_at")
+    private LocalDateTime completedAt;
+
+    @Column(name = "progress_count", nullable = false)
+    private Integer progressCount = 0;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Builder
+    public UserMission(User user, Mission mission) {
+        this.user = user;
+        this.mission = mission;
+        this.status = MissionStatus.IN_PROGRESS;
+        this.startedAt = LocalDateTime.now();
+        this.progressCount = 0;
+    }
+
+    // 비즈니스 로직
+    public void incrementProgress() {
+        this.progressCount++;
+    }
+
+    public void complete() {
+        this.status = MissionStatus.COMPLETED;
+        this.completedAt = LocalDateTime.now();
+    }
+
+    public boolean isCompleted() {
+        return this.status == MissionStatus.COMPLETED;
+    }
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/mission/entity/UserPinecone.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/mission/entity/UserPinecone.java
@@ -1,0 +1,56 @@
+package com.solif.backend.domain.mission.entity;
+
+import com.solif.backend.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "user_pinecone",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_user_pinecone_season",
+                columnNames = {"user_id", "pinecone_category", "season_key"}
+        )
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class UserPinecone {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_pinecone_id")
+    private Long userPineconeId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "pinecone_category", nullable = false, length = 20)
+    private MissionCategory pineconeCategory;
+
+    @Column(name = "season_key", nullable = false, length = 20)
+    private String seasonKey;
+
+    @Column(name = "earned_at", nullable = false)
+    private LocalDateTime earnedAt;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Builder
+    public UserPinecone(User user, MissionCategory pineconeCategory, String seasonKey) {
+        this.user = user;
+        this.pineconeCategory = pineconeCategory;
+        this.seasonKey = seasonKey;
+        this.earnedAt = LocalDateTime.now();
+    }
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/mission/repository/MissionRepository.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/mission/repository/MissionRepository.java
@@ -1,0 +1,19 @@
+package com.solif.backend.domain.mission.repository;
+
+import com.solif.backend.domain.mission.entity.Mission;
+import com.solif.backend.domain.mission.entity.MissionCategory;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface MissionRepository extends JpaRepository<Mission, Long> {
+
+    List<Mission> findAllByOrderByMissionCategoryAscSequenceOrderAsc();
+
+    List<Mission> findByMissionCategoryOrderBySequenceOrderAsc(MissionCategory category);
+
+    Optional<Mission> findByMissionCategoryAndSequenceOrder(MissionCategory category, Integer sequenceOrder);
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/mission/repository/MissionRepository.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/mission/repository/MissionRepository.java
@@ -2,6 +2,7 @@ package com.solif.backend.domain.mission.repository;
 
 import com.solif.backend.domain.mission.entity.Mission;
 import com.solif.backend.domain.mission.entity.MissionCategory;
+import com.solif.backend.domain.mission.entity.MissionConditionType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -16,4 +17,7 @@ public interface MissionRepository extends JpaRepository<Mission, Long> {
     List<Mission> findByMissionCategoryOrderBySequenceOrderAsc(MissionCategory category);
 
     Optional<Mission> findByMissionCategoryAndSequenceOrder(MissionCategory category, Integer sequenceOrder);
+
+    // ConditionType으로 미션 조회
+    Optional<Mission> findByConditionType(MissionConditionType conditionType);
 }

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/mission/repository/PineconeMemoryRepository.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/mission/repository/PineconeMemoryRepository.java
@@ -1,0 +1,16 @@
+package com.solif.backend.domain.mission.repository;
+
+import com.solif.backend.domain.mission.entity.PineconeMemory;
+import com.solif.backend.domain.mission.entity.UserPinecone;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface PineconeMemoryRepository extends JpaRepository<PineconeMemory, Long> {
+
+    List<PineconeMemory> findByUserPinecone(UserPinecone userPinecone);
+
+    List<PineconeMemory> findByUserPineconeOrderByCreatedAtAsc(UserPinecone userPinecone);
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/mission/repository/UserMissionRepository.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/mission/repository/UserMissionRepository.java
@@ -36,5 +36,13 @@ public interface UserMissionRepository extends JpaRepository<UserMission, Long> 
             @Param("status") MissionStatus status
     );
 
-    List<UserMission> findByUserAndMission_MissionCategory(User user, MissionCategory category);
+    @Query("SELECT um FROM UserMission um " +
+            "JOIN FETCH um.mission m " +
+            "WHERE um.user = :user " +
+            "AND m.missionCategory = :category " +
+            "ORDER BY m.sequenceOrder ASC")
+    List<UserMission> findByUserAndMission_MissionCategory(
+            @Param("user") User user,
+            @Param("category") MissionCategory category
+    );
 }

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/mission/repository/UserMissionRepository.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/mission/repository/UserMissionRepository.java
@@ -1,0 +1,40 @@
+package com.solif.backend.domain.mission.repository;
+
+import com.solif.backend.domain.mission.entity.Mission;
+import com.solif.backend.domain.mission.entity.MissionCategory;
+import com.solif.backend.domain.mission.entity.MissionStatus;
+import com.solif.backend.domain.mission.entity.UserMission;
+import com.solif.backend.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface UserMissionRepository extends JpaRepository<UserMission, Long> {
+
+    Optional<UserMission> findByUserAndMission(User user, Mission mission);
+
+    List<UserMission> findByUser(User user);
+
+    @Query("SELECT um FROM UserMission um " +
+            "JOIN FETCH um.mission m " +
+            "WHERE um.user = :user " +
+            "ORDER BY m.missionCategory ASC, m.sequenceOrder ASC")
+    List<UserMission> findByUserWithMission(@Param("user") User user);
+
+    @Query("SELECT COUNT(um) FROM UserMission um " +
+            "WHERE um.user = :user " +
+            "AND um.mission.missionCategory = :category " +
+            "AND um.status = :status")
+    Long countByUserAndCategoryAndStatus(
+            @Param("user") User user,
+            @Param("category") MissionCategory category,
+            @Param("status") MissionStatus status
+    );
+
+    List<UserMission> findByUserAndMission_MissionCategory(User user, MissionCategory category);
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/mission/repository/UserPineconeRepository.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/mission/repository/UserPineconeRepository.java
@@ -1,0 +1,26 @@
+package com.solif.backend.domain.mission.repository;
+
+import com.solif.backend.domain.mission.entity.MissionCategory;
+import com.solif.backend.domain.mission.entity.UserPinecone;
+import com.solif.backend.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface UserPineconeRepository extends JpaRepository<UserPinecone, Long> {
+
+    List<UserPinecone> findByUserAndSeasonKey(User user, String seasonKey);
+
+    Optional<UserPinecone> findByUserAndPineconeCategoryAndSeasonKey(
+            User user, MissionCategory category, String seasonKey
+    );
+
+    boolean existsByUserAndPineconeCategoryAndSeasonKey(
+            User user, MissionCategory category, String seasonKey
+    );
+
+    Long countByUserAndSeasonKey(User user, String seasonKey);
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/mission/service/MissionService.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/mission/service/MissionService.java
@@ -153,7 +153,7 @@ public class MissionService {
         List<PineconeMemoryResponse.CompletedMission> completedMissions = new ArrayList<>();
 
         for (PineconeMemory memory : memories) {
-            MissionConditionType conditionType = getMissionConditionTypeFromMemory(memory);
+            MissionConditionType conditionType = memory.getConditionType();
             String missionTitle = getMissionTitleByConditionType(conditionType);
 
             boolean hasMemoryDetail = hasMemoryDetail(memory.getSourceType());
@@ -487,6 +487,7 @@ public class MissionService {
                     .userPinecone(pinecone)
                     .sourceType(sourceType)
                     .sourceId(sourceId)
+                    .conditionType(conditionType)
                     .build();
             pineconeMemoryRepository.save(memory);
         }
@@ -613,14 +614,14 @@ public class MissionService {
     }
 
     // Memory에서 ConditionType 추출
-    private MissionConditionType getMissionConditionTypeFromMemory(PineconeMemory memory) {
-        return switch (memory.getSourceType()) {
-            case MESSAGE -> MissionConditionType.MESSAGE;
-            case POST -> MissionConditionType.POST_CREATE;
-            case COMMENT -> MissionConditionType.COMMENT_CREATE;
-            case MENTORING -> MissionConditionType.MENTORING_COMPLETE;
-        };
-    }
+//    private MissionConditionType getMissionConditionTypeFromMemory(PineconeMemory memory) {
+//        return switch (memory.getSourceType()) {
+//            case MESSAGE -> MissionConditionType.MESSAGE;
+//            case POST -> MissionConditionType.POST_CREATE;
+//            case COMMENT -> MissionConditionType.COMMENT_CREATE;
+//            case MENTORING -> MissionConditionType.MENTORING_COMPLETE;
+//        };
+//    }
 
     // 회원가입 완료 후 미션 초기화
     @Transactional

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/mission/service/MissionService.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/mission/service/MissionService.java
@@ -1,5 +1,6 @@
 package com.solif.backend.domain.mission.service;
 
+import com.solif.backend.domain.auth.code.AuthErrorCode;
 import com.solif.backend.domain.comment.entity.Comment;
 import com.solif.backend.domain.comment.repository.CommentRepository;
 import com.solif.backend.domain.message.entity.Message;
@@ -259,7 +260,7 @@ public class MissionService {
 
     private User findUserById(Long userId) {
         return userRepository.findById(userId)
-                .orElseThrow(() -> new CustomException(MissionErrorCode.USER_MISSION_NOT_FOUND));
+                .orElseThrow(() -> new CustomException(AuthErrorCode.USER_NOT_FOUND));
     }
 
     // 현재 시즌 키 계산 (2026-H1, 2026-H2)

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/mission/service/MissionService.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/mission/service/MissionService.java
@@ -1,0 +1,636 @@
+package com.solif.backend.domain.mission.service;
+
+import com.solif.backend.domain.comment.entity.Comment;
+import com.solif.backend.domain.comment.repository.CommentRepository;
+import com.solif.backend.domain.message.entity.Message;
+import com.solif.backend.domain.message.repository.MessageRepository;
+import com.solif.backend.domain.mission.code.MissionErrorCode;
+import com.solif.backend.domain.mission.dto.MissionProgressResponse;
+import com.solif.backend.domain.mission.dto.PineconeEarnResponse;
+import com.solif.backend.domain.mission.dto.PineconeMemoryResponse;
+import com.solif.backend.domain.mission.entity.*;
+import com.solif.backend.domain.mission.repository.MissionRepository;
+import com.solif.backend.domain.mission.repository.PineconeMemoryRepository;
+import com.solif.backend.domain.mission.repository.UserMissionRepository;
+import com.solif.backend.domain.mission.repository.UserPineconeRepository;
+import com.solif.backend.domain.notification.entity.Notification;
+import com.solif.backend.domain.notification.entity.NotificationType;
+import com.solif.backend.domain.notification.repository.NotificationRepository;
+import com.solif.backend.domain.post.entity.Post;
+import com.solif.backend.domain.post.repository.PostRepository;
+import com.solif.backend.domain.profile.entity.UserProfile;
+import com.solif.backend.domain.profile.repository.UserProfileRepository;
+import com.solif.backend.domain.user.entity.User;
+import com.solif.backend.domain.user.repository.UserRepository;
+import com.solif.backend.global.common.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MissionService {
+
+    private final MissionRepository missionRepository;
+    private final UserMissionRepository userMissionRepository;
+    private final UserPineconeRepository userPineconeRepository;
+    private final PineconeMemoryRepository pineconeMemoryRepository;
+    private final UserRepository userRepository;
+    private final UserProfileRepository userProfileRepository;
+    private final NotificationRepository notificationRepository;
+    private final MessageRepository messageRepository;
+    private final PostRepository postRepository;
+    private final CommentRepository commentRepository;
+
+    // ===== 미션 진행 상황 조회 =====
+    public MissionProgressResponse getMissionProgress(Long userId) {
+        User user = findUserById(userId);
+        String currentSeason = getCurrentSeasonKey();
+
+        // 획득한 솔방울 개수
+        Long earnedPineconeCount = userPineconeRepository.countByUserAndSeasonKey(user, currentSeason);
+
+        // D-Day 계산 (상반기 종료까지)
+        Integer daysUntilEnd = calculateDaysUntilSeasonEnd();
+
+        // 사용자 미션 목록 조회
+        List<UserMission> userMissions = userMissionRepository.findByUserWithMission(user);
+
+        // 카테고리별 진행 상황
+        List<MissionProgressResponse.CategoryProgress> categoryProgress = buildCategoryProgress(user, currentSeason, userMissions);
+
+        // 이번주 미션 리스트 (각 카테고리의 현재 진행 중인 미션)
+        List<MissionProgressResponse.WeeklyMissionCard> weeklyMissions = buildWeeklyMissions(userMissions);
+
+        return MissionProgressResponse.builder()
+                .currentSeason(currentSeason)
+                .earnedPineconeCount(earnedPineconeCount.intValue())
+                .daysUntilSeasonEnd(daysUntilEnd)
+                .categoryProgress(categoryProgress)
+                .weeklyMissions(weeklyMissions)
+                .build();
+    }
+
+    // ===== 솔방울 획득 (받기 버튼) =====
+    @Transactional
+    public PineconeEarnResponse earnPinecone(Long userId, MissionCategory category) {
+        User user = findUserById(userId);
+        String currentSeason = getCurrentSeasonKey();
+
+        // 이미 획득했는지 확인
+        if (userPineconeRepository.existsByUserAndPineconeCategoryAndSeasonKey(user, category, currentSeason)) {
+            throw new CustomException(MissionErrorCode.PINECONE_ALREADY_EARNED);
+        }
+
+        // 해당 카테고리의 미션 3개가 모두 완료되었는지 확인
+        Long completedCount = userMissionRepository.countByUserAndCategoryAndStatus(
+                user, category, MissionStatus.COMPLETED
+        );
+
+        if (completedCount < 3) {
+            throw new CustomException(MissionErrorCode.CATEGORY_MISSIONS_NOT_COMPLETED);
+        }
+
+        // 솔방울 생성
+        UserPinecone pinecone = UserPinecone.builder()
+                .user(user)
+                .pineconeCategory(category)
+                .seasonKey(currentSeason)
+                .build();
+        userPineconeRepository.save(pinecone);
+
+        // 솔방울 추억 생성 (완료된 미션 3개의 추억 저장)
+        List<UserMission> completedMissions = userMissionRepository.findByUserAndMission_MissionCategory(user, category)
+                .stream()
+                .filter(UserMission::isCompleted)
+                .limit(3)
+                .toList();
+
+        for (UserMission userMission : completedMissions) {
+            savePineconeMemory(pinecone, userMission);
+        }
+
+        // TODO: 알림 발송
+        // notificationService.send(userId, ...);
+
+        log.info("솔방울 획득 - userId: {}, category: {}, season: {}", userId, category, currentSeason);
+
+        return PineconeEarnResponse.builder()
+                .pineconeId(pinecone.getUserPineconeId())
+                .category(category)
+                .categoryName(getCategoryName(category))
+                .seasonKey(currentSeason)
+                .earnedAt(pinecone.getEarnedAt())
+                .build();
+    }
+
+    // ===== 솔방울 추억 회상 =====
+    public PineconeMemoryResponse getPineconeMemory(Long userId, MissionCategory category) {
+        User user = findUserById(userId);
+        String currentSeason = getCurrentSeasonKey();
+
+        // 솔방울 조회
+        UserPinecone pinecone = userPineconeRepository.findByUserAndPineconeCategoryAndSeasonKey(
+                user, category, currentSeason
+        ).orElseThrow(() -> new CustomException(MissionErrorCode.PINECONE_NOT_FOUND));
+
+        // 추억 조회
+        List<PineconeMemory> memories = pineconeMemoryRepository.findByUserPineconeOrderByCreatedAtAsc(pinecone);
+
+        // 완료한 미션 3개 구성
+        List<PineconeMemoryResponse.CompletedMission> completedMissions = new ArrayList<>();
+
+        for (PineconeMemory memory : memories) {
+            MissionConditionType conditionType = getMissionConditionTypeFromMemory(memory);
+            String missionTitle = getMissionTitleByConditionType(conditionType);
+
+            boolean hasMemoryDetail = hasMemoryDetail(memory.getSourceType());
+            PineconeMemoryResponse.MemoryDetail memoryDetail = null;
+
+            if (hasMemoryDetail) {
+                memoryDetail = buildMemoryDetail(memory);
+            }
+
+            completedMissions.add(
+                    PineconeMemoryResponse.CompletedMission.builder()
+                            .missionTitle(missionTitle)
+                            .isCompleted(true)
+                            .hasMemoryDetail(hasMemoryDetail)
+                            .memoryDetail(memoryDetail)
+                            .build()
+            );
+        }
+
+        return PineconeMemoryResponse.builder()
+                .category(category)
+                .categoryName(getCategoryName(category))
+                .completedMissions(completedMissions)
+                .build();
+    }
+
+    // ===== 미션 체크 & 완료 처리 (각 Service에서 호출) =====
+    @Transactional
+    public void checkAndCompleteMission(Long userId, MissionConditionType conditionType, Long sourceId) {
+        User user = findUserById(userId);
+
+        // 해당 조건 타입의 미션 찾기
+        Mission mission = missionRepository.findAll().stream()
+                .filter(m -> m.getConditionType() == conditionType)
+                .findFirst()
+                .orElse(null);
+
+        if (mission == null) {
+            log.warn("미션을 찾을 수 없음 - conditionType: {}", conditionType);
+            return;
+        }
+
+        // 사용자 미션 조회
+        UserMission userMission = userMissionRepository.findByUserAndMission(user, mission)
+                .orElse(null);
+
+        if (userMission == null) {
+            log.warn("사용자 미션을 찾을 수 없음 - userId: {}, missionId: {}", userId, mission.getMissionId());
+            return;
+        }
+
+        // 이미 완료된 미션이면 무시
+        if (userMission.isCompleted()) {
+            return;
+        }
+
+        // 미션별 완료 조건 체크
+        boolean shouldComplete = checkMissionCondition(userMission, mission, user, sourceId);
+
+        if (shouldComplete) {
+            userMission.complete();
+            log.info("미션 완료 - userId: {}, missionId: {}, conditionType: {}", userId, mission.getMissionId(), conditionType);
+
+            // TODO: 알림 발송
+            // notificationService.send(userId, NotificationType.MISSION_COMPLETED, ...);
+        }
+    }
+
+    // ===== 미션 진행도 증가 (카운트 기반 미션용) =====
+    @Transactional
+    public void incrementMissionProgress(Long userId, MissionConditionType conditionType) {
+        User user = findUserById(userId);
+
+        Mission mission = missionRepository.findAll().stream()
+                .filter(m -> m.getConditionType() == conditionType)
+                .findFirst()
+                .orElse(null);
+
+        if (mission == null) {
+            return;
+        }
+
+        UserMission userMission = userMissionRepository.findByUserAndMission(user, mission)
+                .orElse(null);
+
+        if (userMission == null || userMission.isCompleted()) {
+            return;
+        }
+
+        userMission.incrementProgress();
+
+        // 목표 달성 확인
+        int targetCount = getTargetCountFromConditionValue(mission.getConditionValue());
+        if (userMission.getProgressCount() >= targetCount) {
+            userMission.complete();
+            log.info("미션 완료 (카운트 달성) - userId: {}, missionId: {}, count: {}/{}",
+                    userId, mission.getMissionId(), userMission.getProgressCount(), targetCount);
+
+            // TODO: 알림 발송
+        }
+    }
+
+    // ===== Helper Methods =====
+
+    private User findUserById(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(MissionErrorCode.USER_MISSION_NOT_FOUND));
+    }
+
+    // 현재 시즌 키 계산 (2026-H1, 2026-H2)
+    private String getCurrentSeasonKey() {
+        LocalDate now = LocalDate.now();
+        int year = now.getYear();
+        int month = now.getMonthValue();
+        String half = (month <= 6) ? "H1" : "H2";
+        return year + "-" + half;
+    }
+
+    // 시즌 종료까지 남은 일수 계산
+    private Integer calculateDaysUntilSeasonEnd() {
+        LocalDate now = LocalDate.now();
+        int year = now.getYear();
+        int month = now.getMonthValue();
+
+        LocalDate seasonEnd;
+        if (month <= 6) {
+            // 상반기: 6월 30일
+            seasonEnd = LocalDate.of(year, 6, 30);
+        } else {
+            // 하반기: 12월 31일
+            seasonEnd = LocalDate.of(year, 12, 31);
+        }
+
+        return (int) ChronoUnit.DAYS.between(now, seasonEnd);
+    }
+
+    // 카테고리별 진행 상황 구성
+    private List<MissionProgressResponse.CategoryProgress> buildCategoryProgress(
+            User user, String currentSeason, List<UserMission> userMissions
+    ) {
+        List<MissionProgressResponse.CategoryProgress> result = new ArrayList<>();
+
+        for (MissionCategory category : MissionCategory.values()) {
+            Long completedCount = userMissions.stream()
+                    .filter(um -> um.getMission().getMissionCategory() == category)
+                    .filter(UserMission::isCompleted)
+                    .count();
+
+            boolean isPineconeEarned = userPineconeRepository.existsByUserAndPineconeCategoryAndSeasonKey(
+                    user, category, currentSeason
+            );
+
+            boolean canClaimPinecone = (completedCount >= 3) && !isPineconeEarned;
+
+            result.add(
+                    MissionProgressResponse.CategoryProgress.builder()
+                            .category(category)
+                            .categoryName(getCategoryName(category))
+                            .completedCount(completedCount.intValue())
+                            .totalCount(3)
+                            .isPineconeEarned(isPineconeEarned)
+                            .canClaimPinecone(canClaimPinecone)
+                            .build()
+            );
+        }
+
+        return result;
+    }
+
+    // 이번주 미션 리스트 구성 (각 카테고리에서 진행 중인 첫 미션)
+    private List<MissionProgressResponse.WeeklyMissionCard> buildWeeklyMissions(List<UserMission> userMissions) {
+        List<MissionProgressResponse.WeeklyMissionCard> weeklyMissions = new ArrayList<>();
+
+        // 카테고리별로 그룹화
+        Map<MissionCategory, List<UserMission>> groupedByCategory = userMissions.stream()
+                .collect(Collectors.groupingBy(um -> um.getMission().getMissionCategory()));
+
+        for (MissionCategory category : MissionCategory.values()) {
+            List<UserMission> categoryMissions = groupedByCategory.getOrDefault(category, List.of());
+
+            // 진행 중인 첫 번째 미션 찾기 (sequence_order 순)
+            UserMission currentMission = categoryMissions.stream()
+                    .filter(um -> !um.isCompleted())
+                    .min((um1, um2) -> Integer.compare(
+                            um1.getMission().getSequenceOrder(),
+                            um2.getMission().getSequenceOrder()
+                    ))
+                    .orElse(null);
+
+            if (currentMission != null) {
+                Mission mission = currentMission.getMission();
+                int targetCount = getTargetCountFromConditionValue(mission.getConditionValue());
+
+                weeklyMissions.add(
+                        MissionProgressResponse.WeeklyMissionCard.builder()
+                                .missionId(mission.getMissionId())
+                                .category(category)
+                                .categoryName(getCategoryName(category))
+                                .missionTitle(mission.getMissionTitle())
+                                .description(mission.getDescription())
+                                .progress(currentMission.getProgressCount() + "/" + targetCount)
+                                .currentCount(currentMission.getProgressCount())
+                                .targetCount(targetCount)
+                                .status(currentMission.getStatus())
+                                .isCompleted(currentMission.isCompleted())
+                                .build()
+                );
+            }
+        }
+
+        return weeklyMissions;
+    }
+
+    // 카테고리명 반환
+    private String getCategoryName(MissionCategory category) {
+        return switch (category) {
+            case CONNECT -> "연결";
+            case GROW -> "성장";
+            case IMPACT -> "기여";
+        };
+    }
+
+    // conditionValue에서 목표 카운트 추출 (예: "5" -> 5)
+    private int getTargetCountFromConditionValue(String conditionValue) {
+        if (conditionValue == null || conditionValue.isEmpty()) {
+            return 1;
+        }
+        try {
+            return Integer.parseInt(conditionValue);
+        } catch (NumberFormatException e) {
+            return 1;
+        }
+    }
+
+    // 미션 완료 조건 체크
+    private boolean checkMissionCondition(UserMission userMission, Mission mission, User user, Long sourceId) {
+        MissionConditionType conditionType = mission.getConditionType();
+
+        return switch (conditionType) {
+            case PROFILE_VIEW -> {
+                // 프로필 조회 5회
+                userMission.incrementProgress();
+                yield userMission.getProgressCount() >= 5;
+            }
+            case CONNECTION_ACTION -> {
+                // 응원/경험나누기 3회
+                userMission.incrementProgress();
+                yield userMission.getProgressCount() >= 3;
+            }
+            case MESSAGE -> {
+                // 첫 쪽지 발송 (1회만)
+                yield userMission.getProgressCount() == 0;
+            }
+            case PROFILE_COMPLETE -> {
+                // 프로필 100% 완성
+                UserProfile profile = userProfileRepository.findByUser_UserId(user.getUserId()).orElse(null);
+                yield profile != null && isProfileComplete(profile);
+            }
+            case MESSAGE_THREAD -> {
+                // 경험 나누기 → 쪽지 소통
+                yield checkMessageThreadCondition(user);
+            }
+            case POST_VIEW -> {
+                // 재단 소식 확인 (1회)
+                userMission.incrementProgress();
+                yield userMission.getProgressCount() >= 1;
+            }
+            case POST_CREATE, COMMENT_CREATE, MENTORING_COMPLETE -> {
+                // 단순 1회 완료
+                yield true;
+            }
+            default -> false;
+        };
+    }
+
+    // 프로필 완성 여부 체크 (필수/선택 정보 모두 입력)
+    private boolean isProfileComplete(UserProfile profile) {
+        // 필수: userCharacter, backgroundPattern, mainGoal, solidGoalName
+        // 선택: qrImageUrl 등
+        // 간단히 Null 체크로 구현 (실제로는 더 정교한 로직 필요)
+        return profile.getUserCharacter() != null &&
+                profile.getBackgroundPattern() != null &&
+                profile.getMainGoal() != null &&
+                profile.getSolidGoalName() != null;
+    }
+
+    // 경험 나누기 → 쪽지 소통 조건 체크
+    private boolean checkMessageThreadCondition(User user) {
+        // HELP 알림 조회: 내가 보낸 HELP 알림
+        // targetId에 sender(나)의 userId가 저장되어 있음
+        List<Notification> helpNotifications = notificationRepository
+                .findByNotificationTypeAndTargetId(NotificationType.HELP, user.getUserId());
+
+        if (helpNotifications.isEmpty()) {
+            return false;
+        }
+
+        // 해당 사람들(receiver)과 쪽지를 주고받았는지 확인
+        for (Notification notification : helpNotifications) {
+            Long receiverId = notification.getReceiver().getUserId();
+
+            // 쪽지 확인 (양방향)
+            boolean hasMessage = messageRepository.existsBySender_UserIdAndReceiver_UserId(user.getUserId(), receiverId) ||
+                    messageRepository.existsBySender_UserIdAndReceiver_UserId(receiverId, user.getUserId());
+
+            if (hasMessage) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    // 솔방울 추억 저장
+    private void savePineconeMemory(UserPinecone pinecone, UserMission userMission) {
+        MissionConditionType conditionType = userMission.getMission().getConditionType();
+        PineconeSourceType sourceType = mapConditionTypeToSourceType(conditionType);
+
+        if (sourceType == null) {
+            return; // 추억이 없는 미션
+        }
+
+        // sourceId 결정 (실제 데이터 조회)
+        Long sourceId = findSourceIdForMemory(userMission.getUser(), conditionType);
+
+        if (sourceId != null) {
+            PineconeMemory memory = PineconeMemory.builder()
+                    .userPinecone(pinecone)
+                    .sourceType(sourceType)
+                    .sourceId(sourceId)
+                    .build();
+            pineconeMemoryRepository.save(memory);
+        }
+    }
+
+    // ConditionType -> SourceType 매핑
+    private PineconeSourceType mapConditionTypeToSourceType(MissionConditionType conditionType) {
+        return switch (conditionType) {
+            case MESSAGE, MESSAGE_THREAD -> PineconeSourceType.MESSAGE;
+            case POST_CREATE -> PineconeSourceType.POST;
+            case COMMENT_CREATE -> PineconeSourceType.COMMENT;
+            case MENTORING_COMPLETE -> PineconeSourceType.MENTORING;
+            default -> null;
+        };
+    }
+
+    // 추억 sourceId 찾기
+    private Long findSourceIdForMemory(User user, MissionConditionType conditionType) {
+        return switch (conditionType) {
+            case MESSAGE -> {
+                // 첫 번째 보낸 쪽지
+                Message message = messageRepository.findFirstBySender_UserIdOrderByCreatedAtAsc(user.getUserId())
+                        .orElse(null);
+                yield message != null ? message.getMessageId() : null;
+            }
+            case MESSAGE_THREAD -> {
+                // 경험나누기로 연결된 첫 쪽지
+                // targetId에 내(sender) userId가 들어있음
+                List<Notification> helpNotifications = notificationRepository
+                        .findByNotificationTypeAndTargetId(NotificationType.HELP, user.getUserId());
+
+                for (Notification notification : helpNotifications) {
+                    Long receiverId = notification.getReceiver().getUserId();
+
+                    Message message = messageRepository.findFirstBySender_UserIdAndReceiver_UserIdOrderByCreatedAtAsc(
+                            user.getUserId(), receiverId
+                    ).orElse(null);
+
+                    if (message != null) {
+                        yield message.getMessageId();
+                    }
+                }
+                yield null;
+            }
+            case POST_CREATE -> {
+                // 첫 번째 작성한 게시글
+                Post post = postRepository.findFirstByAuthor_UserIdOrderByCreatedAtAsc(user.getUserId())
+                        .orElse(null);
+                yield post != null ? post.getPostId() : null;
+            }
+            case COMMENT_CREATE -> {
+                // 첫 번째 작성한 댓글
+                Comment comment = commentRepository.findFirstByUser_UserIdOrderByCreatedAtAsc(user.getUserId())
+                        .orElse(null);
+                yield comment != null ? comment.getCommentId() : null;
+            }
+            case MENTORING_COMPLETE -> {
+                // TODO: 멘토링 도메인 구현 후 추가
+                yield null;
+            }
+            default -> null;
+        };
+    }
+
+    // 추억 상세 구성
+    private PineconeMemoryResponse.MemoryDetail buildMemoryDetail(PineconeMemory memory) {
+        return switch (memory.getSourceType()) {
+            case MESSAGE -> {
+                Message message = messageRepository.findById(memory.getSourceId()).orElse(null);
+                if (message != null) {
+                    yield PineconeMemoryResponse.MemoryDetail.builder()
+                            .memoryType("MESSAGE")
+                            .memoryContent(message.getMessageTitle())
+                            .relatedUserName(message.getReceiver().getName())
+                            .createdAt(message.getCreatedAt().toString())
+                            .build();
+                }
+                yield null;
+            }
+            case POST -> {
+                Post post = postRepository.findById(memory.getSourceId()).orElse(null);
+                if (post != null) {
+                    yield PineconeMemoryResponse.MemoryDetail.builder()
+                            .memoryType("POST")
+                            .memoryContent(post.getPostTitle())
+                            .relatedUserName(null)
+                            .createdAt(post.getCreatedAt().toString())
+                            .build();
+                }
+                yield null;
+            }
+            case COMMENT -> {
+                Comment comment = commentRepository.findById(memory.getSourceId()).orElse(null);
+                if (comment != null) {
+                    yield PineconeMemoryResponse.MemoryDetail.builder()
+                            .memoryType("COMMENT")
+                            .memoryContent(comment.getCommentContent())
+                            .relatedUserName(comment.getPost().getAuthor().getName())
+                            .createdAt(comment.getCreatedAt().toString())
+                            .build();
+                }
+                yield null;
+            }
+            case MENTORING -> {
+                // TODO: 멘토링 도메인 구현 후 추가
+                yield null;
+            }
+        };
+    }
+
+    // 추억 상세 조회 가능 여부
+    private boolean hasMemoryDetail(PineconeSourceType sourceType) {
+        // MESSAGE, POST, COMMENT, MENTORING만 추억 상세 있음
+        return sourceType != null;
+    }
+
+    // ConditionType으로 미션 제목 조회
+    private String getMissionTitleByConditionType(MissionConditionType conditionType) {
+        Mission mission = missionRepository.findAll().stream()
+                .filter(m -> m.getConditionType() == conditionType)
+                .findFirst()
+                .orElse(null);
+        return mission != null ? mission.getMissionTitle() : "";
+    }
+
+    // Memory에서 ConditionType 추출
+    private MissionConditionType getMissionConditionTypeFromMemory(PineconeMemory memory) {
+        return switch (memory.getSourceType()) {
+            case MESSAGE -> MissionConditionType.MESSAGE;
+            case POST -> MissionConditionType.POST_CREATE;
+            case COMMENT -> MissionConditionType.COMMENT_CREATE;
+            case MENTORING -> MissionConditionType.MENTORING_COMPLETE;
+        };
+    }
+
+    // 회원가입 완료 후 미션 초기화
+    @Transactional
+    public void initializeUserMissions(User user) {
+        List<Mission> allMissions = missionRepository.findAllByOrderByMissionCategoryAscSequenceOrderAsc();
+
+        for (Mission mission : allMissions) {
+            UserMission userMission = UserMission.builder()
+                    .user(user)
+                    .mission(mission)
+                    .build();
+            userMissionRepository.save(userMission);
+        }
+
+        log.info("사용자 미션 초기화 완료 - userId: {}, 미션 개수: {}", user.getUserId(), allMissions.size());
+    }
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/mission/service/MissionService.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/mission/service/MissionService.java
@@ -30,7 +30,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
@@ -390,17 +389,18 @@ public class MissionService {
     // 미션 완료 조건 체크
     private boolean checkMissionCondition(UserMission userMission, Mission mission, User user, Long sourceId) {
         MissionConditionType conditionType = mission.getConditionType();
+        int targetCount = getTargetCountFromConditionValue(mission.getConditionValue());
 
         return switch (conditionType) {
             case PROFILE_VIEW -> {
-                // 프로필 조회 5회
+                // 프로필 조회 N회
                 userMission.incrementProgress();
-                yield userMission.getProgressCount() >= 5;
+                yield userMission.getProgressCount() >= targetCount;
             }
             case CONNECTION_ACTION -> {
-                // 응원/경험나누기 3회
+                // 응원/경험나누기 N회
                 userMission.incrementProgress();
-                yield userMission.getProgressCount() >= 3;
+                yield userMission.getProgressCount() >= targetCount;
             }
             case MESSAGE -> {
                 // 첫 쪽지 발송 (1회만)
@@ -416,9 +416,9 @@ public class MissionService {
                 yield checkMessageThreadCondition(user);
             }
             case POST_VIEW -> {
-                // 재단 소식 확인 (1회)
+                // 재단 소식 확인 (N회)
                 userMission.incrementProgress();
-                yield userMission.getProgressCount() >= 1;
+                yield userMission.getProgressCount() >= targetCount;
             }
             case POST_CREATE, COMMENT_CREATE, MENTORING_COMPLETE -> {
                 // 단순 1회 완료

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/mission/service/MissionService.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/mission/service/MissionService.java
@@ -112,7 +112,8 @@ public class MissionService {
         userPineconeRepository.save(pinecone);
 
         // 솔방울 추억 생성 (완료된 미션 3개의 추억 저장)
-        List<UserMission> completedMissions = userMissionRepository.findByUserAndMission_MissionCategory(user, category)
+        List<UserMission> completedMissions = userMissionRepository
+                .findByUserAndMission_MissionCategory(user, category)
                 .stream()
                 .filter(UserMission::isCompleted)
                 .limit(3)
@@ -186,9 +187,7 @@ public class MissionService {
         User user = findUserById(userId);
 
         // 해당 조건 타입의 미션 찾기
-        Mission mission = missionRepository.findAll().stream()
-                .filter(m -> m.getConditionType() == conditionType)
-                .findFirst()
+        Mission mission = missionRepository.findByConditionType(conditionType)
                 .orElse(null);
 
         if (mission == null) {

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/mission/service/MissionService.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/mission/service/MissionService.java
@@ -161,6 +161,10 @@ public class MissionService {
 
             if (hasMemoryDetail) {
                 memoryDetail = buildMemoryDetail(memory);
+                // null인 경우 hasMemoryDetail을 false로 변경
+                if (memoryDetail == null) {
+                    hasMemoryDetail = false;
+                }
             }
 
             completedMissions.add(
@@ -552,39 +556,39 @@ public class MissionService {
         return switch (memory.getSourceType()) {
             case MESSAGE -> {
                 Message message = messageRepository.findById(memory.getSourceId()).orElse(null);
-                if (message != null) {
-                    yield PineconeMemoryResponse.MemoryDetail.builder()
-                            .memoryType("MESSAGE")
-                            .memoryContent(message.getMessageTitle())
-                            .relatedUserName(message.getReceiver().getName())
-                            .createdAt(message.getCreatedAt().toString())
-                            .build();
+                if (message == null) {
+                    yield null;
                 }
-                yield null;
+                yield PineconeMemoryResponse.MemoryDetail.builder()
+                        .memoryType("MESSAGE")
+                        .memoryContent(message.getMessageTitle())
+                        .relatedUserName(message.getReceiver().getName())
+                        .createdAt(message.getCreatedAt().toString())
+                        .build();
             }
             case POST -> {
                 Post post = postRepository.findById(memory.getSourceId()).orElse(null);
-                if (post != null) {
-                    yield PineconeMemoryResponse.MemoryDetail.builder()
-                            .memoryType("POST")
-                            .memoryContent(post.getPostTitle())
-                            .relatedUserName(null)
-                            .createdAt(post.getCreatedAt().toString())
-                            .build();
+                if (post == null) {
+                    yield null;
                 }
-                yield null;
+                yield PineconeMemoryResponse.MemoryDetail.builder()
+                        .memoryType("POST")
+                        .memoryContent(post.getPostTitle())
+                        .relatedUserName(null)
+                        .createdAt(post.getCreatedAt().toString())
+                        .build();
             }
             case COMMENT -> {
                 Comment comment = commentRepository.findById(memory.getSourceId()).orElse(null);
-                if (comment != null) {
-                    yield PineconeMemoryResponse.MemoryDetail.builder()
-                            .memoryType("COMMENT")
-                            .memoryContent(comment.getCommentContent())
-                            .relatedUserName(comment.getPost().getAuthor().getName())
-                            .createdAt(comment.getCreatedAt().toString())
-                            .build();
+                if (comment == null) {
+                    yield null;
                 }
-                yield null;
+                yield PineconeMemoryResponse.MemoryDetail.builder()
+                        .memoryType("COMMENT")
+                        .memoryContent(comment.getCommentContent())
+                        .relatedUserName(comment.getPost().getAuthor().getName())
+                        .createdAt(comment.getCreatedAt().toString())
+                        .build();
             }
             case MENTORING -> {
                 // TODO: 멘토링 도메인 구현 후 추가

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/notification/repository/NotificationRepository.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/notification/repository/NotificationRepository.java
@@ -6,6 +6,8 @@ import com.solif.backend.domain.user.entity.User;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
@@ -21,4 +23,7 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
 
     // 안읽은 알림 수
     long countByReceiverAndIsReadFalse(User receiver);
+
+    // targetId로 조회 (targetId에 sender userId 저장됨)
+    List<Notification> findByNotificationTypeAndTargetId(NotificationType type, Long targetId);
 }

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/post/repository/PostRepository.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/post/repository/PostRepository.java
@@ -8,6 +8,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.Optional;
+
 public interface PostRepository extends JpaRepository<Post, Long> {
 
     // 게시판별 목록 조회 (Author fetch join 없음 - 익명용)
@@ -49,4 +51,7 @@ public interface PostRepository extends JpaRepository<Post, Long> {
             @Param("postCategory") PostCategory postCategory,
             Pageable pageable
     );
+
+    // 사용자가 첫 번째 작성한 게시글
+    Optional<Post> findFirstByAuthor_UserIdOrderByCreatedAtAsc(Long authorUserId);
 }

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/post/repository/PostRepository.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/post/repository/PostRepository.java
@@ -52,6 +52,10 @@ public interface PostRepository extends JpaRepository<Post, Long> {
             Pageable pageable
     );
 
-    // 사용자가 첫 번째 작성한 게시글
-    Optional<Post> findFirstByAuthor_UserIdOrderByCreatedAtAsc(Long authorUserId);
+    // 사용자가 첫 번째 작성한 게시글 (삭제되지 않은 것만)
+    @Query("SELECT p FROM Post p " +
+            "WHERE p.author.userId = :authorUserId " +
+            "AND p.deletedAt IS NULL " +
+            "ORDER BY p.createdAt ASC")
+    Optional<Post> findFirstByAuthor_UserIdOrderByCreatedAtAsc(@Param("authorUserId") Long authorUserId);
 }


### PR DESCRIPTION
## 🔍 개요
성장 도메인(미션 / 솔방울 / 활동 기록)에 대한 **기본 API 및 도메인 구조를 구현**합니다.

본 PR에서는 성장 도메인의 엔티티, 레포지토리, 서비스, 컨트롤러 및
조회/응답용 API를 제공하며,
**기존 서비스 로직과의 실제 연동(미션 트리거 연결)은 포함하지 않습니다.**

## ✨ 변경 사항
- 성장 도메인 기본 구조 구현
  - Mission / UserMission
  - PineconeMemory / UserPinecone
- 미션 상태, 카테고리, 조건 타입 Enum 정의
- 성장 관련 API 구현
  - 사용자 미션 진행 현황 조회
  - 솔방울 적립 내역 조회
  - 미션 달성 결과 응답
- 성장 도메인 SuccessCode / ErrorCode 정의

## 🧪 테스트
- [x] 로컬 테스트 완료
- [ ] API 테스트 완료
- [ ] 테스트 코드 작성 (해당 시)

## 📎 관련 이슈
Closes: #73 

## ⚠️ 참고 사항
- 본 PR은 **성장 도메인 API 자체 구현**에 집중합니다.
- 미션 조건 충족을 위한 기존 서비스 로직과의 연동은
  **후의 issue에서 진행 예정**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 미션 시스템 전반 추가: 주간 미션 진행조회, 솔방울 획득, 솔방울 기억 조회 API 제공.
  * 가입 시 사용자 미션 자동 초기화 호출 추가.
  * 미션 진행·완료 처리, 카테고리별 진행/집계, 메모리(기억) 생성 기능 추가.

* **데이터/모델 변경**
  * 미션 관련 DTO, 엔티티(미션·유저미션·솔방울·기억 등) 및 카테고리/상태/조건 타입 추가.

* **저장소·검색 개선**
  * 첫 항목 조회 및 존재 확인 등 조회용 쿼리 메서드 여러 건 추가 (메시지/포스트/댓글/알림/유저파인콘/유저미션 등).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->