### PR TITLE
fix: 보낸 멘토링 신청서 목록 조회 응답에 멘토 프로필 이미지 추가

### DIFF
--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/mentoring/dto/MentoringRequestListResponse.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/mentoring/dto/MentoringRequestListResponse.java
@@ -21,6 +21,9 @@ public class MentoringRequestListResponse {
     @Schema(description = "멘토 직함", example = "멘토 SO&L 글로벌자산운용 대표")
     private String mentorTitle;
 
+    @Schema(description = "멘토 프로필 이미지 URL")
+    private String mentorProfileImageUrl;
+
     @Schema(description = "카테고리", example = "STUDY")
     private String category;
 
@@ -44,11 +47,12 @@ public class MentoringRequestListResponse {
     @Schema(description = "답변 일시", example = "2026-02-10T15:00:00", nullable = true)
     private LocalDateTime repliedAt;
 
-    public static MentoringRequestListResponse from(MentoringRequest request) {
+    public static MentoringRequestListResponse from(MentoringRequest request, String mentorProfileImageUrl) {
         return MentoringRequestListResponse.builder()
                 .mentoringRequestId(request.getMentoringRequestId())
                 .mentorName(request.getMentor().getMentorName())
                 .mentorTitle(request.getMentor().getMentorTitle())
+                .mentorProfileImageUrl(mentorProfileImageUrl)
                 .category(request.getCategory().name())
                 .method(request.getMethod().name())
                 .status(request.getStatus().name())

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/mentoring/service/MentoringService.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/mentoring/service/MentoringService.java
@@ -105,7 +105,12 @@ public class MentoringService {
 
         Slice<MentoringRequest> requests = mentoringRequestRepository.findSentRequests(userId, pageable);
 
-        return requests.map(MentoringRequestListResponse::from);
+        return requests.map(request ->
+                MentoringRequestListResponse.from(
+                        request,
+                        request.getMentor().getProfileImageFile()
+                )
+        );
     }
 
     // 멘토링 신청서 상세 조회
@@ -133,7 +138,12 @@ public class MentoringService {
 
         Slice<MentoringRequest> requests = mentoringRequestRepository.findReceivedRequests(userId, pageable);
 
-        return requests.map(MentoringRequestListResponse::from);
+        return requests.map(request ->
+                MentoringRequestListResponse.from(
+                        request,
+                        request.getMentor().getProfileImageFile()
+                )
+        );
     }
 
     // 멘토링 홈 조회


### PR DESCRIPTION
## 🔍 개요
멘토링 신청 내역 화면 연동 과정에서,
`내가 보낸 멘토링 신청서 목록 조회` API 응답에
멘토 프로필 이미지 정보가 누락된 것을 확인하여 이를 보완했습니다.


## ✨ 변경 사항
- 보낸 멘토링 신청서 목록 조회 응답 DTO 수정
- 멘토(`Mentor`) 엔티티의 `profileImageFile` 필드 응답에 추가
- 멘토 정보 조회 시 프로필 이미지 포함되도록 조회 로직 보완

## 🧪 테스트
- [x] 로컬 테스트 완료
- [ ] API 테스트 완료
- [ ] 테스트 코드 작성 (해당 시)

## 📎 관련 이슈
Closes: #90 

## ⚠️ 참고 사항
- 기존 응답 필드는 유지하며 멘토 프로필 이미지 필드만 확장했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 멘토링 요청 목록에서 멘토의 프로필 이미지가 표시되도록 개선되었습니다. 사용자가 보낸 요청과 받은 요청 목록 모두에서 각 멘토의 프로필 이미지를 함께 확인할 수 있어 멘토를 더 쉽게 식별할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->