### PR TITLE
fix: 사용자 검색 API 응답에 캐릭터/배경 패턴 필드 추가

### DIFF
--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/user/controller/UserController.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/user/controller/UserController.java
@@ -20,7 +20,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
-@Tag(name = "사용자", description = "테스트용 사용자 정보 API")
+@Tag(name = "사용자", description = "사용자 정보 API")
 @RestController
 @RequestMapping("/api/v1/users")
 @RequiredArgsConstructor

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/user/dto/UserSearchResponse.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/user/dto/UserSearchResponse.java
@@ -29,7 +29,21 @@ public class UserSearchResponse {
     @Schema(description = "소속 자치회 이름", example = "제주최강산한이들")
     private String councilName;
 
-    public static UserSearchResponse from(User user, CouncilMember membership) {
+    @Schema(description = "캐릭터")
+    private String userCharacter;
+
+    @Schema(description = "캐릭터 이미지 URL")
+    private String characterImageUrl;
+
+    @Schema(description = "배경 패턴")
+    private String backgroundPattern;
+
+    @Schema(description = "배경 이미지 URL")
+    private String backgroundImageUrl;
+
+    public static UserSearchResponse from(User user, CouncilMember membership,
+                                          String userCharacter, String characterImageUrl,
+                                          String backgroundPattern, String backgroundImageUrl) {
         return UserSearchResponse.builder()
                 .userId(user.getUserId())
                 .name(user.getName())
@@ -37,6 +51,10 @@ public class UserSearchResponse {
                 .schoolName(user.getSchoolName())
                 .isInCouncil(membership != null)
                 .councilName(membership != null ? membership.getCouncil().getCouncilName() : null)
+                .userCharacter(userCharacter)
+                .characterImageUrl(characterImageUrl)
+                .backgroundPattern(backgroundPattern)
+                .backgroundImageUrl(backgroundImageUrl)
                 .build();
     }
 }

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/user/service/UserService.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/user/service/UserService.java
@@ -3,6 +3,8 @@ package com.solif.backend.domain.user.service;
 import com.solif.backend.domain.auth.code.AuthErrorCode;
 import com.solif.backend.domain.council.entity.CouncilMember;
 import com.solif.backend.domain.council.repository.CouncilMemberRepository;
+import com.solif.backend.domain.profile.entity.UserProfile;
+import com.solif.backend.domain.profile.repository.UserProfileRepository;
 import com.solif.backend.domain.user.dto.UserMeResponse;
 import com.solif.backend.domain.user.dto.UserSearchResponse;
 import com.solif.backend.domain.user.entity.User;
@@ -10,14 +12,15 @@ import com.solif.backend.domain.user.repository.UserRepository;
 import com.solif.backend.global.common.exception.CustomException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -29,6 +32,13 @@ public class UserService {
 
     private final UserRepository userRepository;
     private final CouncilMemberRepository councilMemberRepository;
+    private final UserProfileRepository userProfileRepository;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
 
     // 내 정보 조회
     public UserMeResponse getMyInfo(Long userId) {
@@ -57,12 +67,12 @@ public class UserService {
         }
 
         // 사용자 ID 목록
-        Set<Long> userIds = users.stream()
+        List<Long> userIds = users.stream()
                 .map(User::getUserId)
-                .collect(Collectors.toSet());
+                .collect(Collectors.toList());
 
         // 한 번의 쿼리로 모든 멤버십 조회 (N+1 방지)
-        List<CouncilMember> memberships = councilMemberRepository.findByUserIdIn(userIds);
+        List<CouncilMember> memberships = councilMemberRepository.findByUserIdIn(new HashSet<>(userIds));
 
         // userId -> CouncilMember 매핑
         Map<Long, CouncilMember> membershipMap = memberships.stream()
@@ -71,9 +81,44 @@ public class UserService {
                         Function.identity()
                 ));
 
+        // 한 번의 쿼리로 모든 프로필 조회 (N+1 방지)
+        List<UserProfile> profiles = userProfileRepository.findByUser_UserIdIn(userIds);
+
+        // userId -> UserProfile 매핑
+        Map<Long, UserProfile> profileMap = profiles.stream()
+                .collect(Collectors.toMap(
+                        profile -> profile.getUser().getUserId(),
+                        Function.identity()
+                ));
+
         // DTO 변환
         return users.stream()
-                .map(user -> UserSearchResponse.from(user, membershipMap.get(user.getUserId())))
+                .map(user -> {
+                    UserProfile profile = profileMap.get(user.getUserId());
+
+                    String userCharacter = profile != null ? profile.getUserCharacter() : null;
+                    String characterImageUrl = buildS3Url(userCharacter);
+
+                    String backgroundPattern = profile != null ? profile.getBackgroundPattern() : null;
+                    String backgroundImageUrl = buildS3Url(backgroundPattern);
+
+                    return UserSearchResponse.from(
+                            user,
+                            membershipMap.get(user.getUserId()),
+                            userCharacter,
+                            characterImageUrl,
+                            backgroundPattern,
+                            backgroundImageUrl
+                    );
+                })
                 .collect(Collectors.toList());
+    }
+
+    // ===== Helper Methods =====
+
+    // S3 URL 빌더
+    private String buildS3Url(String key) {
+        if (key == null || key.isBlank()) return null;
+        return String.format("https://%s.s3.%s.amazonaws.com/%s", bucket, region, key);
     }
 }


### PR DESCRIPTION
## 🔍 개요
프론트엔드 멘토링 화면 연동 과정에서,
사용자 검색 API(`/api/v1/users/search`) 응답에
`userCharacter`, `backgroundPattern` 필드가 누락된 것을 확인하여 이를 보완했습니다.

## ✨ 변경 사항
- 사용자 검색 API 응답 DTO 수정
- 응답 데이터에 다음 필드 추가
  - `userCharacter`
  - `backgroundPattern`

## 🧪 테스트
- [ ] 로컬 테스트 완료
- [ ] API 테스트 완료
- [ ] 테스트 코드 작성 (해당 시)

## 📎 관련 이슈
Closes: #88 

## ⚠️ 참고 사항
- 기존 응답 구조는 유지하며 필드만 확장했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 사용자 검색 결과에 사용자 캐릭터, 배경 패턴 및 관련 이미지 정보가 추가되었습니다.

* **문서**
  * 사용자 정보 API 설명 텍스트가 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->