### PR TITLE
feat: 장학 프로그램 게시판(boardId=5) 통합 및 목록 조회 API 구현

### DIFF
--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/post/entity/PostCategory.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/post/entity/PostCategory.java
@@ -15,7 +15,11 @@ public enum PostCategory {
 
     // 장학재단 소식 카테고리
     NOTICE("운영공지"),
-    PROGRAM("프로그램");
+    PROGRAM("프로그램"),
+
+    // 장학 프로그램 카테고리
+    REQUIRED("필수 프로그램"),
+    OPTIONAL("선택 프로그램");
 
     private final String description;
 }

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/scholarshipprogrampost/code/ScholarshipProgramSuccessCode.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/scholarshipprogrampost/code/ScholarshipProgramSuccessCode.java
@@ -1,0 +1,17 @@
+package com.solif.backend.domain.scholarshipprogrampost.code;
+
+import com.solif.backend.global.common.response.SuccessCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ScholarshipProgramSuccessCode implements SuccessCode {
+
+    SCHOLARSHIP_PROGRAM_LIST_SUCCESS(HttpStatus.OK, "SCHOLARSHIP_PROGRAM_200", "장학 프로그램 목록 조회에 성공했습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/scholarshipprogrampost/controller/ScholarshipProgramController.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/scholarshipprogrampost/controller/ScholarshipProgramController.java
@@ -1,0 +1,30 @@
+package com.solif.backend.domain.scholarshipprogrampost.controller;
+
+import com.solif.backend.domain.scholarshipprogrampost.code.ScholarshipProgramSuccessCode;
+import com.solif.backend.domain.scholarshipprogrampost.dto.ScholarshipProgramListResponse;
+import com.solif.backend.domain.scholarshipprogrampost.service.ScholarshipProgramService;
+import com.solif.backend.global.common.response.ResponseFactory;
+import com.solif.backend.global.common.response.SuccessResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "장학 프로그램", description = "장학 프로그램 API")
+@RestController
+@RequestMapping("/api/v1/scholarship-programs")
+@RequiredArgsConstructor
+public class ScholarshipProgramController {
+
+    private final ScholarshipProgramService scholarshipProgramService;
+
+    @Operation(summary = "장학 프로그램 목록 조회", description = "필수/선택 프로그램을 분리하여 조회합니다.")
+    @GetMapping
+    public ResponseEntity<SuccessResponse<ScholarshipProgramListResponse>> getScholarshipPrograms() {
+        ScholarshipProgramListResponse response = scholarshipProgramService.getScholarshipPrograms();
+        return ResponseFactory.success(ScholarshipProgramSuccessCode.SCHOLARSHIP_PROGRAM_LIST_SUCCESS, response);
+    }
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/scholarshipprogrampost/dto/ScholarshipProgramListResponse.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/scholarshipprogrampost/dto/ScholarshipProgramListResponse.java
@@ -1,0 +1,21 @@
+package com.solif.backend.domain.scholarshipprogrampost.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@Schema(description = "장학 프로그램 목록 응답")
+public class ScholarshipProgramListResponse {
+
+    @Schema(description = "필수 프로그램 목록")
+    private List<ScholarshipProgramResponse> required;
+
+    @Schema(description = "선택 프로그램 목록")
+    private List<ScholarshipProgramResponse> optional;
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/scholarshipprogrampost/dto/ScholarshipProgramResponse.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/scholarshipprogrampost/dto/ScholarshipProgramResponse.java
@@ -1,0 +1,59 @@
+package com.solif.backend.domain.scholarshipprogrampost.dto;
+
+import com.solif.backend.domain.scholarshipprogrampost.entity.ScholarshipProgramPost;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@Schema(description = "장학 프로그램 응답")
+public class ScholarshipProgramResponse {
+
+    @Schema(description = "게시글 ID", example = "1")
+    private Long postId;
+
+    @Schema(description = "제목", example = "2025.9.11 입직원 직무 멘토링")
+    private String title;
+
+    @Schema(description = "내용 미리보기", example = "신한금융그룹 입직원분들과 함께...")
+    private String content;
+
+    @Schema(description = "조회수", example = "25")
+    private Integer viewCount;
+
+    @Schema(description = "댓글 수", example = "2")
+    private Long commentCount;
+
+    @Schema(description = "작성일시", example = "2026-02-19T10:00:00")
+    private LocalDateTime createdAt;
+
+    @Schema(description = "썸네일 URL", example = "https://s3.amazonaws.com/...")
+    private String thumbnailUrl;
+
+    public static ScholarshipProgramResponse from(ScholarshipProgramPost scholarshipProgramPost, Long commentCount, String thumbnailUrl) {
+        return ScholarshipProgramResponse.builder()
+                .postId(scholarshipProgramPost.getPost().getPostId())
+                .title(scholarshipProgramPost.getPost().getPostTitle())
+                .content(extractPreview(scholarshipProgramPost.getPost().getPostContent()))
+                .viewCount(scholarshipProgramPost.getPost().getViewCount())
+                .commentCount(commentCount)
+                .createdAt(scholarshipProgramPost.getPost().getCreatedAt())
+                .thumbnailUrl(thumbnailUrl)
+                .build();
+    }
+
+    /**
+     * 내용 미리보기 추출 (최대 100자)
+     */
+    private static String extractPreview(String content) {
+        if (content == null) {
+            return "";
+        }
+        return content.length() > 100 ? content.substring(0, 100) + "..." : content;
+    }
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/scholarshipprogrampost/entity/ScholarshipProgramPost.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/scholarshipprogrampost/entity/ScholarshipProgramPost.java
@@ -1,0 +1,38 @@
+package com.solif.backend.domain.scholarshipprogrampost.entity;
+
+import com.solif.backend.domain.post.entity.Post;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "scholarship_program_post")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ScholarshipProgramPost {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "scholarship_program_post_id")
+    private Long scholarshipProgramPostId;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id", nullable = false)
+    private Post post;
+
+    @Builder
+    public ScholarshipProgramPost(Post post) {
+        this.post = post;
+    }
+
+    // 비즈니스 로직
+    public boolean isDeleted() {
+        return this.post.isDeleted();
+    }
+
+    public boolean isAuthor(Long userId) {
+        return this.post.isAuthor(userId);
+    }
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/scholarshipprogrampost/repository/ScholarshipProgramPostRepository.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/scholarshipprogrampost/repository/ScholarshipProgramPostRepository.java
@@ -1,0 +1,28 @@
+package com.solif.backend.domain.scholarshipprogrampost.repository;
+
+import com.solif.backend.domain.post.entity.PostCategory;
+import com.solif.backend.domain.scholarshipprogrampost.entity.ScholarshipProgramPost;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface ScholarshipProgramPostRepository extends JpaRepository<ScholarshipProgramPost, Long> {
+
+    /**
+     * 장학 프로그램 카테고리별 목록 조회 (Post, Author fetch join)
+     * - N+1 문제 해결을 위한 fetch join
+     * - 삭제되지 않은 게시글만 조회
+     * - 최신순 정렬
+     */
+    @Query("SELECT spp FROM ScholarshipProgramPost spp " +
+            "JOIN FETCH spp.post p " +
+            "JOIN FETCH p.author " +
+            "WHERE p.postCategory = :postCategory " +
+            "AND p.deletedAt IS NULL " +
+            "ORDER BY p.createdAt DESC")
+    List<ScholarshipProgramPost> findByPostCategoryWithPostAndAuthor(
+            @Param("postCategory") PostCategory postCategory
+    );
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/scholarshipprogrampost/service/ScholarshipProgramService.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/scholarshipprogrampost/service/ScholarshipProgramService.java
@@ -1,0 +1,107 @@
+package com.solif.backend.domain.scholarshipprogrampost.service;
+
+import com.solif.backend.domain.comment.dto.PostCommentCount;
+import com.solif.backend.domain.comment.repository.CommentRepository;
+import com.solif.backend.domain.file.entity.AttachmentPurpose;
+import com.solif.backend.domain.file.entity.FileAttachment;
+import com.solif.backend.domain.file.entity.FileTargetType;
+import com.solif.backend.domain.file.repository.FileAttachmentRepository;
+import com.solif.backend.domain.post.entity.PostCategory;
+import com.solif.backend.domain.scholarshipprogrampost.dto.ScholarshipProgramListResponse;
+import com.solif.backend.domain.scholarshipprogrampost.dto.ScholarshipProgramResponse;
+import com.solif.backend.domain.scholarshipprogrampost.entity.ScholarshipProgramPost;
+import com.solif.backend.domain.scholarshipprogrampost.repository.ScholarshipProgramPostRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ScholarshipProgramService {
+
+    private final ScholarshipProgramPostRepository scholarshipProgramPostRepository;
+    private final CommentRepository commentRepository;
+    private final FileAttachmentRepository fileAttachmentRepository;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    /**
+     * 장학 프로그램 목록 조회 (필수/선택 분리)
+     */
+    public ScholarshipProgramListResponse getScholarshipPrograms() {
+        log.info("장학 프로그램 목록 조회 시작");
+
+        // 필수 프로그램 조회
+        List<ScholarshipProgramPost> requiredPrograms =
+                scholarshipProgramPostRepository.findByPostCategoryWithPostAndAuthor(PostCategory.REQUIRED);
+        log.info("필수 프로그램 조회 완료 - count: {}", requiredPrograms.size());
+
+        // 선택 프로그램 조회
+        List<ScholarshipProgramPost> optionalPrograms =
+                scholarshipProgramPostRepository.findByPostCategoryWithPostAndAuthor(PostCategory.OPTIONAL);
+        log.info("선택 프로그램 조회 완료 - count: {}", optionalPrograms.size());
+
+        // 댓글 수 일괄 조회 (N+1 방지)
+        List<Long> allPostIds = Stream.concat(
+                requiredPrograms.stream().map(spp -> spp.getPost().getPostId()),
+                optionalPrograms.stream().map(spp -> spp.getPost().getPostId())
+        ).collect(Collectors.toList());
+
+        Map<Long, Long> commentCountMap = commentRepository.countByPostIds(allPostIds).stream()
+                .collect(Collectors.toMap(
+                        PostCommentCount::getPostId,
+                        PostCommentCount::getCommentCount
+                ));
+
+        // 썸네일 일괄 조회 (N+1 방지) - sortOrder=1인 대표 이미지만
+        List<FileAttachment> thumbnails = fileAttachmentRepository
+                .findByFileTargetTypeAndTargetIdInAndSortOrderAndPurpose(
+                        FileTargetType.POST,
+                        allPostIds,
+                        1,  // 첫 번째 이미지만
+                        AttachmentPurpose.POST_ATTACHMENT
+                );
+
+        Map<Long, String> thumbnailMap = thumbnails.stream()
+                .collect(Collectors.toMap(
+                        FileAttachment::getTargetId,
+                        attachment -> attachment.getFile().getUrl(region),
+                        (existing, replacement) -> existing  // 중복 시 첫 번째 유지
+                ));
+
+        // Response 변환
+        List<ScholarshipProgramResponse> requiredResponses = requiredPrograms.stream()
+                .map(spp -> ScholarshipProgramResponse.from(
+                        spp,
+                        commentCountMap.getOrDefault(spp.getPost().getPostId(), 0L),
+                        thumbnailMap.get(spp.getPost().getPostId())
+                ))
+                .collect(Collectors.toList());
+
+        List<ScholarshipProgramResponse> optionalResponses = optionalPrograms.stream()
+                .map(spp -> ScholarshipProgramResponse.from(
+                        spp,
+                        commentCountMap.getOrDefault(spp.getPost().getPostId(), 0L),
+                        thumbnailMap.get(spp.getPost().getPostId())
+                ))
+                .collect(Collectors.toList());
+
+        log.info("장학 프로그램 목록 조회 완료 - required: {}, optional: {}",
+                requiredResponses.size(), optionalResponses.size());
+
+        return ScholarshipProgramListResponse.builder()
+                .required(requiredResponses)
+                .optional(optionalResponses)
+                .build();
+    }
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/scholarshipprogrampost/service/ScholarshipProgramService.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/scholarshipprogrampost/service/ScholarshipProgramService.java
@@ -55,6 +55,15 @@ public class ScholarshipProgramService {
                 optionalPrograms.stream().map(spp -> spp.getPost().getPostId())
         ).collect(Collectors.toList());
 
+        // Early return
+        if (allPostIds.isEmpty()) {
+            log.info("장학 프로그램 데이터 없음 - 빈 응답 반환");
+            return ScholarshipProgramListResponse.builder()
+                    .required(List.of())
+                    .optional(List.of())
+                    .build();
+        }
+
         Map<Long, Long> commentCountMap = commentRepository.countByPostIds(allPostIds).stream()
                 .collect(Collectors.toMap(
                         PostCommentCount::getPostId,

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/scholarshipprogrampost/service/ScholarshipProgramService.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/scholarshipprogrampost/service/ScholarshipProgramService.java
@@ -35,9 +35,7 @@ public class ScholarshipProgramService {
     @Value("${cloud.aws.region.static}")
     private String region;
 
-    /**
-     * 장학 프로그램 목록 조회 (필수/선택 분리)
-     */
+    // 장학 프로그램 목록 조회 (필수/선택 분리)
     public ScholarshipProgramListResponse getScholarshipPrograms() {
         log.info("장학 프로그램 목록 조회 시작");
 


### PR DESCRIPTION
## 🔍 개요
장학 프로그램 파트를 기존 게시판 시스템에 통합했습니다.

기존에 독립 테이블로 구성하려던 장학 프로그램을
`post` 기반 게시판 구조로 편입하고,
boardId=5(장학 프로그램)를 기준으로 조회/댓글/좋아요 기능을 재사용합니다.

## ✨ 변경 사항
- 게시판 구조 확장
- 장학 프로그램 전용 테이블 추가
- 게시글 카테고리 확장
- 전용 목록 조회 API 구현

## 🧪 테스트
- [x] 로컬 테스트 완료
- [ ] API 테스트 완료
- [ ] 테스트 코드 작성 (해당 시)

## 📎 관련 이슈
Closes: #96 

## ⚠️ 참고 사항
- 기존 게시판 구조 및 API와의 호환성을 유지합니다.
-  장학 프로그램은 게시판 시스템에 통합되어 관리됩니다.
- 필수/선택 분리는 PostCategory 값을 기준으로 처리합니다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 장학 프로그램 목록 조회 API 추가
  * 프로그램을 "필수 프로그램"과 "선택 프로그램"으로 분류하여 제공
  * 각 프로그램에 제목, 최대 100자 미리보기, 조회수, 댓글 수, 썸네일 URL 포함
  * 빈 목록 처리 및 썸네일/댓글 수 집계 최적화로 응답 일관성 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->