### PR TITLE
feat: 멘토링 도메인 및 신청/엽서/조회 API 구현

### DIFF
--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/file/entity/AttachmentPurpose.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/file/entity/AttachmentPurpose.java
@@ -1,9 +1,10 @@
 package com.solif.backend.domain.file.entity;
 
 public enum AttachmentPurpose {
-    PROFILE_IMAGE,           // 프로필 이미지
-    PINECONE_MEMORY_IMAGE,   // 솔방울 추억 이미지
-    POST_ATTACHMENT,         // 게시글 첨부 이미지
-    RECEIPT,                 // 영수증 (OCR용)
-    MESSAGE_ATTACHMENT       // 쪽지
+    PROFILE_IMAGE,            // 프로필 이미지
+    PINECONE_MEMORY_IMAGE,    // 솔방울 추억 이미지
+    POST_ATTACHMENT,          // 게시글 첨부 이미지
+    RECEIPT,                  // 영수증 (OCR용)
+    MESSAGE_ATTACHMENT,       // 쪽지
+    MENTORING_CARD_ATTACHMENT // 멘토링 엽서 첨부파일
 }

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/file/entity/AttachmentPurpose.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/file/entity/AttachmentPurpose.java
@@ -4,5 +4,6 @@ public enum AttachmentPurpose {
     PROFILE_IMAGE,           // 프로필 이미지
     PINECONE_MEMORY_IMAGE,   // 솔방울 추억 이미지
     POST_ATTACHMENT,         // 게시글 첨부 이미지
-    RECEIPT                  // 영수증 (OCR용)
+    RECEIPT,                 // 영수증 (OCR용)
+    MESSAGE_ATTACHMENT       // 쪽지
 }

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/file/entity/FileTargetType.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/file/entity/FileTargetType.java
@@ -4,5 +4,6 @@ public enum FileTargetType {
     POST,              // 통합 게시글
     COUNCIL_POST,      // 자치회 활동 후기
     USER_PROFILE,
-    PINECONE_MEMORY
+    PINECONE_MEMORY,
+    MESSAGE            // 쪽지 첨부파일
 }

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/file/entity/FileTargetType.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/file/entity/FileTargetType.java
@@ -5,5 +5,7 @@ public enum FileTargetType {
     COUNCIL_POST,      // 자치회 활동 후기
     USER_PROFILE,
     PINECONE_MEMORY,
-    MESSAGE            // 쪽지 첨부파일
+    MESSAGE,           // 쪽지 첨부파일
+    MENTOR_PROFILE,    // 전문가 멘토 프로필 이미지
+    MENTORING_CARD     // 멘토링 엽서 첨부파일
 }

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/interest/repository/UserInterestRepository.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/interest/repository/UserInterestRepository.java
@@ -15,4 +15,7 @@ public interface UserInterestRepository extends JpaRepository<UserInterest, Long
 
     // 특정 관심사를 가진 사용자 조회
     List<UserInterest> findAllByCategoryNameIn(List<String> categoryNames);
