### PR TITLE
feature: NetworkListResponse에 region 추가

### DIFF
--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/network/dto/NetworkListResponse.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/network/dto/NetworkListResponse.java
@@ -86,6 +86,9 @@ public class NetworkListResponse {
         @Schema(description = "소속 자치회 이름", example = "제주최강산한이들")
         private String councilName;
 
+        @Schema(description = "지역", example = "서울")
+        private String region;
+
         @Schema(description = "학교 이름 (장학생) 또는 직업 (졸업생)", example = "서울 행운고등학교")
         private String schoolName;
 

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/network/service/NetworkService.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/network/service/NetworkService.java
@@ -130,6 +130,7 @@ public class NetworkService {
                             .buttonType(buttonType)
                             .isInCouncil(membership != null)
                             .councilName(membership != null ? membership.getCouncil().getCouncilName() : null)
+                            .region(other.getRegion())
                             .schoolName(getSchoolOrJob(other))
                             .joinYear(getJoinYear(other))
                             .build();


### PR DESCRIPTION
## 🔍 개요
feature: NetworkListResponse에 region 추가

## ✨ 변경 사항
- NetworkListResponse에 region 추가
- NetworkService에 region 추가

## 🧪 테스트
- [x] 로컬 테스트 완료
- [ ] API 테스트 완료
- [ ] 테스트 코드 작성 (해당 시)

## 📎 관련 이슈
Closes: #86 

## ⚠️ 참고 사항
리뷰어가 알아야 할 사항이나 논의가 필요한 부분을 작성해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* 네트워크 카드에 지역 정보 표시 기능이 추가되었습니다. 내 네트워크에 속한 각 사용자의 지역을 네트워크 목록 화면에서 바로 확인할 수 있게 되었습니다. 이를 통해 지역별 네트워크 관리가 더욱 직관적이고 효율적으로 개선되었으며, 지역 기반의 사용자 연결 활동을 더 쉽게 진행할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->