### PR TITLE
feat: 게시글 타입별 테이블 분리로 게시판 구조 개선

### DIFF
--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/counselingpost/entity/CounselingPost.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/counselingpost/entity/CounselingPost.java
@@ -1,0 +1,60 @@
+package com.solif.backend.domain.counselingpost.entity;
+
+import com.solif.backend.domain.post.entity.Post;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "counseling_post")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class CounselingPost {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "counseling_post_id")
+    private Long counselingPostId;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id", nullable = false)
+    private Post post;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+    @Builder
+    public CounselingPost(Post post) {
+        this.post = post;
+    }
+
+    // 비즈니스 로직
+    public void softDelete() {
+        this.deletedAt = LocalDateTime.now();
+        this.post.softDelete();
+    }
+
+    public boolean isDeleted() {
+        return this.deletedAt != null;
+    }
+
+    public boolean isAuthor(Long userId) {
+        return this.post.isAuthor(userId);
+    }
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/counselingpost/repository/CounselingPostRepository.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/counselingpost/repository/CounselingPostRepository.java
@@ -1,0 +1,29 @@
+package com.solif.backend.domain.counselingpost.repository;
+
+import com.solif.backend.domain.counselingpost.entity.CounselingPost;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface CounselingPostRepository extends JpaRepository<CounselingPost, Long> {
+
+    // Post ID로 조회
+    @Query("SELECT cp FROM CounselingPost cp " +
+            "WHERE cp.post.postId = :postId")
+    Optional<CounselingPost> findByPostId(@Param("postId") Long postId);
+
+    // 삭제되지 않은 게시글 조회 (상세 조회용)
+    @Query("SELECT cp FROM CounselingPost cp " +
+            "JOIN FETCH cp.post p " +
+            "WHERE cp.counselingPostId = :counselingPostId " +
+            "AND cp.deletedAt IS NULL")
+    Optional<CounselingPost> findActiveByIdWithPost(@Param("counselingPostId") Long counselingPostId);
+
+    // 삭제 여부 무관 조회 (수정/삭제용)
+    @Query("SELECT cp FROM CounselingPost cp " +
+            "JOIN FETCH cp.post p " +
+            "WHERE cp.counselingPostId = :counselingPostId")
+    Optional<CounselingPost> findByIdWithPost(@Param("counselingPostId") Long counselingPostId);
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/mentoring/dto/MentoringRequestDetailResponse.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/mentoring/dto/MentoringRequestDetailResponse.java
@@ -60,12 +60,6 @@ public class MentoringRequestDetailResponse {
     @Schema(description = "답변 일시", nullable = true)
     private LocalDateTime repliedAt;
 
-    @Schema(description = "후기 작성 여부", example = "false")
-    private Boolean hasReview;
-
-    @Schema(description = "후기 게시글 ID", nullable = true)
-    private Long reviewPostId;
-
     public static MentoringRequestDetailResponse from(MentoringRequest request, String mentorProfileImageUrl) {
         return MentoringRequestDetailResponse.builder()
                 .mentoringRequestId(request.getMentoringRequestId())
@@ -84,8 +78,6 @@ public class MentoringRequestDetailResponse {
                 .createdAt(request.getCreatedAt())
                 .updatedAt(request.getUpdatedAt())
                 .repliedAt(request.getRepliedAt())
-                .hasReview(request.getReviewPost() != null)
-                .reviewPostId(request.getReviewPost() != null ? request.getReviewPost().getPostId() : null)
                 .build();
     }
 }

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/mentoring/entity/MentoringRequest.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/mentoring/entity/MentoringRequest.java
@@ -1,6 +1,5 @@
 package com.solif.backend.domain.mentoring.entity;
 
-import com.solif.backend.domain.post.entity.Post;
 import com.solif.backend.domain.user.entity.User;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -32,10 +31,6 @@ public class MentoringRequest {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "mentee_user_id", nullable = false)
     private User menteeUser;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "review_post_id")
-    private Post reviewPost;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "category", nullable = false, length = 50)
@@ -82,10 +77,6 @@ public class MentoringRequest {
     // 비즈니스 로직
     public void updateStatus(MentoringRequestStatus newStatus) {
         this.status = newStatus;
-    }
-
-    public void linkReviewPost(Post reviewPost) {
-        this.reviewPost = reviewPost;
     }
 
     // 관리자 답변 작성

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/mentoring/repository/MentoringRequestRepository.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/mentoring/repository/MentoringRequestRepository.java
@@ -30,7 +30,6 @@ public interface MentoringRequestRepository extends JpaRepository<MentoringReque
     @Query("SELECT mr FROM MentoringRequest mr " +
             "JOIN FETCH mr.mentor m " +
             "JOIN FETCH mr.menteeUser " +
-            "LEFT JOIN FETCH mr.reviewPost " +
             "WHERE mr.mentoringRequestId = :requestId")
     Optional<MentoringRequest> findByIdWithDetails(@Param("requestId") Long requestId);
 }

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/mentoringpost/entity/MentoringPost.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/mentoringpost/entity/MentoringPost.java
@@ -1,0 +1,60 @@
+package com.solif.backend.domain.mentoringpost.entity;
+
+import com.solif.backend.domain.post.entity.Post;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "mentoring_post")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class MentoringPost {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "mentoring_post_id")
+    private Long mentoringPostId;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id", nullable = false)
+    private Post post;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+    @Builder
+    public MentoringPost(Post post) {
+        this.post = post;
+    }
+
+    // 비즈니스 로직
+    public void softDelete() {
+        this.deletedAt = LocalDateTime.now();
+        this.post.softDelete();
+    }
+
+    public boolean isDeleted() {
+        return this.deletedAt != null;
+    }
+
+    public boolean isAuthor(Long userId) {
+        return this.post.isAuthor(userId);
+    }
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/mentoringpost/repository/MentoringPostRepository.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/mentoringpost/repository/MentoringPostRepository.java
@@ -1,0 +1,31 @@
+package com.solif.backend.domain.mentoringpost.repository;
+
+import com.solif.backend.domain.mentoringpost.entity.MentoringPost;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface MentoringPostRepository extends JpaRepository<MentoringPost, Long> {
+
+    // Post ID로 조회
+    @Query("SELECT mp FROM MentoringPost mp " +
+            "WHERE mp.post.postId = :postId")
+    Optional<MentoringPost> findByPostId(@Param("postId") Long postId);
+
+    // 삭제되지 않은 게시글 조회 (상세 조회용)
+    @Query("SELECT mp FROM MentoringPost mp " +
+            "JOIN FETCH mp.post p " +
+            "JOIN FETCH p.author " +
+            "WHERE mp.mentoringPostId = :mentoringPostId " +
+            "AND mp.deletedAt IS NULL")
+    Optional<MentoringPost> findActiveByIdWithPost(@Param("mentoringPostId") Long mentoringPostId);
+
+    // 삭제 여부 무관 조회 (수정/삭제용)
+    @Query("SELECT mp FROM MentoringPost mp " +
+            "JOIN FETCH mp.post p " +
+            "JOIN FETCH p.author " +
+            "WHERE mp.mentoringPostId = :mentoringPostId")
+    Optional<MentoringPost> findByIdWithPost(@Param("mentoringPostId") Long mentoringPostId);
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/noticepost/entity/NoticePost.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/noticepost/entity/NoticePost.java
@@ -53,4 +53,8 @@ public class NoticePost {
     public boolean isDeleted() {
         return this.deletedAt != null;
     }
+
+    public boolean isAuthor(Long userId) {
+        return this.post.isAuthor(userId);
+    }
 }

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/noticepost/entity/NoticePost.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/noticepost/entity/NoticePost.java
@@ -1,0 +1,56 @@
+package com.solif.backend.domain.noticepost.entity;
+
+import com.solif.backend.domain.post.entity.Post;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "notice_post")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class NoticePost {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "notice_post_id")
+    private Long noticePostId;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id", nullable = false)
+    private Post post;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+    @Builder
+    public NoticePost(Post post) {
+        this.post = post;
+    }
+
+    // 비즈니스 로직
+    public void softDelete() {
+        this.deletedAt = LocalDateTime.now();
+        this.post.softDelete();
+    }
+
+    public boolean isDeleted() {
+        return this.deletedAt != null;
+    }
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/noticepost/repository/NoticePostRepository.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/noticepost/repository/NoticePostRepository.java
@@ -1,0 +1,31 @@
+package com.solif.backend.domain.noticepost.repository;
+
+import com.solif.backend.domain.noticepost.entity.NoticePost;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface NoticePostRepository extends JpaRepository<NoticePost, Long> {
+
+    // Post ID로 조회
+    @Query("SELECT np FROM NoticePost np " +
+            "WHERE np.post.postId = :postId")
+    Optional<NoticePost> findByPostId(@Param("postId") Long postId);
+
+    // 삭제되지 않은 게시글 조회 (상세 조회용)
+    @Query("SELECT np FROM NoticePost np " +
+            "JOIN FETCH np.post p " +
+            "JOIN FETCH p.author " +
+            "WHERE np.noticePostId = :noticePostId " +
+            "AND np.deletedAt IS NULL")
+    Optional<NoticePost> findActiveByIdWithPost(@Param("noticePostId") Long noticePostId);
+
+    // 삭제 여부 무관 조회 (수정/삭제용)
+    @Query("SELECT np FROM NoticePost np " +
+            "JOIN FETCH np.post p " +
+            "JOIN FETCH p.author " +
+            "WHERE np.noticePostId = :noticePostId")
+    Optional<NoticePost> findByIdWithPost(@Param("noticePostId") Long noticePostId);
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/post/service/PostService.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/post/service/PostService.java
@@ -267,7 +267,10 @@ public class PostService {
         Post savedPost = postRepository.save(post);
 
         // 게시판별 타입 테이블 생성
-        if (request.getBoardId() == 2L) {
+        if (request.getBoardId() == 1L) {
+            // 자치회 활동 후기는 CouncilReviewPostController 사용
+            throw new CustomException(PostErrorCode.INVALID_BOARD);
+        } else if (request.getBoardId() == 2L) {
             // 멘토링 후기
             MentoringPost mentoringPost = MentoringPost.builder()
                     .post(savedPost)
@@ -391,28 +394,28 @@ public class PostService {
 
         // 게시판별 타입 테이블 Soft Delete
         Long boardId = post.getBoard().getBoardId();
-        if (boardId == 2L) {
+        if (boardId == 1L) {
+            // 자치회 활동 후기는 CouncilReviewPostController 사용
+            throw new CustomException(PostErrorCode.INVALID_BOARD);
+        } else if (boardId == 2L) {
             // 멘토링 후기
             MentoringPost mentoringPost = mentoringPostRepository.findByPostId(postId)
                     .orElseThrow(() -> new CustomException(PostErrorCode.POST_NOT_FOUND));
-            mentoringPost.softDelete();
+            mentoringPost.softDelete();  // 내부에서 post.softDelete() 호출됨
             log.info("멘토링 후기 삭제 - mentoringPostId: {}", mentoringPost.getMentoringPostId());
         } else if (boardId == 3L) {
             // 고민상담
             CounselingPost counselingPost = counselingPostRepository.findByPostId(postId)
                     .orElseThrow(() -> new CustomException(PostErrorCode.POST_NOT_FOUND));
-            counselingPost.softDelete();
+            counselingPost.softDelete();  // 내부에서 post.softDelete() 호출됨
             log.info("고민상담 삭제 - counselingPostId: {}", counselingPost.getCounselingPostId());
         } else if (boardId == 4L) {
             // 재단소식
             NoticePost noticePost = noticePostRepository.findByPostId(postId)
                     .orElseThrow(() -> new CustomException(PostErrorCode.POST_NOT_FOUND));
-            noticePost.softDelete();
+            noticePost.softDelete();  // 내부에서 post.softDelete() 호출됨
             log.info("재단소식 삭제 - noticePostId: {}", noticePost.getNoticePostId());
         }
-
-        // Soft Delete (이미 타입별 테이블에서 post.softDelete() 호출했지만, 명시적으로 한 번 더)
-        post.softDelete();
     }
 
     // 게시판별 카테고리 검증

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/post/service/PostService.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/post/service/PostService.java
@@ -1,5 +1,11 @@
 package com.solif.backend.domain.post.service;
 
+import com.solif.backend.domain.mentoringpost.entity.MentoringPost;
+import com.solif.backend.domain.mentoringpost.repository.MentoringPostRepository;
+import com.solif.backend.domain.counselingpost.entity.CounselingPost;
+import com.solif.backend.domain.counselingpost.repository.CounselingPostRepository;
+import com.solif.backend.domain.noticepost.entity.NoticePost;
+import com.solif.backend.domain.noticepost.repository.NoticePostRepository;
 import com.solif.backend.domain.auth.code.AuthErrorCode;
 import com.solif.backend.domain.board.code.BoardErrorCode;
 import com.solif.backend.domain.board.entity.Board;
@@ -50,6 +56,9 @@ public class PostService {
     private final CouncilReviewPostRepository councilReviewPostRepository;
     private final FileService fileService;
     private final FileAttachmentRepository fileAttachmentRepository;
+    private final MentoringPostRepository mentoringPostRepository;
+    private final CounselingPostRepository counselingPostRepository;
+    private final NoticePostRepository noticePostRepository;
 
     @Value("${cloud.aws.region.static}")
     private String region;
@@ -257,6 +266,30 @@ public class PostService {
         // 저장
         Post savedPost = postRepository.save(post);
 
+        // 게시판별 타입 테이블 생성
+        if (request.getBoardId() == 2L) {
+            // 멘토링 후기
+            MentoringPost mentoringPost = MentoringPost.builder()
+                    .post(savedPost)
+                    .build();
+            mentoringPostRepository.save(mentoringPost);
+            log.info("멘토링 후기 생성 - mentoringPostId: {}", mentoringPost.getMentoringPostId());
+        } else if (request.getBoardId() == 3L) {
+            // 고민상담
+            CounselingPost counselingPost = CounselingPost.builder()
+                    .post(savedPost)
+                    .build();
+            counselingPostRepository.save(counselingPost);
+            log.info("고민상담 생성 - counselingPostId: {}", counselingPost.getCounselingPostId());
+        } else if (request.getBoardId() == 4L) {
+            // 재단소식
+            NoticePost noticePost = NoticePost.builder()
+                    .post(savedPost)
+                    .build();
+            noticePostRepository.save(noticePost);
+            log.info("재단소식 생성 - noticePostId: {}", noticePost.getNoticePostId());
+        }
+
         // 파일 확정 (fileIds가 있으면)
         if (request.getFileIds() != null && !request.getFileIds().isEmpty()) {
             fileService.confirmFiles(
@@ -266,12 +299,6 @@ public class PostService {
                     AttachmentPurpose.POST_ATTACHMENT
             );
         }
-
-        // TODO: mentoringRequestId 처리 (나중에 멘토링 도메인 구현 시)
-        // if (request.getMentoringRequestId() != null) {
-        //     mentoringRequestRepository.updateReviewPostId(
-        //         request.getMentoringRequestId(), savedPost.getPostId());
-        // }
 
         return PostCreateResponse.from(savedPost);
     }
@@ -362,7 +389,29 @@ public class PostService {
             throw new CustomException(PostErrorCode.UNAUTHORIZED_POST_ACCESS);
         }
 
-        // Soft Delete
+        // 게시판별 타입 테이블 Soft Delete
+        Long boardId = post.getBoard().getBoardId();
+        if (boardId == 2L) {
+            // 멘토링 후기
+            MentoringPost mentoringPost = mentoringPostRepository.findByPostId(postId)
+                    .orElseThrow(() -> new CustomException(PostErrorCode.POST_NOT_FOUND));
+            mentoringPost.softDelete();
+            log.info("멘토링 후기 삭제 - mentoringPostId: {}", mentoringPost.getMentoringPostId());
+        } else if (boardId == 3L) {
+            // 고민상담
+            CounselingPost counselingPost = counselingPostRepository.findByPostId(postId)
+                    .orElseThrow(() -> new CustomException(PostErrorCode.POST_NOT_FOUND));
+            counselingPost.softDelete();
+            log.info("고민상담 삭제 - counselingPostId: {}", counselingPost.getCounselingPostId());
+        } else if (boardId == 4L) {
+            // 재단소식
+            NoticePost noticePost = noticePostRepository.findByPostId(postId)
+                    .orElseThrow(() -> new CustomException(PostErrorCode.POST_NOT_FOUND));
+            noticePost.softDelete();
+            log.info("재단소식 삭제 - noticePostId: {}", noticePost.getNoticePostId());
+        }
+
+        // Soft Delete (이미 타입별 테이블에서 post.softDelete() 호출했지만, 명시적으로 한 번 더)
         post.softDelete();
     }
 


### PR DESCRIPTION
## 🔍 개요
게시글(post) 테이블을 공통 정보만 유지하고,
게시글 타입별 테이블을 분리하여 게시판 구조를 개선했습니다.

멘토링 후기/고민상담/재단소식 게시글을 타입별 테이블로 분리하고,
기존 API 호환성은 유지하는 방향으로 로직을 보완했습니다.

## ✨ 변경 사항
### 1) DDL / DB 구조 변경
### 2) 엔티티/레포지토리 추가
### 3) 서비스/컨트롤러 로직 수정 (기존 API 호환)

## 🧪 테스트
- [x] 로컬 테스트 완료
- [ ] API 테스트 완료
- [ ] 테스트 코드 작성 (해당 시)

## 📎 관련 이슈
Closes: #92 

## ⚠️ 참고 사항
- `post`는 공통 게시글 정보만 유지합니다.
- `council_review_post`(자치회 후기) 구조를 참고하여 타입 분리 구조를 통일했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 게시물 유형(멘토링·상담·공지)에 따른 개별 생성·관리 및 유형별 소프트 삭제 지원
  * 각 유형 게시물에서 작성자 확인 기능 제공

* **변경사항**
  * 멘토링 요청 응답에서 리뷰 관련 필드 제거로 응답 페이로드 간소화
  * 멘토링 요청 상세 조회 시 리뷰 게시물 연계 조회 축소 및 관련 데이터 로딩 변경
<!-- end of auto-generated comment: release notes by coderabbit.ai -->