+
+    // 여러 사용자 ID로 관심사 배치 조회
+    List<UserInterest> findAllByUser_UserIdIn(List<Long> userIds);
 }

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/mentoring/code/MentoringErrorCode.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/mentoring/code/MentoringErrorCode.java
@@ -1,0 +1,23 @@
+package com.solif.backend.domain.mentoring.code;
+
+import com.solif.backend.global.common.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum MentoringErrorCode implements ErrorCode {
+
+    MENTOR_NOT_FOUND(HttpStatus.NOT_FOUND, "MENTORING_001", "존재하지 않는 전문가 멘토입니다."),
+    MENTORING_REQUEST_NOT_FOUND(HttpStatus.NOT_FOUND, "MENTORING_002", "존재하지 않는 멘토링 신청입니다."),
+    INVALID_CATEGORY(HttpStatus.BAD_REQUEST, "MENTORING_003", "유효하지 않은 카테고리입니다."),
+    INVALID_METHOD(HttpStatus.BAD_REQUEST, "MENTORING_004", "유효하지 않은 멘토링 방식입니다."),
+    UNAUTHORIZED_REQUEST_ACCESS(HttpStatus.FORBIDDEN, "MENTORING_005", "해당 멘토링 신청에 대한 권한이 없습니다."),
+    MENTORING_CARD_NOT_FOUND(HttpStatus.NOT_FOUND, "MENTORING_006", "존재하지 않는 멘토링 엽서입니다."),
+    UNAUTHORIZED_CARD_ACCESS(HttpStatus.FORBIDDEN, "MENTORING_007", "해당 멘토링 엽서에 대한 권한이 없습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/mentoring/code/MentoringSuccessCode.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/mentoring/code/MentoringSuccessCode.java
@@ -1,0 +1,25 @@
+package com.solif.backend.domain.mentoring.code;
+
+import com.solif.backend.global.common.response.SuccessCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum MentoringSuccessCode implements SuccessCode {
+
+    MENTOR_LIST_SUCCESS(HttpStatus.OK, "MENTORING_200", "전문가 멘토 목록 조회에 성공했습니다."),
+    MENTORING_REQUEST_CREATE_SUCCESS(HttpStatus.CREATED, "MENTORING_201", "멘토링 신청에 성공했습니다."),
+    MENTORING_REQUEST_SENT_LIST_SUCCESS(HttpStatus.OK, "MENTORING_202", "내가 보낸 신청서 목록 조회에 성공했습니다."),
+    MENTORING_REQUEST_RECEIVED_LIST_SUCCESS(HttpStatus.OK, "MENTORING_203", "받은 신청서 목록 조회에 성공했습니다."),
+    MENTORING_HOME_SUCCESS(HttpStatus.OK, "MENTORING_204", "멘토링 홈 조회에 성공했습니다."),
+    MENTORING_CARD_SEND_SUCCESS(HttpStatus.CREATED, "MENTORING_205", "멘토링 엽서 발송에 성공했습니다."),
+    MENTORING_CARD_SENT_LIST_SUCCESS(HttpStatus.OK, "MENTORING_206", "보낸 멘토링 엽서 목록 조회에 성공했습니다."),
+    MENTORING_CARD_DETAIL_SUCCESS(HttpStatus.OK, "MENTORING_207", "멘토링 엽서 상세 조회에 성공했습니다."),
+    MENTORING_REQUEST_DETAIL_SUCCESS(HttpStatus.OK, "MENTORING_208", "멘토링 신청서 상세 조회에 성공했습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/mentoring/controller/MentoringController.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/mentoring/controller/MentoringController.java
@@ -1,0 +1,159 @@
+package com.solif.backend.domain.mentoring.controller;
+
+import com.solif.backend.domain.mentoring.code.MentoringSuccessCode;
+import com.solif.backend.domain.mentoring.dto.*;
+import com.solif.backend.domain.mentoring.service.MentoringService;
+import com.solif.backend.global.common.response.ResponseFactory;
+import com.solif.backend.global.common.response.SuccessResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "멘토링", description = "멘토링 API")
+@RestController
+@RequestMapping("/api/v1/mentoring")
+@RequiredArgsConstructor
+public class MentoringController {
+
+    private final MentoringService mentoringService;
+
+    @Operation(
+            summary = "전문가 멘토 목록 조회",
+            description = "활성화된 전문가 멘토 목록을 조회합니다.",
+            security = @SecurityRequirement(name = "Bearer Authentication")
+    )
+    @GetMapping("/mentors")
+    public ResponseEntity<SuccessResponse<List<MentorListResponse>>> getMentors(
+            @AuthenticationPrincipal Long userId
+    ) {
+        List<MentorListResponse> response = mentoringService.getMentors();
+        return ResponseFactory.success(MentoringSuccessCode.MENTOR_LIST_SUCCESS, response);
+    }
+
+    @Operation(
+            summary = "멘토링 신청",
+            description = "전문가 멘토에게 멘토링을 신청합니다.",
+            security = @SecurityRequirement(name = "Bearer Authentication")
+    )
+    @PostMapping("/requests")
+    public ResponseEntity<SuccessResponse<MentoringRequestCreateResponse>> createMentoringRequest(
+            @AuthenticationPrincipal Long userId,
+            @Valid @RequestBody MentoringRequestCreateRequest request
+    ) {
+        MentoringRequestCreateResponse response = mentoringService.createMentoringRequest(userId, request);
+        return ResponseFactory.success(MentoringSuccessCode.MENTORING_REQUEST_CREATE_SUCCESS, response);
+    }
+
+    @Operation(
+            summary = "내가 보낸 신청서 목록 조회",
+            description = "내가 전문가 멘토에게 보낸 멘토링 신청서 목록을 조회합니다.",
+            security = @SecurityRequirement(name = "Bearer Authentication")
+    )
+    @GetMapping("/requests/sent")
+    public ResponseEntity<SuccessResponse<Slice<MentoringRequestListResponse>>> getSentRequests(
+            @AuthenticationPrincipal Long userId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size
+    ) {
+        Pageable pageable = PageRequest.of(page, size);
+        Slice<MentoringRequestListResponse> response = mentoringService.getSentRequests(userId, pageable);
+        return ResponseFactory.success(MentoringSuccessCode.MENTORING_REQUEST_SENT_LIST_SUCCESS, response);
+    }
+
+    @Operation(
+            summary = "받은 신청서 목록 조회",
+            description = "내가 보낸 멘토링 신청서 중 관리자가 답변을 작성한 신청서 목록을 조회합니다.",
+            security = @SecurityRequirement(name = "Bearer Authentication")
+    )
+    @GetMapping("/requests/received")
+    public ResponseEntity<SuccessResponse<Slice<MentoringRequestListResponse>>> getReceivedRequests(
+            @AuthenticationPrincipal Long userId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size
+    ) {
+        Pageable pageable = PageRequest.of(page, size);
+        Slice<MentoringRequestListResponse> response = mentoringService.getReceivedRequests(userId, pageable);
+        return ResponseFactory.success(MentoringSuccessCode.MENTORING_REQUEST_RECEIVED_LIST_SUCCESS, response);
+    }
+
+    @Operation(
+            summary = "멘토링 홈 조회",
+            description = "멘토링 홈 화면 정보를 조회합니다. (전문가 멘토, 선후배 멘토링, 후기 목록)",
+            security = @SecurityRequirement(name = "Bearer Authentication")
+    )
+    @GetMapping("/home")
+    public ResponseEntity<SuccessResponse<MentoringHomeResponse>> getMentoringHome(
+            @AuthenticationPrincipal Long userId
+    ) {
+        MentoringHomeResponse response = mentoringService.getMentoringHome(userId);
+        return ResponseFactory.success(MentoringSuccessCode.MENTORING_HOME_SUCCESS, response);
+    }
+
+    @Operation(
+            summary = "멘토링 엽서 발송",
+            description = "관리자에게 멘토링 엽서를 발송합니다. 전문가 멘토 중 맘에 드는 사람이 없을 때 사용합니다.",
+            security = @SecurityRequirement(name = "Bearer Authentication")
+    )
+    @PostMapping("/cards")
+    public ResponseEntity<SuccessResponse<MentoringCardSendResponse>> sendMentoringCard(
+            @AuthenticationPrincipal Long userId,
+            @Valid @RequestBody MentoringCardSendRequest request
+    ) {
+        MentoringCardSendResponse response = mentoringService.sendMentoringCard(userId, request);
+        return ResponseFactory.success(MentoringSuccessCode.MENTORING_CARD_SEND_SUCCESS, response);
+    }
+
+    @Operation(
+            summary = "보낸 멘토링 엽서 목록 조회",
+            description = "내가 관리자에게 보낸 멘토링 엽서 목록을 조회합니다.",
+            security = @SecurityRequirement(name = "Bearer Authentication")
+    )
+    @GetMapping("/cards/sent")
+    public ResponseEntity<SuccessResponse<Slice<MentoringCardListResponse>>> getSentCards(
+            @AuthenticationPrincipal Long userId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size
+    ) {
+        Pageable pageable = PageRequest.of(page, size);
+        Slice<MentoringCardListResponse> response = mentoringService.getSentCards(userId, pageable);
+        return ResponseFactory.success(MentoringSuccessCode.MENTORING_CARD_SENT_LIST_SUCCESS, response);
+    }
+
+    @Operation(
+            summary = "멘토링 엽서 상세 조회",
+            description = "멘토링 엽서 상세 내용을 조회합니다.",
+            security = @SecurityRequirement(name = "Bearer Authentication")
+    )
+    @GetMapping("/cards/{cardId}")
+    public ResponseEntity<SuccessResponse<MentoringCardDetailResponse>> getCardDetail(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long cardId
+    ) {
+        MentoringCardDetailResponse response = mentoringService.getCardDetail(userId, cardId);
+        return ResponseFactory.success(MentoringSuccessCode.MENTORING_CARD_DETAIL_SUCCESS, response);
+    }
+
+    @Operation(
+            summary = "멘토링 신청서 상세 조회",
+            description = "멘토링 신청서의 상세 내용을 조회합니다. 신청자 본인만 조회 가능합니다.",
+            security = @SecurityRequirement(name = "Bearer Authentication")
+    )
+    @GetMapping("/requests/{requestId}")
+    public ResponseEntity<SuccessResponse<MentoringRequestDetailResponse>> getRequestDetail(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long requestId
+    ) {
+        MentoringRequestDetailResponse response = mentoringService.getRequestDetail(userId, requestId);
+        return ResponseFactory.success(MentoringSuccessCode.MENTORING_REQUEST_DETAIL_SUCCESS, response);
+    }
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/mentoring/controller/MentoringController.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/mentoring/controller/MentoringController.java
@@ -71,7 +71,21 @@ public class MentoringController {
     }
 
     @Operation(
-            summary = "받은 신청서 목록 조회",
+            summary = "멘토링 신청서 상세 조회",
+            description = "멘토링 신청서의 상세 내용을 조회합니다. 신청자 본인만 조회 가능합니다.",
+            security = @SecurityRequirement(name = "Bearer Authentication")
+    )
+    @GetMapping("/requests/{requestId}")
+    public ResponseEntity<SuccessResponse<MentoringRequestDetailResponse>> getRequestDetail(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long requestId
+    ) {
+        MentoringRequestDetailResponse response = mentoringService.getRequestDetail(userId, requestId);
+        return ResponseFactory.success(MentoringSuccessCode.MENTORING_REQUEST_DETAIL_SUCCESS, response);
+    }
+
+    @Operation(
+            summary = "내가 받은 답변 목록 조회",
             description = "내가 보낸 멘토링 신청서 중 관리자가 답변을 작성한 신청서 목록을 조회합니다.",
             security = @SecurityRequirement(name = "Bearer Authentication")
     )
@@ -141,19 +155,5 @@ public class MentoringController {
     ) {
         MentoringCardDetailResponse response = mentoringService.getCardDetail(userId, cardId);
         return ResponseFactory.success(MentoringSuccessCode.MENTORING_CARD_DETAIL_SUCCESS, response);
-    }
-
-    @Operation(
-            summary = "멘토링 신청서 상세 조회",
-            description = "멘토링 신청서의 상세 내용을 조회합니다. 신청자 본인만 조회 가능합니다.",
-            security = @SecurityRequirement(name = "Bearer Authentication")
-    )
-    @GetMapping("/requests/{requestId}")
-    public ResponseEntity<SuccessResponse<MentoringRequestDetailResponse>> getRequestDetail(
-            @AuthenticationPrincipal Long userId,
-            @PathVariable Long requestId
-    ) {
-        MentoringRequestDetailResponse response = mentoringService.getRequestDetail(userId, requestId);
-        return ResponseFactory.success(MentoringSuccessCode.MENTORING_REQUEST_DETAIL_SUCCESS, response);
     }
 }

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/mentoring/controller/MentoringController.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/mentoring/controller/MentoringController.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -63,7 +64,7 @@ public class MentoringController {
     public ResponseEntity<SuccessResponse<Slice<MentoringRequestListResponse>>> getSentRequests(
             @AuthenticationPrincipal Long userId,
             @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "20") int size
+            @RequestParam(defaultValue = "20") @Max(100) int size
     ) {
         Pageable pageable = PageRequest.of(page, size);
         Slice<MentoringRequestListResponse> response = mentoringService.getSentRequests(userId, pageable);
@@ -93,7 +94,7 @@ public class MentoringController {
     public ResponseEntity<SuccessResponse<Slice<MentoringRequestListResponse>>> getReceivedRequests(
             @AuthenticationPrincipal Long userId,
             @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "20") int size
+            @RequestParam(defaultValue = "20") @Max(100) int size
     ) {
         Pageable pageable = PageRequest.of(page, size);
         Slice<MentoringRequestListResponse> response = mentoringService.getReceivedRequests(userId, pageable);
@@ -136,7 +137,7 @@ public class MentoringController {
     public ResponseEntity<SuccessResponse<Slice<MentoringCardListResponse>>> getSentCards(
             @AuthenticationPrincipal Long userId,
             @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "20") int size
+            @RequestParam(defaultValue = "20") @Max(100) int size
     ) {
         Pageable pageable = PageRequest.of(page, size);
         Slice<MentoringCardListResponse> response = mentoringService.getSentCards(userId, pageable);

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/mentoring/dto/MentorListResponse.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/mentoring/dto/MentorListResponse.java
@@ -22,6 +22,9 @@ public class MentorListResponse {
     @Schema(description = "멘토 소개", example = "안녕하세요. 저는 한국대학교에 재학중인 신석균입니다. 대학생활의 시작...")
     private String mentorIntro;
 
+    @Schema(description = "멘토 카테고리", example = "STUDY")
+    private String mentorCategory;
+
     @Schema(description = "프로필 이미지 URL", nullable = true)
     private String profileImageUrl;
 
@@ -31,6 +34,7 @@ public class MentorListResponse {
                 .mentorTitle(mentor.getMentorTitle())
                 .mentorName(mentor.getMentorName())
                 .mentorIntro(mentor.getMentorIntro())
+                .mentorCategory(mentor.getMentorCategory().name())
                 .profileImageUrl(profileImageUrl)
                 .build();
     }

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/mentoring/dto/MentorListResponse.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/mentoring/dto/MentorListResponse.java
@@ -1,0 +1,37 @@
+package com.solif.backend.domain.mentoring.dto;
+
+import com.solif.backend.domain.mentoring.entity.Mentor;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@Schema(description = "전문가 멘토 목록 응답")
+public class MentorListResponse {
+
+    @Schema(description = "멘토 ID", example = "1")
+    private Long mentorId;
+
+    @Schema(description = "멘토 직함", example = "멘토 SO&L 글로벌자산운용 대표")
+    private String mentorTitle;
+
+    @Schema(description = "멘토 이름", example = "신석균")
+    private String mentorName;
+
+    @Schema(description = "멘토 소개", example = "안녕하세요. 저는 한국대학교에 재학중인 신석균입니다. 대학생활의 시작...")
+    private String mentorIntro;
+
+    @Schema(description = "프로필 이미지 URL", nullable = true)
+    private String profileImageUrl;
+
+    public static MentorListResponse from(Mentor mentor, String profileImageUrl) {
+        return MentorListResponse.builder()
+                .mentorId(mentor.getMentorId())
+                .mentorTitle(mentor.getMentorTitle())
+                .mentorName(mentor.getMentorName())
+                .mentorIntro(mentor.getMentorIntro())
+                .profileImageUrl(profileImageUrl)
+                .build();
+    }
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/mentoring/dto/MentoringCardDetailResponse.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/mentoring/dto/MentoringCardDetailResponse.java
@@ -44,9 +44,9 @@ public class MentoringCardDetailResponse {
     private LocalDateTime createdAt;
 
     @Schema(description = "첨부 파일 URL 목록", nullable = true)
-    private List<String> fileUrls;
+    private List<String> imageUrls;
 
-    public static MentoringCardDetailResponse from(MentoringCard card, List<String> fileUrls) {
+    public static MentoringCardDetailResponse from(MentoringCard card, List<String> imageUrls) {
         return MentoringCardDetailResponse.builder()
                 .mentoringCardId(card.getMentoringCardId())
                 .senderId(card.getSender().getUserId())
@@ -58,7 +58,7 @@ public class MentoringCardDetailResponse {
                 .isRead(card.getIsRead())
                 .readAt(card.getReadAt())
                 .createdAt(card.getCreatedAt())
-                .fileUrls(fileUrls)
+                .imageUrls(imageUrls)
                 .build();
     }
 }

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/mentoring/dto/MentoringCardDetailResponse.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/mentoring/dto/MentoringCardDetailResponse.java
@@ -1,0 +1,64 @@
+package com.solif.backend.domain.mentoring.dto;
+
+import com.solif.backend.domain.mentoring.entity.MentoringCard;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+@Schema(description = "멘토링 엽서 상세 응답")
+public class MentoringCardDetailResponse {
+
+    @Schema(description = "멘토링 엽서 ID", example = "1")
+    private Long mentoringCardId;
+
+    @Schema(description = "발송자 ID", example = "1")
+    private Long senderId;
+
+    @Schema(description = "발송자 이름", example = "김철수")
+    private String senderName;
+
+    @Schema(description = "엽서 제목", example = "금융권 IB 직무 멘토를 찾고 싶습니다")
+    private String cardTitle;
+
+    @Schema(description = "카테고리", example = "JOB")
+    private String category;
+
+    @Schema(description = "멘토링 방식", example = "VIDEO")
+    private String method;
+
+    @Schema(description = "엽서 내용", example = "안녕하세요. 저는 한국대학교에 재학중인 학생입니다...")
+    private String cardContent;
+
+    @Schema(description = "읽음 여부", example = "false")
+    private Boolean isRead;
+
+    @Schema(description = "읽은 시간", nullable = true)
+    private LocalDateTime readAt;
+
+    @Schema(description = "발송 일시", example = "2026-02-09T12:00:00")
+    private LocalDateTime createdAt;
+
+    @Schema(description = "첨부 파일 URL 목록", nullable = true)
+    private List<String> fileUrls;
+
+    public static MentoringCardDetailResponse from(MentoringCard card, List<String> fileUrls) {
+        return MentoringCardDetailResponse.builder()
+                .mentoringCardId(card.getMentoringCardId())
+                .senderId(card.getSender().getUserId())
+                .senderName(card.getSender().getName())
+                .cardTitle(card.getCardTitle())
+                .category(card.getCategory().name())
+                .method(card.getMethod().name())
+                .cardContent(card.getCardContent())
+                .isRead(card.getIsRead())
+                .readAt(card.getReadAt())
+                .createdAt(card.getCreatedAt())
+                .fileUrls(fileUrls)
+                .build();
+    }
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/mentoring/dto/MentoringCardListResponse.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/mentoring/dto/MentoringCardListResponse.java
@@ -1,0 +1,47 @@
+package com.solif.backend.domain.mentoring.dto;
+
+import com.solif.backend.domain.mentoring.entity.MentoringCard;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@Schema(description = "멘토링 엽서 목록 응답")
+public class MentoringCardListResponse {
+
+    @Schema(description = "멘토링 엽서 ID", example = "1")
+    private Long mentoringCardId;
+
+    @Schema(description = "발송자 이름", example = "김철수")
+    private String senderName;
+
+    @Schema(description = "엽서 제목", example = "금융권 IB 직무 멘토를 찾고 싶습니다")
+    private String cardTitle;
+
+    @Schema(description = "카테고리", example = "JOB")
+    private String category;
+
+    @Schema(description = "멘토링 방식", example = "VIDEO")
+    private String method;
+
+    @Schema(description = "읽음 여부", example = "false")
+    private Boolean isRead;
+
+    @Schema(description = "발송 일시", example = "2026-02-09T12:00:00")
+    private LocalDateTime createdAt;
+
+    public static MentoringCardListResponse from(MentoringCard card) {
+        return MentoringCardListResponse.builder()
+                .mentoringCardId(card.getMentoringCardId())
+                .senderName(card.getSender().getName())
+                .cardTitle(card.getCardTitle())
+                .category(card.getCategory().name())
+                .method(card.getMethod().name())
+                .isRead(card.getIsRead())
+                .createdAt(card.getCreatedAt())
+                .build();
+    }
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/mentoring/dto/MentoringCardSendRequest.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/mentoring/dto/MentoringCardSendRequest.java
@@ -1,0 +1,34 @@
+package com.solif.backend.domain.mentoring.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@Schema(description = "멘토링 엽서 발송 요청")
+public class MentoringCardSendRequest {
+
+    @NotBlank(message = "제목은 필수입니다.")
+    @Schema(description = "엽서 제목", example = "금융권 IB 직무 멘토를 찾고 싶습니다")
+    private String cardTitle;
+
+    @NotNull(message = "카테고리는 필수입니다.")
+    @Schema(description = "멘토링 카테고리 (STUDY/JOB/ADMISSION/ETC)", example = "JOB")
+    private String category;
+
+    @NotNull(message = "멘토링 방식은 필수입니다.")
+    @Schema(description = "멘토링 방식 (MESSAGE/VIDEO/PHONE/OFFLINE)", example = "VIDEO")
+    private String method;
+
+    @NotBlank(message = "내용은 필수입니다.")
+    @Schema(description = "엽서 내용", example = "안녕하세요. 저는 한국대학교에 재학중인 학생입니다...")
+    private String cardContent;
+
+    @Schema(description = "첨부 파일 ID 목록", nullable = true)
+    private List<Long> fileIds;
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/mentoring/dto/MentoringCardSendRequest.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/mentoring/dto/MentoringCardSendRequest.java
@@ -1,5 +1,7 @@
 package com.solif.backend.domain.mentoring.dto;
 
+import com.solif.backend.domain.mentoring.entity.MentoringCategory;
+import com.solif.backend.domain.mentoring.entity.MentoringMethod;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -21,11 +23,11 @@ public class MentoringCardSendRequest {
 
     @NotNull(message = "카테고리는 필수입니다.")
     @Schema(description = "멘토링 카테고리 (STUDY/JOB/ADMISSION/ETC)", example = "JOB")
-    private String category;
+    private MentoringCategory category;
 
     @NotNull(message = "멘토링 방식은 필수입니다.")
     @Schema(description = "멘토링 방식 (MESSAGE/VIDEO/PHONE/OFFLINE)", example = "VIDEO")
-    private String method;
+    private MentoringMethod method;
 
     @NotBlank(message = "내용은 필수입니다.")
     @Schema(description = "엽서 내용", example = "안녕하세요. 저는 한국대학교에 재학중인 학생입니다...")

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/mentoring/dto/MentoringCardSendRequest.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/mentoring/dto/MentoringCardSendRequest.java
@@ -3,6 +3,7 @@ package com.solif.backend.domain.mentoring.dto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -14,6 +15,7 @@ import java.util.List;
 public class MentoringCardSendRequest {
 
     @NotBlank(message = "제목은 필수입니다.")
+    @Size(max = 255, message = "제목은 255자 이하여야 합니다.")
     @Schema(description = "엽서 제목", example = "금융권 IB 직무 멘토를 찾고 싶습니다")
     private String cardTitle;
 

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/mentoring/dto/MentoringCardSendResponse.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/mentoring/dto/MentoringCardSendResponse.java
@@ -1,0 +1,31 @@
+package com.solif.backend.domain.mentoring.dto;
+
+import com.solif.backend.domain.mentoring.entity.MentoringCard;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@Schema(description = "멘토링 엽서 발송 응답")
+public class MentoringCardSendResponse {
+
+    @Schema(description = "멘토링 엽서 ID", example = "1")
+    private Long mentoringCardId;
+
+    @Schema(description = "발송자 이름", example = "김철수")
+    private String senderName;
+
+    @Schema(description = "발송 일시", example = "2026-02-09T12:00:00")
+    private LocalDateTime createdAt;
+
+    public static MentoringCardSendResponse from(MentoringCard card) {
+        return MentoringCardSendResponse.builder()
+                .mentoringCardId(card.getMentoringCardId())
+                .senderName(card.getSender().getName())
+                .createdAt(card.getCreatedAt())
+                .build();
+    }
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/mentoring/dto/MentoringHomeResponse.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/mentoring/dto/MentoringHomeResponse.java
@@ -52,6 +52,9 @@ public class MentoringHomeResponse {
 
             @Schema(description = "관심사 목록")
             private List<String> interests;
+
+            @Schema(description = "상태 (PENDING: 대기중, COMPLETED: 양방향 완료)", example = "PENDING")
+            private String status;
         }
     }
 

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/mentoring/dto/MentoringHomeResponse.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/mentoring/dto/MentoringHomeResponse.java
@@ -1,0 +1,77 @@
+package com.solif.backend.domain.mentoring.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+@Schema(description = "멘토링 홈 응답")
+public class MentoringHomeResponse {
+
+    @Schema(description = "전문가 멘토 목록 (최대 4개)")
+    private List<MentorListResponse> mentors;
+
+    @Schema(description = "선후배 멘토링 사용자 목록 (응원하기)")
+    private SeniorJuniorMentoringResponse cheerList;
+
+    @Schema(description = "선후배 멘토링 사용자 목록 (경험나누기)")
+    private SeniorJuniorMentoringResponse helpList;
+
+    @Schema(description = "멘토링 후기 목록 (최대 4개)")
+    private List<MentoringReviewResponse> reviews;
+
+    @Getter
+    @Builder
+    @Schema(description = "선후배 멘토링 응답")
+    public static class SeniorJuniorMentoringResponse {
+
+        @Schema(description = "사용자 목록")
+        private List<UserCardResponse> users;
+
+        @Getter
+        @Builder
+        @Schema(description = "사용자 카드 응답")
+        public static class UserCardResponse {
+            @Schema(description = "사용자 ID", example = "1")
+            private Long userId;
+
+            @Schema(description = "사용자 이름", example = "김철수")
+            private String userName;
+
+            @Schema(description = "캐릭터", example = "character_1")
+            private String character;
+
+            @Schema(description = "배경 패턴", example = "pattern_1")
+            private String backgroundPattern;
+
+            @Schema(description = "단단한 목표 이름", example = "취업 준비")
+            private String solidGoalName;
+
+            @Schema(description = "관심사 목록")
+            private List<String> interests;
+        }
+    }
+
+    @Getter
+    @Builder
+    @Schema(description = "멘토링 후기 응답")
+    public static class MentoringReviewResponse {
+        @Schema(description = "게시글 ID", example = "1")
+        private Long postId;
+
+        @Schema(description = "제목", example = "신한 멘토님과의 멘토링 후기")
+        private String title;
+
+        @Schema(description = "작성자", example = "김철수")
+        private String authorName;
+
+        @Schema(description = "카테고리", example = "STUDY")
+        private String category;
+
+        @Schema(description = "조회수", example = "150")
+        private Integer viewCount;
+    }
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/mentoring/dto/MentoringHomeResponse.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/mentoring/dto/MentoringHomeResponse.java
@@ -11,8 +11,17 @@ import java.util.List;
 @Schema(description = "멘토링 홈 응답")
 public class MentoringHomeResponse {
 
-    @Schema(description = "전문가 멘토 목록 (최대 4개)")
-    private List<MentorListResponse> mentors;
+    @Schema(description = "전체 전문가 멘토 목록")
+    private List<MentorListResponse> allMentors;
+
+    @Schema(description = "학업고민 멘토 목록")
+    private List<MentorListResponse> studyMentors;
+
+    @Schema(description = "취업고민 멘토 목록")
+    private List<MentorListResponse> jobMentors;
+
+    @Schema(description = "인생의 멘토 목록")
+    private List<MentorListResponse> lifeMentors;
 
     @Schema(description = "선후배 멘토링 사용자 목록 (응원하기)")
     private SeniorJuniorMentoringResponse cheerList;

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/mentoring/dto/MentoringRequestCreateRequest.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/mentoring/dto/MentoringRequestCreateRequest.java
@@ -1,5 +1,7 @@
 package com.solif.backend.domain.mentoring.dto;
 
+import com.solif.backend.domain.mentoring.entity.MentoringCategory;
+import com.solif.backend.domain.mentoring.entity.MentoringMethod;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -17,7 +19,7 @@ public class MentoringRequestCreateRequest {
 
     @NotNull(message = "카테고리는 필수입니다.")
     @Schema(description = "멘토링 카테고리 (STUDY/JOB/ADMISSION/ETC)", example = "STUDY")
-    private String category;
+    private MentoringCategory category;
 
     @NotBlank(message = "신청 내용은 필수입니다.")
     @Schema(description = "멘토링 신청 내용", example = "안녕하세요. 저는 한국대학교에 재학중인 학생입니다...")
@@ -25,5 +27,5 @@ public class MentoringRequestCreateRequest {
 
     @NotNull(message = "멘토링 방식은 필수입니다.")
     @Schema(description = "멘토링 방식 (MESSAGE/VIDEO/PHONE/OFFLINE)", example = "MESSAGE")
-    private String method;
+    private MentoringMethod method;
 }

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/mentoring/dto/MentoringRequestCreateRequest.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/mentoring/dto/MentoringRequestCreateRequest.java
@@ -1,0 +1,29 @@
+package com.solif.backend.domain.mentoring.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@Schema(description = "멘토링 신청 요청")
+public class MentoringRequestCreateRequest {
+
+    @NotNull(message = "멘토 ID는 필수입니다.")
+    @Schema(description = "멘토 ID", example = "1")
+    private Long mentorId;
+
+    @NotNull(message = "카테고리는 필수입니다.")
+    @Schema(description = "멘토링 카테고리 (STUDY/JOB/ADMISSION/ETC)", example = "STUDY")
+    private String category;
+
+    @NotBlank(message = "신청 내용은 필수입니다.")
+    @Schema(description = "멘토링 신청 내용", example = "안녕하세요. 저는 한국대학교에 재학중인 학생입니다...")
+    private String content;
+
+    @NotNull(message = "멘토링 방식은 필수입니다.")
+    @Schema(description = "멘토링 방식 (MESSAGE/VIDEO/PHONE/OFFLINE)", example = "MESSAGE")
+    private String method;
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/mentoring/dto/MentoringRequestCreateResponse.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/mentoring/dto/MentoringRequestCreateResponse.java
@@ -1,0 +1,35 @@
+package com.solif.backend.domain.mentoring.dto;
+
+import com.solif.backend.domain.mentoring.entity.MentoringRequest;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@Schema(description = "멘토링 신청 응답")
+public class MentoringRequestCreateResponse {
+
+    @Schema(description = "멘토링 신청 ID", example = "1")
+    private Long mentoringRequestId;
+
+    @Schema(description = "멘토 이름", example = "신석균")
+    private String mentorName;
+
+    @Schema(description = "신청 상태", example = "PENDING")
+    private String status;
+
+    @Schema(description = "신청 일시", example = "2026-02-09T12:00:00")
+    private LocalDateTime createdAt;
+
+    public static MentoringRequestCreateResponse from(MentoringRequest request) {
+        return MentoringRequestCreateResponse.builder()
+                .mentoringRequestId(request.getMentoringRequestId())
+                .mentorName(request.getMentor().getMentorName())
+                .status(request.getStatus().name())
+                .createdAt(request.getCreatedAt())
+                .build();
+    }
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/mentoring/dto/MentoringRequestDetailResponse.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/mentoring/dto/MentoringRequestDetailResponse.java
@@ -1,0 +1,91 @@
+package com.solif.backend.domain.mentoring.dto;
+
+import com.solif.backend.domain.mentoring.entity.MentoringRequest;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@Schema(description = "멘토링 신청서 상세 응답")
+public class MentoringRequestDetailResponse {
+
+    @Schema(description = "멘토링 신청 ID", example = "1")
+    private Long mentoringRequestId;
+
+    @Schema(description = "멘토 ID", example = "1")
+    private Long mentorId;
+
+    @Schema(description = "멘토 이름", example = "신석균")
+    private String mentorName;
+
+    @Schema(description = "멘토 직함", example = "멘토 SO&L 글로벌자산운용 대표")
+    private String mentorTitle;
+
+    @Schema(description = "멘토 소개", example = "안녕하세요. 저는 SO&L 글로벌자산운용 대표...")
+    private String mentorIntro;
+
+    @Schema(description = "멘토 프로필 이미지 URL", nullable = true)
+    private String mentorProfileImageUrl;
+
+    @Schema(description = "신청자 ID", example = "5")
+    private Long menteeUserId;
+
+    @Schema(description = "신청자 이름", example = "김철수")
+    private String menteeName;
+
+    @Schema(description = "카테고리", example = "STUDY")
+    private String category;
+
+    @Schema(description = "멘토링 방식", example = "MESSAGE")
+    private String method;
+
+    @Schema(description = "신청 상태", example = "PENDING")
+    private String status;
+
+    @Schema(description = "신청 내용", example = "안녕하세요. 자산관리에 대해 멘토링을 받고 싶습니다...")
+    private String content;
+
+    @Schema(description = "관리자 답변", nullable = true)
+    private String adminReply;
+
+    @Schema(description = "신청 일시", example = "2026-02-09T12:00:00")
+    private LocalDateTime createdAt;
+
+    @Schema(description = "상태 변경 일시", nullable = true)
+    private LocalDateTime updatedAt;
+
+    @Schema(description = "답변 일시", nullable = true)
+    private LocalDateTime repliedAt;
+
+    @Schema(description = "후기 작성 여부", example = "false")
+    private Boolean hasReview;
+
+    @Schema(description = "후기 게시글 ID", nullable = true)
+    private Long reviewPostId;
+
+    public static MentoringRequestDetailResponse from(MentoringRequest request, String mentorProfileImageUrl) {
+        return MentoringRequestDetailResponse.builder()
+                .mentoringRequestId(request.getMentoringRequestId())
+                .mentorId(request.getMentor().getMentorId())
+                .mentorName(request.getMentor().getMentorName())
+                .mentorTitle(request.getMentor().getMentorTitle())
+                .mentorIntro(request.getMentor().getMentorIntro())
+                .mentorProfileImageUrl(mentorProfileImageUrl)
+                .menteeUserId(request.getMenteeUser().getUserId())
+                .menteeName(request.getMenteeUser().getName())
+                .category(request.getCategory().name())
+                .method(request.getMethod().name())
+                .status(request.getStatus().name())
+                .content(request.getContent())
+                .adminReply(request.getAdminReply())
+                .createdAt(request.getCreatedAt())
+                .updatedAt(request.getUpdatedAt())
+                .repliedAt(request.getRepliedAt())
+                .hasReview(request.getReviewPost() != null)
+                .reviewPostId(request.getReviewPost() != null ? request.getReviewPost().getPostId() : null)
+                .build();
+    }
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/mentoring/dto/MentoringRequestListResponse.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/mentoring/dto/MentoringRequestListResponse.java
@@ -1,0 +1,61 @@
+package com.solif.backend.domain.mentoring.dto;
+
+import com.solif.backend.domain.mentoring.entity.MentoringRequest;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@Schema(description = "멘토링 신청 내역 응답")
+public class MentoringRequestListResponse {
+
+    @Schema(description = "멘토링 신청 ID", example = "1")
+    private Long mentoringRequestId;
+
+    @Schema(description = "멘토 이름", example = "신석균")
+    private String mentorName;
+
+    @Schema(description = "멘토 직함", example = "멘토 SO&L 글로벌자산운용 대표")
+    private String mentorTitle;
+
+    @Schema(description = "카테고리", example = "STUDY")
+    private String category;
+
+    @Schema(description = "멘토링 방식", example = "MESSAGE")
+    private String method;
+
+    @Schema(description = "신청 상태", example = "PENDING")
+    private String status;
+
+    @Schema(description = "신청 내용", example = "안녕하세요. 자산관리에 대해 멘토링을 받고 싶습니다.")
+    private String content;
+
+    // 관리자 답변
+    @Schema(description = "관리자 답변", example = "김철수님, 멘토링 신청 감사합니다...", nullable = true)
+    private String adminReply;
+
+    @Schema(description = "신청 일시", example = "2026-02-09T12:00:00")
+    private LocalDateTime createdAt;
+
+    // 답변 일시
+    @Schema(description = "답변 일시", example = "2026-02-10T15:00:00", nullable = true)
+    private LocalDateTime repliedAt;
+
+    public static MentoringRequestListResponse from(MentoringRequest request) {
+        return MentoringRequestListResponse.builder()
+                .mentoringRequestId(request.getMentoringRequestId())
+                .mentorName(request.getMentor().getMentorName())
+                .mentorTitle(request.getMentor().getMentorTitle())
+                .category(request.getCategory().name())
+                .method(request.getMethod().name())
+                .status(request.getStatus().name())
+                .content(request.getContent())
+                .adminReply(request.getAdminReply())
+                .createdAt(request.getCreatedAt())
+                .repliedAt(request.getRepliedAt())
+                .build();
+    }
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/mentoring/entity/Mentor.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/mentoring/entity/Mentor.java
@@ -36,6 +36,11 @@ public class Mentor {
     @JoinColumn(name = "profile_image_file_id")
     private File profileImageFile;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "mentor_category", nullable = false, length = 50)
+    private MentorCategory mentorCategory;
+
+
     @Column(name = "is_active", nullable = false)
     private Boolean isActive = true;
 
@@ -45,11 +50,12 @@ public class Mentor {
 
     @Builder
     public Mentor(String mentorTitle, String mentorName, String mentorIntro,
-                  File profileImageFile, Boolean isActive) {
+                  File profileImageFile, MentorCategory mentorCategory, Boolean isActive) {
         this.mentorTitle = mentorTitle;
         this.mentorName = mentorName;
         this.mentorIntro = mentorIntro;
         this.profileImageFile = profileImageFile;
+        this.mentorCategory = mentorCategory;
         this.isActive = isActive != null ? isActive : true;
     }
 }

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/mentoring/entity/Mentor.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/mentoring/entity/Mentor.java
@@ -1,0 +1,55 @@
+package com.solif.backend.domain.mentoring.entity;
+
+import com.solif.backend.domain.file.entity.File;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "mentor")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class Mentor {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "mentor_id")
+    private Long mentorId;
+
+    @Column(name = "mentor_title", nullable = false, length = 150)
+    private String mentorTitle;
+
+    @Column(name = "mentor_name", nullable = false, length = 50)
+    private String mentorName;
+
+    @Column(name = "mentor_intro", nullable = false, columnDefinition = "TEXT")
+    private String mentorIntro;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "profile_image_file_id")
+    private File profileImageFile;
+
+    @Column(name = "is_active", nullable = false)
+    private Boolean isActive = true;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Builder
+    public Mentor(String mentorTitle, String mentorName, String mentorIntro,
+                  File profileImageFile, Boolean isActive) {
+        this.mentorTitle = mentorTitle;
+        this.mentorName = mentorName;
+        this.mentorIntro = mentorIntro;
+        this.profileImageFile = profileImageFile;
+        this.isActive = isActive != null ? isActive : true;
+    }
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/mentoring/entity/MentorCategory.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/mentoring/entity/MentorCategory.java
@@ -1,0 +1,7 @@
+package com.solif.backend.domain.mentoring.entity;
+
+public enum MentorCategory {
+    STUDY,      // 학업고민
+    JOB,        // 취업고민
+    LIFE        // 인생의 멘토
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/mentoring/entity/MentoringCard.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/mentoring/entity/MentoringCard.java
@@ -1,0 +1,76 @@
+package com.solif.backend.domain.mentoring.entity;
+
+import com.solif.backend.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "mentoring_card")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class MentoringCard {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "mentoring_card_id")
+    private Long mentoringCardId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "sender_user_id", nullable = false)
+    private User sender;
+
+    @Column(name = "card_title", nullable = false, length = 255)
+    private String cardTitle;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "category", nullable = false, length = 50)
+    private MentoringCategory category;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "method", nullable = false, length = 50)
+    private MentoringMethod method;
+
+    @Column(name = "card_content", nullable = false, columnDefinition = "TEXT")
+    private String cardContent;
+
+    @Column(name = "is_read", nullable = false)
+    private Boolean isRead = false;
+
+    @Column(name = "read_at")
+    private LocalDateTime readAt;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Builder
+    public MentoringCard(User sender, String cardTitle, MentoringCategory category,
+                         MentoringMethod method, String cardContent) {
+        this.sender = sender;
+        this.cardTitle = cardTitle;
+        this.category = category;
+        this.method = method;
+        this.cardContent = cardContent;
+        this.isRead = false;
+    }
+
+    // 비즈니스 로직
+    public void markAsRead() {
+        if (!this.isRead) {
+            this.isRead = true;
+            this.readAt = LocalDateTime.now();
+        }
+    }
+
+    public boolean isSender(Long userId) {
+        return this.sender.getUserId().equals(userId);
+    }
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/mentoring/entity/MentoringCategory.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/mentoring/entity/MentoringCategory.java
@@ -1,0 +1,8 @@
+package com.solif.backend.domain.mentoring.entity;
+
+public enum MentoringCategory {
+    STUDY,      // 학업
+    ADMISSION,  // 진학
+    JOB,        // 취업
+    ETC         // 기타
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/mentoring/entity/MentoringInteraction.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/mentoring/entity/MentoringInteraction.java
@@ -12,7 +12,15 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "mentoring_interaction")
+@Table(
+        name = "mentoring_interaction",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_mentoring_interaction",
+                        columnNames = {"sender_user_id", "receiver_user_id", "interaction_type"}
+                )
+        }
+)
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @EntityListeners(AuditingEntityListener.class)

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/mentoring/entity/MentoringInteraction.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/mentoring/entity/MentoringInteraction.java
@@ -1,0 +1,48 @@
+package com.solif.backend.domain.mentoring.entity;
+
+import com.solif.backend.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "mentoring_interaction")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class MentoringInteraction {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "mentoring_interaction_id")
+    private Long mentoringInteractionId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "sender_user_id", nullable = false)
+    private User sender;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "receiver_user_id", nullable = false)
+    private User receiver;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "interaction_type", nullable = false, length = 50)
+    private MentoringInteractionType interactionType;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Builder
+    public MentoringInteraction(User sender, User receiver, MentoringInteractionType interactionType) {
+        this.sender = sender;
+        this.receiver = receiver;
+        this.interactionType = interactionType;
+    }
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/mentoring/entity/MentoringInteractionType.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/mentoring/entity/MentoringInteractionType.java
@@ -1,0 +1,6 @@
+package com.solif.backend.domain.mentoring.entity;
+
+public enum MentoringInteractionType {
+    CHEER,  // 응원하기
+    HELP    // 경험나누기
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/mentoring/entity/MentoringMethod.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/mentoring/entity/MentoringMethod.java
@@ -1,0 +1,8 @@
+package com.solif.backend.domain.mentoring.entity;
+
+public enum MentoringMethod {
+    MESSAGE,    // 쪽지
+    VIDEO,      // 화상
+    PHONE,      // 전화
+    OFFLINE     // 대면
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/mentoring/entity/MentoringRequest.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/mentoring/entity/MentoringRequest.java
@@ -1,0 +1,107 @@
+package com.solif.backend.domain.mentoring.entity;
+
+import com.solif.backend.domain.post.entity.Post;
+import com.solif.backend.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "mentoring_request")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class MentoringRequest {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "mentoring_request_id")
+    private Long mentoringRequestId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "mentor_id", nullable = false)
+    private Mentor mentor;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "mentee_user_id", nullable = false)
+    private User menteeUser;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "review_post_id")
+    private Post reviewPost;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "category", nullable = false, length = 50)
+    private MentoringCategory category;
+
+    @Column(name = "content", nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "method", nullable = false, length = 50)
+    private MentoringMethod method;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 50)
+    private MentoringRequestStatus status = MentoringRequestStatus.PENDING;
+
+    // 관리자 답변
+    @Column(name = "admin_reply", columnDefinition = "TEXT")
+    private String adminReply;
+
+    // 답변 작성 일시
+    @Column(name = "replied_at")
+    private LocalDateTime repliedAt;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Builder
+    public MentoringRequest(Mentor mentor, User menteeUser, MentoringCategory category,
+                            String content, MentoringMethod method) {
+        this.mentor = mentor;
+        this.menteeUser = menteeUser;
+        this.category = category;
+        this.content = content;
+        this.method = method;
+        this.status = MentoringRequestStatus.PENDING;
+    }
+
+    // 비즈니스 로직
+    public void updateStatus(MentoringRequestStatus newStatus) {
+        this.status = newStatus;
+    }
+
+    public void linkReviewPost(Post reviewPost) {
+        this.reviewPost = reviewPost;
+    }
+
+    // 관리자 답변 작성
+    public void replyByAdmin(String adminReply) {
+        this.adminReply = adminReply;
+        this.repliedAt = LocalDateTime.now();
+        // 답변 작성 시 상태를 APPROVED 또는 REJECTED로 변경 가능
+        // (상태 변경은 관리자가 선택)
+    }
+
+    public boolean isMentee(Long userId) {
+        return this.menteeUser.getUserId().equals(userId);
+    }
+
+    // 답변 여부 확인
+    public boolean hasReply() {
+        return this.adminReply != null && !this.adminReply.isEmpty();
+    }
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/mentoring/entity/MentoringRequestStatus.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/mentoring/entity/MentoringRequestStatus.java
@@ -1,0 +1,8 @@
+package com.solif.backend.domain.mentoring.entity;
+
+public enum MentoringRequestStatus {
+    PENDING,    // 대기중
+    APPROVED,   // 승인됨
+    REJECTED,   // 거절됨
+    COMPLETED   // 완료됨
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/mentoring/repository/MentorRepository.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/mentoring/repository/MentorRepository.java
@@ -1,0 +1,12 @@
+package com.solif.backend.domain.mentoring.repository;
+
+import com.solif.backend.domain.mentoring.entity.Mentor;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface MentorRepository extends JpaRepository<Mentor, Long> {
+
+    // 활성화된 전문가 멘토 전체 조회
+    List<Mentor> findByIsActiveTrueOrderByCreatedAtDesc();
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/mentoring/repository/MentorRepository.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/mentoring/repository/MentorRepository.java
@@ -1,6 +1,7 @@
 package com.solif.backend.domain.mentoring.repository;
 
 import com.solif.backend.domain.mentoring.entity.Mentor;
+import com.solif.backend.domain.mentoring.entity.MentorCategory;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -9,4 +10,7 @@ public interface MentorRepository extends JpaRepository<Mentor, Long> {
 
     // 활성화된 전문가 멘토 전체 조회
     List<Mentor> findByIsActiveTrueOrderByCreatedAtDesc();
+
+    // 카테고리별 활성화된 멘토 목록 조회
+    List<Mentor> findByIsActiveTrueAndMentorCategoryOrderByCreatedAtDesc(MentorCategory mentorCategory);
 }

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/mentoring/repository/MentoringCardRepository.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/mentoring/repository/MentoringCardRepository.java
@@ -1,0 +1,24 @@
+package com.solif.backend.domain.mentoring.repository;
+
+import com.solif.backend.domain.mentoring.entity.MentoringCard;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface MentoringCardRepository extends JpaRepository<MentoringCard, Long> {
+
+    // 내가 보낸 멘토링 엽서 목록 조회 (최신순)
+    @Query("SELECT mc FROM MentoringCard mc " +
+            "JOIN FETCH mc.sender " +
+            "WHERE mc.sender.userId = :userId " +
+            "ORDER BY mc.createdAt DESC")
+    Slice<MentoringCard> findSentCards(@Param("userId") Long userId, Pageable pageable);
+
+    // 관리자용: 모든 멘토링 엽서 목록 조회 (향후 구현)
+    @Query("SELECT mc FROM MentoringCard mc " +
+            "JOIN FETCH mc.sender " +
+            "ORDER BY mc.createdAt DESC")
+    Slice<MentoringCard> findAllCards(Pageable pageable);
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/mentoring/repository/MentoringInteractionRepository.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/mentoring/repository/MentoringInteractionRepository.java
@@ -1,0 +1,66 @@
+package com.solif.backend.domain.mentoring.repository;
+
+import com.solif.backend.domain.mentoring.entity.MentoringInteraction;
+import com.solif.backend.domain.mentoring.entity.MentoringInteractionType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface MentoringInteractionRepository extends JpaRepository<MentoringInteraction, Long> {
+
+    // 특정 사용자 간 상호작용 존재 여부 확인
+    boolean existsBySender_UserIdAndReceiver_UserIdAndInteractionType(
+            Long senderId, Long receiverId, MentoringInteractionType interactionType);
+
+    // 양방향 상호작용 체크 (서로 보냈는지 확인)
+    @Query("SELECT CASE WHEN COUNT(mi) = 2 THEN true ELSE false END " +
+            "FROM MentoringInteraction mi " +
+            "WHERE ((mi.sender.userId = :userId1 AND mi.receiver.userId = :userId2) OR " +
+            "       (mi.sender.userId = :userId2 AND mi.receiver.userId = :userId1)) " +
+            "AND mi.interactionType = :type")
+    boolean existsMutualInteraction(@Param("userId1") Long userId1,
+                                    @Param("userId2") Long userId2,
+                                    @Param("type") MentoringInteractionType type);
+
+    // 특정 사용자에게 온 상호작용 목록 (받은 것만)
+    @Query("SELECT mi FROM MentoringInteraction mi " +
+            "JOIN FETCH mi.sender " +
+            "WHERE mi.receiver.userId = :userId " +
+            "AND mi.interactionType = :type " +
+            "ORDER BY mi.createdAt DESC")
+    List<MentoringInteraction> findReceivedInteractions(@Param("userId") Long userId,
+                                                        @Param("type") MentoringInteractionType type);
+
+    // 응원하기: 내가 받은 것 중 아직 내가 보내지 않은 사람들 (대기중)
+    @Query("SELECT mi FROM MentoringInteraction mi " +
+            "JOIN FETCH mi.sender " +
+            "WHERE mi.receiver.userId = :userId " +
+            "AND mi.interactionType = :type " +
+            "AND NOT EXISTS (" +
+            "  SELECT 1 FROM MentoringInteraction mi2 " +
+            "  WHERE mi2.sender.userId = :userId " +
+            "  AND mi2.receiver.userId = mi.sender.userId " +
+            "  AND mi2.interactionType = :type" +
+            ") " +
+            "ORDER BY mi.createdAt DESC")
+    List<MentoringInteraction> findPendingReceivedInteractions(@Param("userId") Long userId,
+                                                               @Param("type") MentoringInteractionType type);
+
+    // 양방향 완료된 상호작용 (서로 보낸 사람들)
+    @Query("SELECT mi FROM MentoringInteraction mi " +
+            "JOIN FETCH mi.sender " +
+            "JOIN FETCH mi.receiver " +
+            "WHERE ((mi.sender.userId = :userId OR mi.receiver.userId = :userId)) " +
+            "AND mi.interactionType = :type " +
+            "AND EXISTS (" +
+            "  SELECT 1 FROM MentoringInteraction mi2 " +
+            "  WHERE mi2.sender.userId = mi.receiver.userId " +
+            "  AND mi2.receiver.userId = mi.sender.userId " +
+            "  AND mi2.interactionType = :type" +
+            ") " +
+            "ORDER BY mi.createdAt DESC")
+    List<MentoringInteraction> findCompletedInteractions(@Param("userId") Long userId,
+                                                         @Param("type") MentoringInteractionType type);
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/mentoring/repository/MentoringRequestRepository.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/mentoring/repository/MentoringRequestRepository.java
@@ -1,0 +1,36 @@
+package com.solif.backend.domain.mentoring.repository;
+
+import com.solif.backend.domain.mentoring.entity.MentoringRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface MentoringRequestRepository extends JpaRepository<MentoringRequest, Long> {
+
+    // 내가 보낸 신청서 목록 조회 (전체 - 답변 유무 상관없이)
+    @Query("SELECT mr FROM MentoringRequest mr " +
+            "JOIN FETCH mr.mentor " +
+            "WHERE mr.menteeUser.userId = :userId " +
+            "ORDER BY mr.createdAt DESC")
+    Slice<MentoringRequest> findSentRequests(@Param("userId") Long userId, Pageable pageable);
+
+    // 받은 신청서 목록 조회 (답변이 있는 것만)
+    @Query("SELECT mr FROM MentoringRequest mr " +
+            "JOIN FETCH mr.mentor " +
+            "WHERE mr.menteeUser.userId = :userId " +
+            "AND mr.adminReply IS NOT NULL " +
+            "ORDER BY mr.repliedAt DESC")
+    Slice<MentoringRequest> findReceivedRequests(@Param("userId") Long userId, Pageable pageable);
+
+    // 신청서 상세 조회 (멘토 정보 포함)
+    @Query("SELECT mr FROM MentoringRequest mr " +
+            "JOIN FETCH mr.mentor m " +
+            "JOIN FETCH mr.menteeUser " +
+            "LEFT JOIN FETCH mr.reviewPost " +
+            "WHERE mr.mentoringRequestId = :requestId")
+    Optional<MentoringRequest> findByIdWithDetails(@Param("requestId") Long requestId);
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/mentoring/service/MentoringService.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/mentoring/service/MentoringService.java
@@ -296,7 +296,7 @@ public class MentoringService {
     }
 
     // 멘토링 엽서 상세 조회
-    @Transactional
+    @Transactional(readOnly = true)
     public MentoringCardDetailResponse getCardDetail(Long userId, Long cardId) {
         log.info("멘토링 엽서 상세 조회 - userId: {}, cardId: {}", userId, cardId);
 
@@ -306,11 +306,6 @@ public class MentoringService {
         // 권한 확인 (본인만 조회 가능)
         if (!card.isSender(userId)) {
             throw new CustomException(MentoringErrorCode.UNAUTHORIZED_CARD_ACCESS);
-        }
-
-        // 읽음 처리
-        if (!card.getIsRead()) {
-            card.markAsRead();
         }
 
         // 첨부 파일 URL 조회

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/mentoring/service/MentoringService.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/mentoring/service/MentoringService.java
@@ -140,7 +140,37 @@ public class MentoringService {
         return requests.map(MentoringRequestListResponse::from);
     }
 
-    // 받은 신청서 목록 조회 (답변이 있는 것만)
+    // 멘토링 신청서 상세 조회
+    public MentoringRequestDetailResponse getRequestDetail(Long userId, Long requestId) {
+        log.info("멘토링 신청서 상세 조회 - userId: {}, requestId: {}", userId, requestId);
+
+        // 신청서 조회
+        MentoringRequest request = mentoringRequestRepository.findByIdWithDetails(requestId)
+                .orElseThrow(() -> new CustomException(MentoringErrorCode.MENTORING_REQUEST_NOT_FOUND));
+
+        // 권한 확인 (신청자 본인만 조회 가능)
+        if (!request.isMentee(userId)) {
+            throw new CustomException(MentoringErrorCode.UNAUTHORIZED_REQUEST_ACCESS);
+        }
+
+        // 멘토 프로필 이미지 조회
+        String mentorProfileImageUrl = null;
+        Optional<FileAttachment> profileImage = fileAttachmentRepository
+                .findByFileTargetTypeAndTargetIdAndSortOrderAndPurpose(
+                        FileTargetType.MENTOR_PROFILE,
+                        request.getMentor().getMentorId(),
+                        1,
+                        AttachmentPurpose.PROFILE_IMAGE
+                );
+
+        if (profileImage.isPresent()) {
+            mentorProfileImageUrl = profileImage.get().getFile().getUrl(region);
+        }
+
+        return MentoringRequestDetailResponse.from(request, mentorProfileImageUrl);
+    }
+
+    // 내가 받은 답변 목록 조회
     public Slice<MentoringRequestListResponse> getReceivedRequests(Long userId, Pageable pageable) {
         log.info("받은 신청서 목록 조회 - userId: {}", userId);
 
@@ -296,36 +326,6 @@ public class MentoringService {
                 .toList();
 
         return MentoringCardDetailResponse.from(card, fileUrls);
-    }
-
-    // 멘토링 신청서 상세 조회
-    public MentoringRequestDetailResponse getRequestDetail(Long userId, Long requestId) {
-        log.info("멘토링 신청서 상세 조회 - userId: {}, requestId: {}", userId, requestId);
-
-        // 신청서 조회
-        MentoringRequest request = mentoringRequestRepository.findByIdWithDetails(requestId)
-                .orElseThrow(() -> new CustomException(MentoringErrorCode.MENTORING_REQUEST_NOT_FOUND));
-
-        // 권한 확인 (신청자 본인만 조회 가능)
-        if (!request.isMentee(userId)) {
-            throw new CustomException(MentoringErrorCode.UNAUTHORIZED_REQUEST_ACCESS);
-        }
-
-        // 멘토 프로필 이미지 조회
-        String mentorProfileImageUrl = null;
-        Optional<FileAttachment> profileImage = fileAttachmentRepository
-                .findByFileTargetTypeAndTargetIdAndSortOrderAndPurpose(
-                        FileTargetType.MENTOR_PROFILE,
-                        request.getMentor().getMentorId(),
-                        1,
-                        AttachmentPurpose.PROFILE_IMAGE
-                );
-
-        if (profileImage.isPresent()) {
-            mentorProfileImageUrl = profileImage.get().getFile().getUrl(region);
-        }
-
-        return MentoringRequestDetailResponse.from(request, mentorProfileImageUrl);
     }
 
     // === Helper Methods ===

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/mentoring/service/MentoringService.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/mentoring/service/MentoringService.java
@@ -1,0 +1,404 @@
+package com.solif.backend.domain.mentoring.service;
+
+import com.solif.backend.domain.auth.code.AuthErrorCode;
+import com.solif.backend.domain.file.entity.AttachmentPurpose;
+import com.solif.backend.domain.file.entity.FileAttachment;
+import com.solif.backend.domain.file.entity.FileTargetType;
+import com.solif.backend.domain.file.repository.FileAttachmentRepository;
+import com.solif.backend.domain.file.service.FileService;
+import com.solif.backend.domain.interest.entity.UserInterest;
+import com.solif.backend.domain.interest.repository.UserInterestRepository;
+import com.solif.backend.domain.mentoring.code.MentoringErrorCode;
+import com.solif.backend.domain.mentoring.dto.*;
+import com.solif.backend.domain.mentoring.entity.*;
+import com.solif.backend.domain.mentoring.repository.MentorRepository;
+import com.solif.backend.domain.mentoring.repository.MentoringCardRepository;
+import com.solif.backend.domain.mentoring.repository.MentoringRequestRepository;
+import com.solif.backend.domain.post.entity.Post;
+import com.solif.backend.domain.post.repository.PostRepository;
+import com.solif.backend.domain.profile.entity.UserProfile;
+import com.solif.backend.domain.profile.repository.UserProfileRepository;
+import com.solif.backend.domain.user.entity.User;
+import com.solif.backend.domain.user.repository.UserRepository;
+import com.solif.backend.global.common.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MentoringService {
+
+    private final MentorRepository mentorRepository;
+    private final MentoringRequestRepository mentoringRequestRepository;
+    private final UserRepository userRepository;
+    private final UserProfileRepository userProfileRepository;
+    private final UserInterestRepository userInterestRepository;
+    private final PostRepository postRepository;
+    private final FileAttachmentRepository fileAttachmentRepository;
+    private final MentoringCardRepository mentoringCardRepository;
+    private final FileService fileService;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    // 전문가 멘토 목록 조회
+    public List<MentorListResponse> getMentors() {
+        log.info("전문가 멘토 목록 조회");
+
+        List<Mentor> mentors = mentorRepository.findByIsActiveTrueOrderByCreatedAtDesc();
+
+        // N+1 방지: 배치로 프로필 이미지 조회
+        List<Long> mentorIds = mentors.stream()
+                .map(Mentor::getMentorId)
+                .collect(Collectors.toList());
+
+        // 기존 메서드 사용: findByFileTargetTypeAndTargetIdInAndSortOrderAndPurpose
+        Map<Long, String> profileImageMap = mentorIds.isEmpty() ? Map.of() :
+                fileAttachmentRepository.findByFileTargetTypeAndTargetIdInAndSortOrderAndPurpose(
+                                FileTargetType.MENTOR_PROFILE,
+                                mentorIds,
+                                1,
+                                AttachmentPurpose.PROFILE_IMAGE
+                        )
+                        .stream()
+                        .collect(Collectors.toMap(
+                                FileAttachment::getTargetId,
+                                attachment -> attachment.getFile().getUrl(region),
+                                (existing, replacement) -> existing
+                        ));
+
+        return mentors.stream()
+                .map(mentor -> MentorListResponse.from(
+                        mentor,
+                        profileImageMap.get(mentor.getMentorId())
+                ))
+                .collect(Collectors.toList());
+    }
+
+    // 멘토링 신청
+    @Transactional
+    public MentoringRequestCreateResponse createMentoringRequest(Long userId, MentoringRequestCreateRequest request) {
+        log.info("멘토링 신청 - userId: {}, mentorId: {}", userId, request.getMentorId());
+
+        // 사용자 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(AuthErrorCode.USER_NOT_FOUND));
+
+        // 멘토 조회
+        Mentor mentor = mentorRepository.findById(request.getMentorId())
+                .orElseThrow(() -> new CustomException(MentoringErrorCode.MENTOR_NOT_FOUND));
+
+        // Enum 변환
+        MentoringCategory category;
+        MentoringMethod method;
+
+        try {
+            category = MentoringCategory.valueOf(request.getCategory().toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new CustomException(MentoringErrorCode.INVALID_CATEGORY);
+        }
+
+        try {
+            method = MentoringMethod.valueOf(request.getMethod().toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new CustomException(MentoringErrorCode.INVALID_METHOD);
+        }
+
+        // 멘토링 신청 생성
+        MentoringRequest mentoringRequest = MentoringRequest.builder()
+                .mentor(mentor)
+                .menteeUser(user)
+                .category(category)
+                .content(request.getContent())
+                .method(method)
+                .build();
+
+        MentoringRequest saved = mentoringRequestRepository.save(mentoringRequest);
+
+        return MentoringRequestCreateResponse.from(saved);
+    }
+
+    // 내가 보낸 신청서 목록 조회
+    public Slice<MentoringRequestListResponse> getSentRequests(Long userId, Pageable pageable) {
+        log.info("내가 보낸 신청서 목록 조회 - userId: {}", userId);
+
+        Slice<MentoringRequest> requests = mentoringRequestRepository.findSentRequests(userId, pageable);
+
+        return requests.map(MentoringRequestListResponse::from);
+    }
+
+    // 받은 신청서 목록 조회 (답변이 있는 것만)
+    public Slice<MentoringRequestListResponse> getReceivedRequests(Long userId, Pageable pageable) {
+        log.info("받은 신청서 목록 조회 - userId: {}", userId);
+
+        Slice<MentoringRequest> requests = mentoringRequestRepository.findReceivedRequests(userId, pageable);
+
+        return requests.map(MentoringRequestListResponse::from);
+    }
+
+    // 멘토링 홈 조회
+    public MentoringHomeResponse getMentoringHome(Long userId) {
+        log.info("멘토링 홈 조회 - userId: {}", userId);
+
+        User currentUser = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(AuthErrorCode.USER_NOT_FOUND));
+
+        // 1. 전문가 멘토 목록 (최대 4개)
+        List<Mentor> mentors = mentorRepository.findByIsActiveTrueOrderByCreatedAtDesc();
+        List<Mentor> topMentors = mentors.stream().limit(4).collect(Collectors.toList());
+
+        List<Long> mentorIds = topMentors.stream()
+                .map(Mentor::getMentorId)
+                .collect(Collectors.toList());
+
+        Map<Long, String> profileImageMap = mentorIds.isEmpty() ? Map.of() :
+                fileAttachmentRepository.findByFileTargetTypeAndTargetIdInAndSortOrderAndPurpose(
+                                FileTargetType.MENTOR_PROFILE,
+                                mentorIds,
+                                1,
+                                AttachmentPurpose.PROFILE_IMAGE
+                        )
+                        .stream()
+                        .collect(Collectors.toMap(
+                                FileAttachment::getTargetId,
+                                attachment -> attachment.getFile().getUrl(region),
+                                (existing, replacement) -> existing
+                        ));
+
+        List<MentorListResponse> mentorResponses = topMentors.stream()
+                .map(mentor -> MentorListResponse.from(mentor, profileImageMap.get(mentor.getMentorId())))
+                .collect(Collectors.toList());
+
+        // 2. 선후배 멘토링 - 응원하기 (나보다 선배)
+        List<User> seniors = getSeniors(currentUser);
+        MentoringHomeResponse.SeniorJuniorMentoringResponse cheerList =
+                buildSeniorJuniorResponse(seniors);
+
+        // 3. 선후배 멘토링 - 경험나누기 (나와 같거나 후배)
+        // TODO: 선후배 멘토링 리스트 표시 추가 조건 구현 필요
+        // 팀원(장난영)과 논의 후 적용
+        List<User> juniorsAndSame = getJuniorsAndSame(currentUser);
+        MentoringHomeResponse.SeniorJuniorMentoringResponse helpList =
+                buildSeniorJuniorResponse(juniorsAndSame);
+
+        // 4. 멘토링 후기 목록 (boardId=2, 최대 4개)
+        Pageable topReviews = PageRequest.of(0, 4);
+        Slice<Post> reviewPosts = postRepository.findByBoard_BoardIdAndDeletedAtIsNullWithAuthor(2L, topReviews);
+
+        List<MentoringHomeResponse.MentoringReviewResponse> reviewResponses = reviewPosts.stream()
+                .map(post -> MentoringHomeResponse.MentoringReviewResponse.builder()
+                        .postId(post.getPostId())
+                        .title(post.getPostTitle())
+                        .authorName(post.getAuthor().getName())
+                        .category(post.getPostCategory() != null ? post.getPostCategory().name() : null)
+                        .viewCount(post.getViewCount())
+                        .build())
+                .collect(Collectors.toList());
+
+        return MentoringHomeResponse.builder()
+                .mentors(mentorResponses)
+                .cheerList(cheerList)
+                .helpList(helpList)
+                .reviews(reviewResponses)
+                .build();
+    }
+
+    // 멘토링 엽서 발송
+    @Transactional
+    public MentoringCardSendResponse sendMentoringCard(Long userId, MentoringCardSendRequest request) {
+        log.info("멘토링 엽서 발송 - userId: {}", userId);
+
+        // 사용자 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(AuthErrorCode.USER_NOT_FOUND));
+
+        // Enum 변환
+        MentoringCategory category;
+        MentoringMethod method;
+
+        try {
+            category = MentoringCategory.valueOf(request.getCategory().toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new CustomException(MentoringErrorCode.INVALID_CATEGORY);
+        }
+
+        try {
+            method = MentoringMethod.valueOf(request.getMethod().toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new CustomException(MentoringErrorCode.INVALID_METHOD);
+        }
+
+        // 멘토링 엽서 생성
+        MentoringCard card = MentoringCard.builder()
+                .sender(user)
+                .cardTitle(request.getCardTitle())
+                .category(category)
+                .method(method)
+                .cardContent(request.getCardContent())
+                .build();
+
+        MentoringCard savedCard = mentoringCardRepository.save(card);
+
+        // 파일 확정 (fileIds가 있으면)
+        if (request.getFileIds() != null && !request.getFileIds().isEmpty()) {
+            fileService.confirmFiles(
+                    request.getFileIds(),
+                    FileTargetType.MENTORING_CARD,
+                    savedCard.getMentoringCardId(),
+                    AttachmentPurpose.POST_ATTACHMENT
+            );
+        }
+
+        return MentoringCardSendResponse.from(savedCard);
+    }
+
+    // 보낸 멘토링 엽서 목록 조회
+    public Slice<MentoringCardListResponse> getSentCards(Long userId, Pageable pageable) {
+        log.info("보낸 멘토링 엽서 목록 조회 - userId: {}", userId);
+
+        Slice<MentoringCard> cards = mentoringCardRepository.findSentCards(userId, pageable);
+
+        return cards.map(MentoringCardListResponse::from);
+    }
+
+    // 멘토링 엽서 상세 조회
+    @Transactional
+    public MentoringCardDetailResponse getCardDetail(Long userId, Long cardId) {
+        log.info("멘토링 엽서 상세 조회 - userId: {}, cardId: {}", userId, cardId);
+
+        MentoringCard card = mentoringCardRepository.findById(cardId)
+                .orElseThrow(() -> new CustomException(MentoringErrorCode.MENTORING_CARD_NOT_FOUND));
+
+        // 권한 확인 (본인만 조회 가능)
+        if (!card.isSender(userId)) {
+            throw new CustomException(MentoringErrorCode.UNAUTHORIZED_CARD_ACCESS);
+        }
+
+        // 첨부 파일 URL 조회
+        List<FileAttachment> attachments = fileAttachmentRepository
+                .findByFileTargetTypeAndTargetIdOrderBySortOrder(FileTargetType.MENTORING_CARD, cardId);
+
+        List<String> fileUrls = attachments.stream()
+                .map(attachment -> attachment.getFile().getUrl(region))
+                .toList();
+
+        return MentoringCardDetailResponse.from(card, fileUrls);
+    }
+
+    // 멘토링 신청서 상세 조회
+    public MentoringRequestDetailResponse getRequestDetail(Long userId, Long requestId) {
+        log.info("멘토링 신청서 상세 조회 - userId: {}, requestId: {}", userId, requestId);
+
+        // 신청서 조회
+        MentoringRequest request = mentoringRequestRepository.findByIdWithDetails(requestId)
+                .orElseThrow(() -> new CustomException(MentoringErrorCode.MENTORING_REQUEST_NOT_FOUND));
+
+        // 권한 확인 (신청자 본인만 조회 가능)
+        if (!request.isMentee(userId)) {
+            throw new CustomException(MentoringErrorCode.UNAUTHORIZED_REQUEST_ACCESS);
+        }
+
+        // 멘토 프로필 이미지 조회
+        String mentorProfileImageUrl = null;
+        Optional<FileAttachment> profileImage = fileAttachmentRepository
+                .findByFileTargetTypeAndTargetIdAndSortOrderAndPurpose(
+                        FileTargetType.MENTOR_PROFILE,
+                        request.getMentor().getMentorId(),
+                        1,
+                        AttachmentPurpose.PROFILE_IMAGE
+                );
+
+        if (profileImage.isPresent()) {
+            mentorProfileImageUrl = profileImage.get().getFile().getUrl(region);
+        }
+
+        return MentoringRequestDetailResponse.from(request, mentorProfileImageUrl);
+    }
+
+    // === Helper Methods ===
+
+    private List<User> getSeniors(User currentUser) {
+        User.UserRole currentRole = currentUser.getUserRole();
+
+        // 나보다 높은 레벨 찾기
+        return switch (currentRole) {
+            case JUNIOR -> userRepository.findAll().stream()
+                    .filter(u -> u.getUserRole() == User.UserRole.SENIOR ||
+                            u.getUserRole() == User.UserRole.GRADUATE ||
+                            u.getUserRole() == User.UserRole.MASTER)
+                    .collect(Collectors.toList());
+            case SENIOR -> userRepository.findAll().stream()
+                    .filter(u -> u.getUserRole() == User.UserRole.GRADUATE ||
+                            u.getUserRole() == User.UserRole.MASTER)
+                    .collect(Collectors.toList());
+            case GRADUATE -> userRepository.findAll().stream()
+                    .filter(u -> u.getUserRole() == User.UserRole.MASTER)
+                    .collect(Collectors.toList());
+            case MASTER -> List.of(); // 최고 레벨
+        };
+    }
+
+    private List<User> getJuniorsAndSame(User currentUser) {
+        User.UserRole currentRole = currentUser.getUserRole();
+
+        // 나와 같거나 낮은 레벨 찾기
+        return switch (currentRole) {
+            case JUNIOR -> userRepository.findAll().stream()
+                    .filter(u -> u.getUserRole() == User.UserRole.JUNIOR)
+                    .filter(u -> !u.getUserId().equals(currentUser.getUserId())) // 본인 제외
+                    .collect(Collectors.toList());
+            case SENIOR -> userRepository.findAll().stream()
+                    .filter(u -> u.getUserRole() == User.UserRole.JUNIOR ||
+                            u.getUserRole() == User.UserRole.SENIOR)
+                    .filter(u -> !u.getUserId().equals(currentUser.getUserId()))
+                    .collect(Collectors.toList());
+            case GRADUATE -> userRepository.findAll().stream()
+                    .filter(u -> u.getUserRole() == User.UserRole.JUNIOR ||
+                            u.getUserRole() == User.UserRole.SENIOR ||
+                            u.getUserRole() == User.UserRole.GRADUATE)
+                    .filter(u -> !u.getUserId().equals(currentUser.getUserId()))
+                    .collect(Collectors.toList());
+            case MASTER -> userRepository.findAll().stream()
+                    .filter(u -> !u.getUserId().equals(currentUser.getUserId()))
+                    .collect(Collectors.toList());
+        };
+    }
+
+    private MentoringHomeResponse.SeniorJuniorMentoringResponse buildSeniorJuniorResponse(List<User> users) {
+        List<MentoringHomeResponse.SeniorJuniorMentoringResponse.UserCardResponse> userCards = users.stream()
+                .limit(10) // 최대 10명
+                .map(user -> {
+                    UserProfile profile = userProfileRepository.findByUser_UserId(user.getUserId()).orElse(null);
+                    List<String> interests = userInterestRepository.findAllByUser_UserId(user.getUserId()).stream()
+                            .map(UserInterest::getCategoryName)
+                            .collect(Collectors.toList());
+
+                    return MentoringHomeResponse.SeniorJuniorMentoringResponse.UserCardResponse.builder()
+                            .userId(user.getUserId())
+                            .userName(user.getName())
+                            .character(profile != null ? profile.getUserCharacter() : null)
+                            .backgroundPattern(profile != null ? profile.getBackgroundPattern() : null)
+                            .solidGoalName(profile != null ? profile.getSolidGoalName() : null)
+                            .interests(interests)
+                            .build();
+                })
+                .collect(Collectors.toList());
+
+        return MentoringHomeResponse.SeniorJuniorMentoringResponse.builder()
+                .users(userCards)
+                .build();
+    }
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/mentoring/service/MentoringService.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/mentoring/service/MentoringService.java
@@ -174,18 +174,21 @@ public class MentoringService {
         User currentUser = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(AuthErrorCode.USER_NOT_FOUND));
 
-        // 1. 전문가 멘토 목록 (최대 4개)
-        List<Mentor> mentors = mentorRepository.findByIsActiveTrueOrderByCreatedAtDesc();
-        List<Mentor> topMentors = mentors.stream().limit(4).collect(Collectors.toList());
+        // 1. 전문가 멘토 목록 조회 (카테고리별)
+        List<Mentor> allMentors = mentorRepository.findByIsActiveTrueOrderByCreatedAtDesc();
+        List<Mentor> studyMentors = mentorRepository.findByIsActiveTrueAndMentorCategoryOrderByCreatedAtDesc(MentorCategory.STUDY);
+        List<Mentor> jobMentors = mentorRepository.findByIsActiveTrueAndMentorCategoryOrderByCreatedAtDesc(MentorCategory.JOB);
+        List<Mentor> lifeMentors = mentorRepository.findByIsActiveTrueAndMentorCategoryOrderByCreatedAtDesc(MentorCategory.LIFE);
 
-        List<Long> mentorIds = topMentors.stream()
+        // 프로필 이미지 배치 조회
+        List<Long> allMentorIds = allMentors.stream()
                 .map(Mentor::getMentorId)
                 .collect(Collectors.toList());
 
-        Map<Long, String> profileImageMap = mentorIds.isEmpty() ? Map.of() :
+        Map<Long, String> profileImageMap = allMentorIds.isEmpty() ? Map.of() :
                 fileAttachmentRepository.findByFileTargetTypeAndTargetIdInAndSortOrderAndPurpose(
                                 FileTargetType.MENTOR_PROFILE,
-                                mentorIds,
+                                allMentorIds,
                                 1,
                                 AttachmentPurpose.PROFILE_IMAGE
                         )
@@ -196,7 +199,20 @@ public class MentoringService {
                                 (existing, replacement) -> existing
                         ));
 
-        List<MentorListResponse> mentorResponses = topMentors.stream()
+        // DTO 변환
+        List<MentorListResponse> allMentorResponses = allMentors.stream()
+                .map(mentor -> MentorListResponse.from(mentor, profileImageMap.get(mentor.getMentorId())))
+                .collect(Collectors.toList());
+
+        List<MentorListResponse> studyMentorResponses = studyMentors.stream()
+                .map(mentor -> MentorListResponse.from(mentor, profileImageMap.get(mentor.getMentorId())))
+                .collect(Collectors.toList());
+
+        List<MentorListResponse> jobMentorResponses = jobMentors.stream()
+                .map(mentor -> MentorListResponse.from(mentor, profileImageMap.get(mentor.getMentorId())))
+                .collect(Collectors.toList());
+
+        List<MentorListResponse> lifeMentorResponses = lifeMentors.stream()
                 .map(mentor -> MentorListResponse.from(mentor, profileImageMap.get(mentor.getMentorId())))
                 .collect(Collectors.toList());
 
@@ -223,7 +239,10 @@ public class MentoringService {
                 .collect(Collectors.toList());
 
         return MentoringHomeResponse.builder()
-                .mentors(mentorResponses)
+                .allMentors(allMentorResponses)
+                .studyMentors(studyMentorResponses)
+                .jobMentors(jobMentorResponses)
+                .lifeMentors(lifeMentorResponses)
                 .cheerList(cheerList)
                 .helpList(helpList)
                 .reviews(reviewResponses)

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/mentoring/service/MentoringService.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/mentoring/service/MentoringService.java
@@ -13,6 +13,7 @@ import com.solif.backend.domain.mentoring.dto.*;
 import com.solif.backend.domain.mentoring.entity.*;
 import com.solif.backend.domain.mentoring.repository.MentorRepository;
 import com.solif.backend.domain.mentoring.repository.MentoringCardRepository;
+import com.solif.backend.domain.mentoring.repository.MentoringInteractionRepository;
 import com.solif.backend.domain.mentoring.repository.MentoringRequestRepository;
 import com.solif.backend.domain.post.entity.Post;
 import com.solif.backend.domain.post.repository.PostRepository;
@@ -30,9 +31,7 @@ import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -50,6 +49,7 @@ public class MentoringService {
     private final FileAttachmentRepository fileAttachmentRepository;
     private final MentoringCardRepository mentoringCardRepository;
     private final FileService fileService;
+    private final MentoringInteractionRepository mentoringInteractionRepository;
 
     @Value("${cloud.aws.region.static}")
     private String region;
@@ -212,17 +212,13 @@ public class MentoringService {
                 .map(mentor -> MentorListResponse.from(mentor, profileImageMap.get(mentor.getMentorId())))
                 .collect(Collectors.toList());
 
-        // 2. 선후배 멘토링 - 응원하기 (나보다 선배)
-        List<User> seniors = getSeniors(currentUser);
+        // 2. 선후배 멘토링 - 응원하기 (내가 선배에게 응원)
         MentoringHomeResponse.SeniorJuniorMentoringResponse cheerList =
-                buildSeniorJuniorResponse(seniors);
+                buildCheerList(currentUser);
 
-        // 3. 선후배 멘토링 - 경험나누기 (나와 같거나 후배)
-        // TODO: 선후배 멘토링 리스트 표시 추가 조건 구현 필요
-        // 팀원(장난영)과 논의 후 적용
-        List<User> juniorsAndSame = getJuniorsAndSame(currentUser);
+        // 3. 선후배 멘토링 - 경험나누기 (내가 후배에게 경험 나누기)
         MentoringHomeResponse.SeniorJuniorMentoringResponse helpList =
-                buildSeniorJuniorResponse(juniorsAndSame);
+                buildHelpList(currentUser);
 
         // 4. 멘토링 후기 목록 (boardId=2, 최대 4개)
         Pageable topReviews = PageRequest.of(0, 4);
@@ -399,6 +395,122 @@ public class MentoringService {
 
         return MentoringHomeResponse.SeniorJuniorMentoringResponse.builder()
                 .users(userCards)
+                .build();
+    }
+
+    // 응원하기 리스트 생성
+    private MentoringHomeResponse.SeniorJuniorMentoringResponse buildCheerList(User currentUser) {
+        // MASTER(관리자)는 응원하기 대상 없음
+        if (currentUser.getUserRole() == User.UserRole.MASTER) {
+            return MentoringHomeResponse.SeniorJuniorMentoringResponse.builder()
+                    .users(List.of())
+                    .build();
+        }
+
+        List<MentoringHomeResponse.SeniorJuniorMentoringResponse.UserCardResponse> userCards = new ArrayList<>();
+
+        // 1) 내가 받은 응원 중 아직 내가 보내지 않은 사람들 (대기중)
+        List<MentoringInteraction> pendingInteractions = mentoringInteractionRepository
+                .findPendingReceivedInteractions(currentUser.getUserId(), MentoringInteractionType.CHEER);
+
+        for (MentoringInteraction interaction : pendingInteractions) {
+            User sender = interaction.getSender();
+            userCards.add(buildUserCard(sender, "PENDING"));
+        }
+
+        // 2) 양방향 완료된 응원 (서로 보낸 사람들)
+        List<MentoringInteraction> completedInteractions = mentoringInteractionRepository
+                .findCompletedInteractions(currentUser.getUserId(), MentoringInteractionType.CHEER);
+
+        // 중복 제거를 위해 Set 사용
+        Set<Long> addedUserIds = userCards.stream()
+                .map(MentoringHomeResponse.SeniorJuniorMentoringResponse.UserCardResponse::getUserId)
+                .collect(Collectors.toSet());
+
+        for (MentoringInteraction interaction : completedInteractions) {
+            User otherUser = interaction.getSender().getUserId().equals(currentUser.getUserId())
+                    ? interaction.getReceiver()
+                    : interaction.getSender();
+
+            if (!addedUserIds.contains(otherUser.getUserId())) {
+                userCards.add(buildUserCard(otherUser, "COMPLETED"));
+                addedUserIds.add(otherUser.getUserId());
+            }
+        }
+
+        // 최대 10명으로 제한
+        List<MentoringHomeResponse.SeniorJuniorMentoringResponse.UserCardResponse> limitedCards =
+                userCards.stream().limit(10).collect(Collectors.toList());
+
+        return MentoringHomeResponse.SeniorJuniorMentoringResponse.builder()
+                .users(limitedCards)
+                .build();
+    }
+
+    // 경험나누기 리스트 생성
+    private MentoringHomeResponse.SeniorJuniorMentoringResponse buildHelpList(User currentUser) {
+        // MASTER(관리자)는 경험나누기 대상 없음
+        if (currentUser.getUserRole() == User.UserRole.MASTER) {
+            return MentoringHomeResponse.SeniorJuniorMentoringResponse.builder()
+                    .users(List.of())
+                    .build();
+        }
+
+        List<MentoringHomeResponse.SeniorJuniorMentoringResponse.UserCardResponse> userCards = new ArrayList<>();
+
+        // 1) 내가 받은 경험나누기 중 아직 내가 보내지 않은 사람들 (대기중)
+        List<MentoringInteraction> pendingInteractions = mentoringInteractionRepository
+                .findPendingReceivedInteractions(currentUser.getUserId(), MentoringInteractionType.HELP);
+
+        for (MentoringInteraction interaction : pendingInteractions) {
+            User sender = interaction.getSender();
+            userCards.add(buildUserCard(sender, "PENDING"));
+        }
+
+        // 2) 양방향 완료된 경험나누기 (서로 보낸 사람들)
+        List<MentoringInteraction> completedInteractions = mentoringInteractionRepository
+                .findCompletedInteractions(currentUser.getUserId(), MentoringInteractionType.HELP);
+
+        // 중복 제거를 위해 Set 사용
+        Set<Long> addedUserIds = userCards.stream()
+                .map(MentoringHomeResponse.SeniorJuniorMentoringResponse.UserCardResponse::getUserId)
+                .collect(Collectors.toSet());
+
+        for (MentoringInteraction interaction : completedInteractions) {
+            User otherUser = interaction.getSender().getUserId().equals(currentUser.getUserId())
+                    ? interaction.getReceiver()
+                    : interaction.getSender();
+
+            if (!addedUserIds.contains(otherUser.getUserId())) {
+                userCards.add(buildUserCard(otherUser, "COMPLETED"));
+                addedUserIds.add(otherUser.getUserId());
+            }
+        }
+
+        // 최대 10명으로 제한
+        List<MentoringHomeResponse.SeniorJuniorMentoringResponse.UserCardResponse> limitedCards =
+                userCards.stream().limit(10).collect(Collectors.toList());
+
+        return MentoringHomeResponse.SeniorJuniorMentoringResponse.builder()
+                .users(limitedCards)
+                .build();
+    }
+
+    // UserCard 생성 헬퍼 메서드
+    private MentoringHomeResponse.SeniorJuniorMentoringResponse.UserCardResponse buildUserCard(User user, String status) {
+        UserProfile profile = userProfileRepository.findByUser_UserId(user.getUserId()).orElse(null);
+        List<String> interests = userInterestRepository.findAllByUser_UserId(user.getUserId()).stream()
+                .map(UserInterest::getCategoryName)
+                .collect(Collectors.toList());
+
+        return MentoringHomeResponse.SeniorJuniorMentoringResponse.UserCardResponse.builder()
+                .userId(user.getUserId())
+                .userName(user.getName())
+                .character(profile != null ? profile.getUserCharacter() : null)
+                .backgroundPattern(profile != null ? profile.getBackgroundPattern() : null)
+                .solidGoalName(profile != null ? profile.getSolidGoalName() : null)
+                .interests(interests)
+                .status(status) // "PENDING" 또는 "COMPLETED"
                 .build();
     }
 }

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/mentoring/service/MentoringService.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/mentoring/service/MentoringService.java
@@ -317,86 +317,14 @@ public class MentoringService {
         List<FileAttachment> attachments = fileAttachmentRepository
                 .findByFileTargetTypeAndTargetIdOrderBySortOrder(FileTargetType.MENTORING_CARD, cardId);
 
-        List<String> fileUrls = attachments.stream()
+        List<String> imageUrls = attachments.stream()
                 .map(attachment -> attachment.getFile().getUrl(region))
                 .toList();
 
-        return MentoringCardDetailResponse.from(card, fileUrls);
+        return MentoringCardDetailResponse.from(card, imageUrls);
     }
 
     // === Helper Methods ===
-
-    private List<User> getSeniors(User currentUser) {
-        User.UserRole currentRole = currentUser.getUserRole();
-
-        // 나보다 높은 레벨 찾기
-        return switch (currentRole) {
-            case JUNIOR -> userRepository.findAll().stream()
-                    .filter(u -> u.getUserRole() == User.UserRole.SENIOR ||
-                            u.getUserRole() == User.UserRole.GRADUATE ||
-                            u.getUserRole() == User.UserRole.MASTER)
-                    .collect(Collectors.toList());
-            case SENIOR -> userRepository.findAll().stream()
-                    .filter(u -> u.getUserRole() == User.UserRole.GRADUATE ||
-                            u.getUserRole() == User.UserRole.MASTER)
-                    .collect(Collectors.toList());
-            case GRADUATE -> userRepository.findAll().stream()
-                    .filter(u -> u.getUserRole() == User.UserRole.MASTER)
-                    .collect(Collectors.toList());
-            case MASTER -> List.of(); // 최고 레벨
-        };
-    }
-
-    private List<User> getJuniorsAndSame(User currentUser) {
-        User.UserRole currentRole = currentUser.getUserRole();
-
-        // 나와 같거나 낮은 레벨 찾기
-        return switch (currentRole) {
-            case JUNIOR -> userRepository.findAll().stream()
-                    .filter(u -> u.getUserRole() == User.UserRole.JUNIOR)
-                    .filter(u -> !u.getUserId().equals(currentUser.getUserId())) // 본인 제외
-                    .collect(Collectors.toList());
-            case SENIOR -> userRepository.findAll().stream()
-                    .filter(u -> u.getUserRole() == User.UserRole.JUNIOR ||
-                            u.getUserRole() == User.UserRole.SENIOR)
-                    .filter(u -> !u.getUserId().equals(currentUser.getUserId()))
-                    .collect(Collectors.toList());
-            case GRADUATE -> userRepository.findAll().stream()
-                    .filter(u -> u.getUserRole() == User.UserRole.JUNIOR ||
-                            u.getUserRole() == User.UserRole.SENIOR ||
-                            u.getUserRole() == User.UserRole.GRADUATE)
-                    .filter(u -> !u.getUserId().equals(currentUser.getUserId()))
-                    .collect(Collectors.toList());
-            case MASTER -> userRepository.findAll().stream()
-                    .filter(u -> !u.getUserId().equals(currentUser.getUserId()))
-                    .collect(Collectors.toList());
-        };
-    }
-
-    private MentoringHomeResponse.SeniorJuniorMentoringResponse buildSeniorJuniorResponse(List<User> users) {
-        List<MentoringHomeResponse.SeniorJuniorMentoringResponse.UserCardResponse> userCards = users.stream()
-                .limit(10) // 최대 10명
-                .map(user -> {
-                    UserProfile profile = userProfileRepository.findByUser_UserId(user.getUserId()).orElse(null);
-                    List<String> interests = userInterestRepository.findAllByUser_UserId(user.getUserId()).stream()
-                            .map(UserInterest::getCategoryName)
-                            .collect(Collectors.toList());
-
-                    return MentoringHomeResponse.SeniorJuniorMentoringResponse.UserCardResponse.builder()
-                            .userId(user.getUserId())
-                            .userName(user.getName())
-                            .character(profile != null ? profile.getUserCharacter() : null)
-                            .backgroundPattern(profile != null ? profile.getBackgroundPattern() : null)
-                            .solidGoalName(profile != null ? profile.getSolidGoalName() : null)
-                            .interests(interests)
-                            .build();
-                })
-                .collect(Collectors.toList());
-
-        return MentoringHomeResponse.SeniorJuniorMentoringResponse.builder()
-                .users(userCards)
-                .build();
-    }
 
     // 응원하기 리스트 생성
     private MentoringHomeResponse.SeniorJuniorMentoringResponse buildCheerList(User currentUser) {

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/mentoring/service/MentoringService.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/mentoring/service/MentoringService.java
@@ -260,7 +260,7 @@ public class MentoringService {
                     request.getFileIds(),
                     FileTargetType.MENTORING_CARD,
                     savedCard.getMentoringCardId(),
-                    AttachmentPurpose.POST_ATTACHMENT
+                    AttachmentPurpose.MENTORING_CARD_ATTACHMENT
             );
         }
 

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/mentoring/service/MentoringService.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/mentoring/service/MentoringService.java
@@ -289,6 +289,11 @@ public class MentoringService {
             throw new CustomException(MentoringErrorCode.UNAUTHORIZED_CARD_ACCESS);
         }
 
+        // 읽음 처리
+        if (!card.getIsRead()) {
+            card.markAsRead();
+        }
+
         // 첨부 파일 URL 조회
         List<FileAttachment> attachments = fileAttachmentRepository
                 .findByFileTargetTypeAndTargetIdOrderBySortOrder(FileTargetType.MENTORING_CARD, cardId);

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/mentoring/service/MentoringService.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/mentoring/service/MentoringService.java
@@ -102,20 +102,8 @@ public class MentoringService {
                 .orElseThrow(() -> new CustomException(MentoringErrorCode.MENTOR_NOT_FOUND));
 
         // Enum 변환
-        MentoringCategory category;
-        MentoringMethod method;
-
-        try {
-            category = MentoringCategory.valueOf(request.getCategory().toUpperCase());
-        } catch (IllegalArgumentException e) {
-            throw new CustomException(MentoringErrorCode.INVALID_CATEGORY);
-        }
-
-        try {
-            method = MentoringMethod.valueOf(request.getMethod().toUpperCase());
-        } catch (IllegalArgumentException e) {
-            throw new CustomException(MentoringErrorCode.INVALID_METHOD);
-        }
+        MentoringCategory category = request.getCategory();
+        MentoringMethod method = request.getMethod();
 
         // 멘토링 신청 생성
         MentoringRequest mentoringRequest = MentoringRequest.builder()
@@ -252,20 +240,8 @@ public class MentoringService {
                 .orElseThrow(() -> new CustomException(AuthErrorCode.USER_NOT_FOUND));
 
         // Enum 변환
-        MentoringCategory category;
-        MentoringMethod method;
-
-        try {
-            category = MentoringCategory.valueOf(request.getCategory().toUpperCase());
-        } catch (IllegalArgumentException e) {
-            throw new CustomException(MentoringErrorCode.INVALID_CATEGORY);
-        }
-
-        try {
-            method = MentoringMethod.valueOf(request.getMethod().toUpperCase());
-        } catch (IllegalArgumentException e) {
-            throw new CustomException(MentoringErrorCode.INVALID_METHOD);
-        }
+        MentoringCategory category = request.getCategory();
+        MentoringMethod method = request.getMethod();
 
         // 멘토링 엽서 생성
         MentoringCard card = MentoringCard.builder()

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/mentoring/service/MentoringService.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/mentoring/service/MentoringService.java
@@ -216,13 +216,13 @@ public class MentoringService {
                 .map(mentor -> MentorListResponse.from(mentor, profileImageMap.get(mentor.getMentorId())))
                 .collect(Collectors.toList());
 
-        // 2. 선후배 멘토링 - 응원하기 (내가 선배에게 응원)
+        // 2. 선후배 멘토링 - 응원하기 (통합 메서드 사용)
         MentoringHomeResponse.SeniorJuniorMentoringResponse cheerList =
-                buildCheerList(currentUser);
+                buildInteractionList(currentUser, MentoringInteractionType.CHEER);
 
-        // 3. 선후배 멘토링 - 경험나누기 (내가 후배에게 경험 나누기)
+        // 3. 선후배 멘토링 - 경험나누기 (통합 메서드 사용)
         MentoringHomeResponse.SeniorJuniorMentoringResponse helpList =
-                buildHelpList(currentUser);
+                buildInteractionList(currentUser, MentoringInteractionType.HELP);
 
         // 4. 멘토링 후기 목록 (boardId=2, 최대 4개)
         Pageable topReviews = PageRequest.of(0, 4);
@@ -321,9 +321,12 @@ public class MentoringService {
 
     // === Helper Methods ===
 
-    // 응원하기 리스트 생성
-    private MentoringHomeResponse.SeniorJuniorMentoringResponse buildCheerList(User currentUser) {
-        // MASTER(관리자)는 응원하기 대상 없음
+    // 통합: buildCheerList + buildHelpList → buildInteractionList
+    private MentoringHomeResponse.SeniorJuniorMentoringResponse buildInteractionList(
+            User currentUser,
+            MentoringInteractionType type) {
+
+        // MASTER(관리자)는 상호작용 대상 없음
         if (currentUser.getUserRole() == User.UserRole.MASTER) {
             return MentoringHomeResponse.SeniorJuniorMentoringResponse.builder()
                     .users(List.of())
@@ -332,20 +335,59 @@ public class MentoringService {
 
         List<MentoringHomeResponse.SeniorJuniorMentoringResponse.UserCardResponse> userCards = new ArrayList<>();
 
-        // 1) 내가 받은 응원 중 아직 내가 보내지 않은 사람들 (대기중)
+        // 1) 내가 받은 상호작용 중 아직 내가 보내지 않은 사람들 (대기중)
         List<MentoringInteraction> pendingInteractions = mentoringInteractionRepository
-                .findPendingReceivedInteractions(currentUser.getUserId(), MentoringInteractionType.CHEER);
+                .findPendingReceivedInteractions(currentUser.getUserId(), type);
+
+        // 2) 양방향 완료된 상호작용 (서로 보낸 사람들)
+        List<MentoringInteraction> completedInteractions = mentoringInteractionRepository
+                .findCompletedInteractions(currentUser.getUserId(), type);
+
+        // 모든 대상 사용자 ID 수집
+        Set<Long> allUserIds = new HashSet<>();
 
         for (MentoringInteraction interaction : pendingInteractions) {
-            User sender = interaction.getSender();
-            userCards.add(buildUserCard(sender, "PENDING"));
+            allUserIds.add(interaction.getSender().getUserId());
         }
 
-        // 2) 양방향 완료된 응원 (서로 보낸 사람들)
-        List<MentoringInteraction> completedInteractions = mentoringInteractionRepository
-                .findCompletedInteractions(currentUser.getUserId(), MentoringInteractionType.CHEER);
+        for (MentoringInteraction interaction : completedInteractions) {
+            User otherUser = interaction.getSender().getUserId().equals(currentUser.getUserId())
+                    ? interaction.getReceiver()
+                    : interaction.getSender();
+            allUserIds.add(otherUser.getUserId());
+        }
 
-        // 중복 제거를 위해 Set 사용
+        // 최대 10명으로 제한
+        List<Long> limitedUserIds = allUserIds.stream().limit(10).collect(Collectors.toList());
+
+        if (limitedUserIds.isEmpty()) {
+            return MentoringHomeResponse.SeniorJuniorMentoringResponse.builder()
+                    .users(List.of())
+                    .build();
+        }
+
+        // 배치 조회 (N+1 방지)
+        Map<Long, UserProfile> profileMap = userProfileRepository.findByUser_UserIdIn(limitedUserIds).stream()
+                .collect(Collectors.toMap(
+                        profile -> profile.getUser().getUserId(),
+                        profile -> profile
+                ));
+
+        Map<Long, List<String>> interestMap = userInterestRepository.findAllByUser_UserIdIn(limitedUserIds).stream()
+                .collect(Collectors.groupingBy(
+                        interest -> interest.getUser().getUserId(),
+                        Collectors.mapping(UserInterest::getCategoryName, Collectors.toList())
+                ));
+
+        // pending 처리
+        for (MentoringInteraction interaction : pendingInteractions) {
+            User sender = interaction.getSender();
+            if (limitedUserIds.contains(sender.getUserId())) {
+                userCards.add(buildUserCardFromCache(sender, "PENDING", profileMap, interestMap));
+            }
+        }
+
+        // completed 처리
         Set<Long> addedUserIds = userCards.stream()
                 .map(MentoringHomeResponse.SeniorJuniorMentoringResponse.UserCardResponse::getUserId)
                 .collect(Collectors.toSet());
@@ -355,76 +397,26 @@ public class MentoringService {
                     ? interaction.getReceiver()
                     : interaction.getSender();
 
-            if (!addedUserIds.contains(otherUser.getUserId())) {
-                userCards.add(buildUserCard(otherUser, "COMPLETED"));
+            if (limitedUserIds.contains(otherUser.getUserId()) && !addedUserIds.contains(otherUser.getUserId())) {
+                userCards.add(buildUserCardFromCache(otherUser, "COMPLETED", profileMap, interestMap));
                 addedUserIds.add(otherUser.getUserId());
             }
         }
 
-        // 최대 10명으로 제한
-        List<MentoringHomeResponse.SeniorJuniorMentoringResponse.UserCardResponse> limitedCards =
-                userCards.stream().limit(10).collect(Collectors.toList());
-
         return MentoringHomeResponse.SeniorJuniorMentoringResponse.builder()
-                .users(limitedCards)
-                .build();
-    }
-
-    // 경험나누기 리스트 생성
-    private MentoringHomeResponse.SeniorJuniorMentoringResponse buildHelpList(User currentUser) {
-        // MASTER(관리자)는 경험나누기 대상 없음
-        if (currentUser.getUserRole() == User.UserRole.MASTER) {
-            return MentoringHomeResponse.SeniorJuniorMentoringResponse.builder()
-                    .users(List.of())
-                    .build();
-        }
-
-        List<MentoringHomeResponse.SeniorJuniorMentoringResponse.UserCardResponse> userCards = new ArrayList<>();
-
-        // 1) 내가 받은 경험나누기 중 아직 내가 보내지 않은 사람들 (대기중)
-        List<MentoringInteraction> pendingInteractions = mentoringInteractionRepository
-                .findPendingReceivedInteractions(currentUser.getUserId(), MentoringInteractionType.HELP);
-
-        for (MentoringInteraction interaction : pendingInteractions) {
-            User sender = interaction.getSender();
-            userCards.add(buildUserCard(sender, "PENDING"));
-        }
-
-        // 2) 양방향 완료된 경험나누기 (서로 보낸 사람들)
-        List<MentoringInteraction> completedInteractions = mentoringInteractionRepository
-                .findCompletedInteractions(currentUser.getUserId(), MentoringInteractionType.HELP);
-
-        // 중복 제거를 위해 Set 사용
-        Set<Long> addedUserIds = userCards.stream()
-                .map(MentoringHomeResponse.SeniorJuniorMentoringResponse.UserCardResponse::getUserId)
-                .collect(Collectors.toSet());
-
-        for (MentoringInteraction interaction : completedInteractions) {
-            User otherUser = interaction.getSender().getUserId().equals(currentUser.getUserId())
-                    ? interaction.getReceiver()
-                    : interaction.getSender();
-
-            if (!addedUserIds.contains(otherUser.getUserId())) {
-                userCards.add(buildUserCard(otherUser, "COMPLETED"));
-                addedUserIds.add(otherUser.getUserId());
-            }
-        }
-
-        // 최대 10명으로 제한
-        List<MentoringHomeResponse.SeniorJuniorMentoringResponse.UserCardResponse> limitedCards =
-                userCards.stream().limit(10).collect(Collectors.toList());
-
-        return MentoringHomeResponse.SeniorJuniorMentoringResponse.builder()
-                .users(limitedCards)
+                .users(userCards)
                 .build();
     }
 
     // UserCard 생성 헬퍼 메서드
-    private MentoringHomeResponse.SeniorJuniorMentoringResponse.UserCardResponse buildUserCard(User user, String status) {
-        UserProfile profile = userProfileRepository.findByUser_UserId(user.getUserId()).orElse(null);
-        List<String> interests = userInterestRepository.findAllByUser_UserId(user.getUserId()).stream()
-                .map(UserInterest::getCategoryName)
-                .collect(Collectors.toList());
+    private MentoringHomeResponse.SeniorJuniorMentoringResponse.UserCardResponse buildUserCardFromCache(
+            User user,
+            String status,
+            Map<Long, UserProfile> profileMap,
+            Map<Long, List<String>> interestMap) {
+
+        UserProfile profile = profileMap.get(user.getUserId());
+        List<String> interests = interestMap.getOrDefault(user.getUserId(), List.of());
 
         return MentoringHomeResponse.SeniorJuniorMentoringResponse.UserCardResponse.builder()
                 .userId(user.getUserId())
@@ -433,7 +425,7 @@ public class MentoringService {
                 .backgroundPattern(profile != null ? profile.getBackgroundPattern() : null)
                 .solidGoalName(profile != null ? profile.getSolidGoalName() : null)
                 .interests(interests)
-                .status(status) // "PENDING" 또는 "COMPLETED"
+                .status(status)
                 .build();
     }
 }

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/message/dto/MessageDetailResponse.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/message/dto/MessageDetailResponse.java
@@ -22,11 +22,20 @@ public class MessageDetailResponse {
     @Schema(description = "보낸 사람 이름", example = "박민수")
     private String senderName;
 
+    @Schema(description = "받는 사람 ID", example = "2")
+    private Long receiverId;
+
+    @Schema(description = "받는 사람 이름", example = "박민수")
+    private String receiverName;
+
     @Schema(description = "쪽지 제목", example = "한국대학교 재학생 박민수 입니다.")
     private String messageTitle;
 
     @Schema(description = "쪽지 내용")
     private String messageContent;
+
+    @Schema(description = "읽음 여부", example = "false")
+    private Boolean isRead;
 
     @Schema(description = "읽은 시간", nullable = true)
     private LocalDateTime readAt;
@@ -34,19 +43,22 @@ public class MessageDetailResponse {
     @Schema(description = "발송 일시", example = "2026-01-31T12:00:00")
     private LocalDateTime createdAt;
 
-    @Schema(description = "첨부 파일 URL 목록", nullable = true)
-    private List<String> fileUrls;
+    @Schema(description = "첨부 이미지 URL 목록")
+    private List<String> imageUrls;
 
-    public static MessageDetailResponse from(Message message, List<String> fileUrls) {
+    public static MessageDetailResponse from(Message message, List<String> imageUrls) {
         return MessageDetailResponse.builder()
                 .messageId(message.getMessageId())
                 .senderId(message.getSender().getUserId())
                 .senderName(message.getSender().getName())
+                .receiverId(message.getReceiver().getUserId())
+                .receiverName(message.getReceiver().getName())
                 .messageTitle(message.getMessageTitle())
                 .messageContent(message.getMessageContent())
+                .isRead(message.getIsRead())
                 .readAt(message.getReadAt())
                 .createdAt(message.getCreatedAt())
-                .fileUrls(fileUrls)
+                .imageUrls(imageUrls)
                 .build();
     }
 }

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/message/dto/MessageDetailResponse.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/message/dto/MessageDetailResponse.java
@@ -22,7 +22,7 @@ public class MessageDetailResponse {
     @Schema(description = "보낸 사람 이름", example = "박민수")
     private String senderName;
 
-    @Schema(description = "받는 사람 ID", example = "2")
+    @Schema(description = "받는 사람 ID", example = "3")
     private Long receiverId;
 
     @Schema(description = "받는 사람 이름", example = "박민수")

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/message/service/MessageService.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/message/service/MessageService.java
@@ -1,5 +1,10 @@
 package com.solif.backend.domain.message.service;
 
+import com.solif.backend.domain.file.entity.AttachmentPurpose;
+import com.solif.backend.domain.file.entity.FileAttachment;
+import com.solif.backend.domain.file.entity.FileTargetType;
+import com.solif.backend.domain.file.repository.FileAttachmentRepository;
+import com.solif.backend.domain.file.service.FileService;
 import com.solif.backend.domain.notification.entity.NotificationType;
 import com.solif.backend.domain.notification.entity.TargetType;
 import com.solif.backend.domain.notification.event.NotificationEvent;
@@ -13,13 +18,13 @@ import com.solif.backend.domain.user.repository.UserRepository;
 import com.solif.backend.global.common.exception.CustomException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Collections;
 import java.util.List;
 
 @Slf4j
@@ -31,7 +36,11 @@ public class MessageService {
     private final MessageRepository messageRepository;
     private final UserRepository userRepository;
     private final ApplicationEventPublisher eventPublisher;
-    // TODO: FileAttachmentRepository 추가 (파일 첨부 기능 구현 시)
+    private final FileService fileService;
+    private final FileAttachmentRepository fileAttachmentRepository;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
 
     // 쪽지 발송
     @Transactional
@@ -60,6 +69,16 @@ public class MessageService {
                 .build();
 
         Message savedMessage = messageRepository.save(message);
+
+        // 파일 확정 (fileIds가 있으면)
+        if (request.getFileIds() != null && !request.getFileIds().isEmpty()) {
+            fileService.confirmFiles(
+                    request.getFileIds(),
+                    FileTargetType.MESSAGE,
+                    savedMessage.getMessageId(),
+                    AttachmentPurpose.MESSAGE_ATTACHMENT
+            );
+        }
 
         // 수신자에게 알림 생성 + SSE 실시간 전송 (트랜잭션 커밋 후 이벤트 리스너에서 처리)
         eventPublisher.publishEvent(new NotificationEvent(
@@ -119,9 +138,13 @@ public class MessageService {
             throw new CustomException(MessageErrorCode.ALREADY_DELETED_MESSAGE);
         }
 
-        // TODO: 첨부 파일 URL 조회
-        List<String> fileUrls = Collections.emptyList();
-        // List<String> fileUrls = fileAttachmentService.getFileUrls("MESSAGE", messageId);
+        // 첨부 파일 URL 조회
+        List<FileAttachment> attachments = fileAttachmentRepository
+                .findByFileTargetTypeAndTargetIdOrderBySortOrder(FileTargetType.MESSAGE, messageId);
+
+        List<String> fileUrls = attachments.stream()
+                .map(attachment -> attachment.getFile().getUrl(region))
+                .toList();
 
         return MessageDetailResponse.from(message, fileUrls);
     }

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/message/service/MessageService.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/message/service/MessageService.java
@@ -142,11 +142,11 @@ public class MessageService {
         List<FileAttachment> attachments = fileAttachmentRepository
                 .findByFileTargetTypeAndTargetIdOrderBySortOrder(FileTargetType.MESSAGE, messageId);
 
-        List<String> fileUrls = attachments.stream()
+        List<String> imageUrls = attachments.stream()
                 .map(attachment -> attachment.getFile().getUrl(region))
                 .toList();
 
-        return MessageDetailResponse.from(message, fileUrls);
+        return MessageDetailResponse.from(message, imageUrls);
     }
 
     // 쪽지 삭제

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/network/code/NetworkErrorCode.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/network/code/NetworkErrorCode.java
@@ -17,7 +17,7 @@ public enum NetworkErrorCode implements ErrorCode {
     INVALID_QR_CODE(HttpStatus.BAD_REQUEST, "NETWORK_006", "유효하지 않은 QR 코드입니다."),
     INVALID_INTERACTION_TYPE(HttpStatus.BAD_REQUEST, "NETWORK_007", "유효하지 않은 상호작용 타입입니다."),
     INTERACTION_NOT_ALLOWED(HttpStatus.FORBIDDEN, "NETWORK_008", "해당 상호작용을 보낼 수 없습니다."),
-    INTERACTION_ALREADY_SENT(HttpStatus.CONFLICT, "NETWORK_008", "이미 상호작용을 보냈습니다.");
+    INTERACTION_ALREADY_SENT(HttpStatus.CONFLICT, "NETWORK_009", "이미 상호작용을 보냈습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/network/code/NetworkErrorCode.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/network/code/NetworkErrorCode.java
@@ -16,7 +16,8 @@ public enum NetworkErrorCode implements ErrorCode {
     CONNECTION_NOT_FOUND(HttpStatus.NOT_FOUND, "NETWORK_005", "교류 관계를 찾을 수 없습니다."),
     INVALID_QR_CODE(HttpStatus.BAD_REQUEST, "NETWORK_006", "유효하지 않은 QR 코드입니다."),
     INVALID_INTERACTION_TYPE(HttpStatus.BAD_REQUEST, "NETWORK_007", "유효하지 않은 상호작용 타입입니다."),
-    INTERACTION_NOT_ALLOWED(HttpStatus.FORBIDDEN, "NETWORK_008", "해당 상호작용을 보낼 수 없습니다.");
+    INTERACTION_NOT_ALLOWED(HttpStatus.FORBIDDEN, "NETWORK_008", "해당 상호작용을 보낼 수 없습니다."),
+    INTERACTION_ALREADY_SENT(HttpStatus.CONFLICT, "NETWORK_008", "이미 상호작용을 보냈습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/network/service/NetworkService.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/network/service/NetworkService.java
@@ -7,6 +7,9 @@ import com.solif.backend.domain.council.entity.CouncilMember;
 import com.solif.backend.domain.council.repository.CouncilMemberRepository;
 import com.solif.backend.domain.interest.entity.UserInterest;
 import com.solif.backend.domain.interest.repository.UserInterestRepository;
+import com.solif.backend.domain.mentoring.entity.MentoringInteraction;
+import com.solif.backend.domain.mentoring.entity.MentoringInteractionType;
+import com.solif.backend.domain.mentoring.repository.MentoringInteractionRepository;
 import com.solif.backend.domain.network.dto.*;
 import com.solif.backend.domain.network.entity.Connection;
 import com.solif.backend.domain.network.entity.ConnectionStatus;
@@ -66,6 +69,7 @@ public class NetworkService {
     private final UserInterestRepository userInterestRepository;
     private final CouncilMemberRepository councilMemberRepository;
     private final ObjectMapper objectMapper;
+    private final MentoringInteractionRepository mentoringInteractionRepository;
 
     // 나의 교류망 목록 조회
     public NetworkListResponse getMyNetworks(Long userId) {
@@ -223,9 +227,34 @@ public class NetworkService {
             throw new CustomException(NetworkErrorCode.INVALID_INTERACTION_TYPE);
         }
 
-        // 역할 기반 상호작용 타입 검증
-        validateInteractionType(sender, receiver, notificationType);
+        // Enum 변환
+        MentoringInteractionType interactionType;
+        try {
+            interactionType = MentoringInteractionType.valueOf(request.getInteractionType().toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new CustomException(NetworkErrorCode.INVALID_INTERACTION_TYPE);
+        }
 
+        // 역할 기반 상호작용 타입 검증
+        validateInteractionType(sender, receiver, interactionType);
+
+        // 이미 보냈는지 확인 (중복 방지)
+        boolean alreadySent = mentoringInteractionRepository.existsBySender_UserIdAndReceiver_UserIdAndInteractionType(
+                sender.getUserId(), receiver.getUserId(), interactionType);
+
+        if (alreadySent) {
+            throw new CustomException(NetworkErrorCode.INTERACTION_ALREADY_SENT);
+        }
+
+        // DB에 상호작용 저장
+        MentoringInteraction interaction = MentoringInteraction.builder()
+                .sender(sender)
+                .receiver(receiver)
+                .interactionType(interactionType)
+                .build();
+        mentoringInteractionRepository.save(interaction);
+
+        // 알림 메시지 설정
         if (notificationType == NotificationType.CHEER) {
             title = "응원이 도착했어요!";
             content = sender.getName() + "님이 응원을 보냈어요";
@@ -389,17 +418,22 @@ public class NetworkService {
         };
     }
 
-    private void validateInteractionType(User sender, User receiver, NotificationType type) {
-        int senderLevel = getRoleLevel(sender.getUserRole());
-        int receiverLevel = getRoleLevel(receiver.getUserRole());
-
-        // CHEER는 보내는 사람이 받는 사람보다 윗 역할일 때만 가능
-        if (type == NotificationType.CHEER && senderLevel <= receiverLevel) {
+    private void validateInteractionType(User sender, User receiver, MentoringInteractionType type) {
+        // MASTER(관리자) 제외
+        if (sender.getUserRole() == User.UserRole.MASTER || receiver.getUserRole() == User.UserRole.MASTER) {
             throw new CustomException(NetworkErrorCode.INTERACTION_NOT_ALLOWED);
         }
 
-        // HELP는 보내는 사람이 받는 사람과 같거나 아래 역할일 때만 가능
-        if (type == NotificationType.HELP && senderLevel > receiverLevel) {
+        int senderLevel = getRoleLevel(sender.getUserRole());
+        int receiverLevel = getRoleLevel(receiver.getUserRole());
+
+        // CHEER(응원하기)는 받는 사람이 보내는 사람보다 선배일 때만 가능
+        if (type == MentoringInteractionType.CHEER && receiverLevel <= senderLevel) {
+            throw new CustomException(NetworkErrorCode.INTERACTION_NOT_ALLOWED);
+        }
+
+        // HELP(경험나누기)는 받는 사람이 보내는 사람과 같거나 후배일 때만 가능
+        if (type == MentoringInteractionType.HELP && receiverLevel > senderLevel) {
             throw new CustomException(NetworkErrorCode.INTERACTION_NOT_ALLOWED);
         }
     }

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/profile/repository/UserProfileRepository.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/profile/repository/UserProfileRepository.java
@@ -3,6 +3,7 @@ package com.solif.backend.domain.profile.repository;
 import com.solif.backend.domain.profile.entity.UserProfile;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface UserProfileRepository extends JpaRepository<UserProfile, Long> {
@@ -13,4 +14,7 @@ public interface UserProfileRepository extends JpaRepository<UserProfile, Long> 
 
     // QR 코드로 프로필 조회
     Optional<UserProfile> findByQrCodeData(String qrCodeData);
+
+    // 여러 사용자 ID로 프로필 배치 조회
+    List<UserProfile> findByUser_UserIdIn(List<Long> userIds);
 }


### PR DESCRIPTION
## 🔍 개요
교류 탭의 멘토링 기능을 위해 `mentoring` 도메인을 신규 생성하고,
멘토/신청/엽서/내역 조회에 필요한 기본 엔티티/레포지토리/서비스/DTO/컨트롤러를 1차로 구성했습니다.

## ✨ 변경 사항
- `mentoring` 도메인 패키지 신규 추가

#### 📌 멘토링 신청
- `POST /api/v1/mentoring/requests`
  - 멘토링 신청 생성

#### 📌 멘토링 엽서
- `POST /api/v1/mentoring/cards`
  - 멘토링 엽서 전송
- `GET /api/v1/mentoring/cards/{cardId}`
  - 멘토링 엽서 상세 조회
- `GET /api/v1/mentoring/cards/sent`
  - 내가 보낸 멘토링 엽서 목록 조회

#### 📌 멘토링 신청 내역
- `GET /api/v1/mentoring/requests/{requestId}`
  - 멘토링 신청서 상세 조회
- `GET /api/v1/mentoring/requests/sent`
  - 내가 보낸 신청서 목록 조회
- `GET /api/v1/mentoring/requests/received`
  - 내가 받은 신청서 목록 조회

#### 📌 멘토링 조회
- `GET /api/v1/mentoring/mentors`
  - 전문가 멘토 목록 조회
- `GET /api/v1/mentoring/home`
  - 멘토링 홈 조회 (집계 화면)

## 🧪 테스트
- [x] 로컬 테스트 완료
- [ ] API 테스트 완료
- [ ] 테스트 코드 작성 (해당 시)

## 📎 관련 이슈
Closes: #80 

## ⚠️ 참고 사항
- 멘토링 기능을 독립 도메인으로 분리하여 이후 교류/쪽지/게시글 연동을 확장하기 쉽게 구성했습니다.
- Enum 기반으로 신청 카테고리/상태/방식(멘토링 방식/인터랙션 타입)을 정의해 정책 변경에 대응 가능하게 했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 멘토링 시스템 전면 도입: 전문가 목록, 멘토링 신청(생성·상세·목록), 멘토링 홈(카테고별 추천·응원·경험 공유·후기)
  * 멘토링 엽서: 엽서 작성·발송, 보낸 엽서 목록 및 엽서 상세(읽음 표시·이미지)
  * 메시지 개선: 이미지 첨부 지원, 수신자 정보 및 읽음 상태 표시, 첨부 이미지 URL 노출
* **문구 / 응답 코드**
  * 멘토링 관련 성공/오류 코드 추가 및 지역화된 메시지 제공
<!-- end of auto-generated comment: release notes by coderabbit.ai -->