### PR TITLE
feat: 마이페이지 조회 API 구현 (프로필/활동 대시보드/지난 활동)

### DIFF
--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/councilreview/repository/CouncilReviewParticipantRepository.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/councilreview/repository/CouncilReviewParticipantRepository.java
@@ -72,4 +72,13 @@ public interface CouncilReviewParticipantRepository extends JpaRepository<Counci
                         row -> (Long) row[1]
                 ));
     }
+
+    // 특정 사용자가 참여한 활동 후기 목록 조회 (최신순, 삭제되지 않은 것만)
+    @Query("SELECT crp FROM CouncilReviewParticipant crp " +
+            "JOIN FETCH crp.councilReviewPost post " +
+            "JOIN FETCH post.post p " +
+            "WHERE crp.user.userId = :userId " +
+            "AND post.deletedAt IS NULL " +
+            "ORDER BY post.createdAt DESC")
+    List<CouncilReviewParticipant> findByUserIdWithPostOrderByCreatedAtDesc(@Param("userId") Long userId);
 }

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/file/entity/AttachmentPurpose.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/file/entity/AttachmentPurpose.java
@@ -1,10 +1,9 @@
 package com.solif.backend.domain.file.entity;
 
 public enum AttachmentPurpose {
-    PROFILE_IMAGE,            // 프로필 이미지
-    PINECONE_MEMORY_IMAGE,    // 솔방울 추억 이미지
     POST_ATTACHMENT,          // 게시글 첨부 이미지
     RECEIPT,                  // 영수증 (OCR용)
+    PINECONE_MEMORY_IMAGE,    // 솔방울 추억 이미지
     MESSAGE_ATTACHMENT,       // 쪽지
     MENTORING_CARD_ATTACHMENT // 멘토링 엽서 첨부파일
 }

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/file/entity/FileTargetType.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/file/entity/FileTargetType.java
@@ -3,7 +3,6 @@ package com.solif.backend.domain.file.entity;
 public enum FileTargetType {
     POST,              // 통합 게시글
     COUNCIL_POST,      // 자치회 활동 후기
-    USER_PROFILE,
     PINECONE_MEMORY,
     MESSAGE,           // 쪽지 첨부파일
     MENTORING_CARD     // 멘토링 엽서 첨부파일

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/mypage/code/MyPageErrorCode.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/mypage/code/MyPageErrorCode.java
@@ -1,0 +1,17 @@
+package com.solif.backend.domain.mypage.code;
+
+import com.solif.backend.global.common.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum MyPageErrorCode implements ErrorCode {
+
+    PROFILE_NOT_FOUND(HttpStatus.NOT_FOUND, "MYPAGE_404_1", "프로필 정보를 찾을 수 없습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/mypage/code/MyPageSuccessCode.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/mypage/code/MyPageSuccessCode.java
@@ -1,0 +1,17 @@
+package com.solif.backend.domain.mypage.code;
+
+import com.solif.backend.global.common.response.SuccessCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum MyPageSuccessCode implements SuccessCode {
+
+    MYPAGE_READ_SUCCESS(HttpStatus.OK, "MYPAGE_200", "마이페이지 조회 성공");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/mypage/controller/MyPageController.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/mypage/controller/MyPageController.java
@@ -1,0 +1,39 @@
+package com.solif.backend.domain.mypage.controller;
+
+import com.solif.backend.domain.mypage.code.MyPageSuccessCode;
+import com.solif.backend.domain.mypage.dto.MyPageResponse;
+import com.solif.backend.domain.mypage.service.MyPageService;
+import com.solif.backend.global.common.response.ResponseFactory;
+import com.solif.backend.global.common.response.SuccessResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "마이페이지 API", description = "마이페이지 조회 API")
+@RestController
+@RequestMapping("/api/v1/mypage")
+@RequiredArgsConstructor
+public class MyPageController {
+
+    private final MyPageService myPageService;
+
+    @Operation(
+            summary = "마이페이지 조회",
+            description = "사용자의 이름, SOLID 목표, 활동 대시보드(점수/타입), 나의 지난 활동(자치회 활동 후기 최신 3개)을 조회합니다.",
+            security = @SecurityRequirement(name = "Bearer Authentication")
+    )
+    @GetMapping
+    public ResponseEntity<SuccessResponse<MyPageResponse>> getMyPage(
+            @Parameter(hidden = true) @AuthenticationPrincipal Long userId
+    ) {
+        MyPageResponse response = myPageService.getMyPage(userId);
+        return ResponseFactory.success(MyPageSuccessCode.MYPAGE_READ_SUCCESS, response);
+    }
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/mypage/dto/MyPageResponse.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/mypage/dto/MyPageResponse.java
@@ -63,6 +63,9 @@ public class MyPageResponse {
         @Schema(description = "활동 날짜", example = "2026-02-10")
         private LocalDate activityDate;
 
+        @Schema(description = "썸네일 이미지 URL (첫 번째 이미지)", example = "https://...")
+        private String thumbnailImageUrl;
+
         @Schema(description = "작성 시간", example = "2026-02-10T15:30:00")
         private LocalDateTime createdAt;
     }

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/mypage/dto/MyPageResponse.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/mypage/dto/MyPageResponse.java
@@ -1,0 +1,83 @@
+package com.solif.backend.domain.mypage.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+@Schema(description = "마이페이지 응답")
+public class MyPageResponse {
+
+    @Schema(description = "사용자 이름", example = "김솔잎")
+    private String name;
+
+    @Schema(description = "SOLID 목표명", example = "한재대 27학번으로 입학하기")
+    private String solidGoalName;
+
+    @Schema(description = "활동 대시보드")
+    private Dashboard dashboard;
+
+    @Schema(description = "나의 지난 활동 (자치회 활동 후기 최신순 3개)")
+    private List<RecentCouncilReview> recentCouncilReviews;
+
+    @Getter
+    @Builder
+    @Schema(description = "활동 대시보드")
+    public static class Dashboard {
+
+        @Schema(description = "연결 점수 (0-30)", example = "30")
+        private Integer connection;
+
+        @Schema(description = "성장 점수 (0-30)", example = "20")
+        private Integer growth;
+
+        @Schema(description = "기여 점수 (0-30)", example = "10")
+        private Integer contribution;
+
+        @Schema(description = "전체 점수 (0-90)", example = "60")
+        private Integer total;
+
+        @Schema(description = "페르소나 타입명", example = "마당발 네트워커")
+        private String personaType;
+    }
+
+    @Getter
+    @Builder
+    @Schema(description = "나의 지난 활동 (자치회 활동 후기)")
+    public static class RecentCouncilReview {
+
+        @Schema(description = "자치회 활동 후기 게시글 ID", example = "1")
+        private Long councilReviewPostId;
+
+        @Schema(description = "통합 게시글 ID", example = "100")
+        private Long postId;
+
+        @Schema(description = "게시글 제목", example = "우리들의 첫 만남")
+        private String title;
+
+        @Schema(description = "활동 날짜", example = "2026-02-10")
+        private LocalDate activityDate;
+
+        @Schema(description = "작성 시간", example = "2026-02-10T15:30:00")
+        private LocalDateTime createdAt;
+    }
+
+    public static MyPageResponse of(
+            String name,
+            String solidGoalName,
+            Dashboard dashboard,
+            List<RecentCouncilReview> recentCouncilReviews
+    ) {
+        return MyPageResponse.builder()
+                .name(name)
+                .solidGoalName(solidGoalName)
+                .dashboard(dashboard)
+                .recentCouncilReviews(recentCouncilReviews)
+                .build();
+    }
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/mypage/service/MyPageService.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/mypage/service/MyPageService.java
@@ -3,6 +3,10 @@ package com.solif.backend.domain.mypage.service;
 import com.solif.backend.domain.auth.code.AuthErrorCode;
 import com.solif.backend.domain.councilreview.entity.CouncilReviewParticipant;
 import com.solif.backend.domain.councilreview.repository.CouncilReviewParticipantRepository;
+import com.solif.backend.domain.file.entity.AttachmentPurpose;
+import com.solif.backend.domain.file.entity.FileAttachment;
+import com.solif.backend.domain.file.entity.FileTargetType;
+import com.solif.backend.domain.file.repository.FileAttachmentRepository;
 import com.solif.backend.domain.mission.entity.MissionCategory;
 import com.solif.backend.domain.mission.entity.MissionStatus;
 import com.solif.backend.domain.mission.repository.UserMissionRepository;
@@ -15,10 +19,12 @@ import com.solif.backend.domain.user.repository.UserRepository;
 import com.solif.backend.global.common.exception.CustomException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -31,6 +37,10 @@ public class MyPageService {
     private final UserProfileRepository userProfileRepository;
     private final UserMissionRepository userMissionRepository;
     private final CouncilReviewParticipantRepository councilReviewParticipantRepository;
+    private final FileAttachmentRepository fileAttachmentRepository;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
 
     // 마이페이지 조회
     public MyPageResponse getMyPage(Long userId) {
@@ -122,17 +132,52 @@ public class MyPageService {
         List<CouncilReviewParticipant> participants =
                 councilReviewParticipantRepository.findByUserIdWithPostOrderByCreatedAtDesc(userId);
 
+        // 빈 결과 처리
+        if (participants.isEmpty()) {
+            return List.of();
+        }
+
         // 최신순 3개만 가져오기
-        return participants.stream()
+        List<CouncilReviewParticipant> topThree = participants.stream()
                 .limit(3)
-                .map(participant -> MyPageResponse.RecentCouncilReview.builder()
-                        .councilReviewPostId(participant.getCouncilReviewPost().getCouncilReviewPostId())
-                        .postId(participant.getCouncilReviewPost().getPost().getPostId())
-                        .title(participant.getCouncilReviewPost().getPost().getPostTitle())
-                        .activityDate(participant.getCouncilReviewPost().getActivityDate())
-                        .createdAt(participant.getCouncilReviewPost().getCreatedAt())
-                        .build()
-                )
+                .toList();
+
+        // Post ID 목록 추출
+        List<Long> postIds = topThree.stream()
+                .map(p -> p.getCouncilReviewPost().getPost().getPostId())
+                .toList();
+
+        // 썸네일 이미지 배치 조회 (sortOrder=1, purpose=POST_ATTACHMENT)
+        List<FileAttachment> thumbnails = fileAttachmentRepository
+                .findByFileTargetTypeAndTargetIdInAndSortOrderAndPurpose(
+                        FileTargetType.POST,
+                        postIds,
+                        1,
+                        AttachmentPurpose.POST_ATTACHMENT
+                );
+
+        // postId -> thumbnailUrl 맵 생성
+        Map<Long, String> thumbnailMap = thumbnails.stream()
+                .collect(Collectors.toMap(
+                        FileAttachment::getTargetId,
+                        fa -> fa.getFile().getUrl(region)
+                ));
+
+        // Response 구성
+        return topThree.stream()
+                .map(participant -> {
+                    Long postId = participant.getCouncilReviewPost().getPost().getPostId();
+                    String thumbnailUrl = thumbnailMap.get(postId);
+
+                    return MyPageResponse.RecentCouncilReview.builder()
+                            .councilReviewPostId(participant.getCouncilReviewPost().getCouncilReviewPostId())
+                            .postId(postId)
+                            .title(participant.getCouncilReviewPost().getPost().getPostTitle())
+                            .activityDate(participant.getCouncilReviewPost().getActivityDate())
+                            .thumbnailImageUrl(thumbnailUrl)
+                            .createdAt(participant.getCouncilReviewPost().getCreatedAt())
+                            .build();
+                })
                 .collect(Collectors.toList());
     }
 

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/mypage/service/MyPageService.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/mypage/service/MyPageService.java
@@ -160,7 +160,8 @@ public class MyPageService {
         Map<Long, String> thumbnailMap = thumbnails.stream()
                 .collect(Collectors.toMap(
                         FileAttachment::getTargetId,
-                        fa -> fa.getFile().getUrl(region)
+                        fa -> fa.getFile().getUrl(region),
+                        (existing, replacement) -> existing  // 중복 키 발생 시 첫 번째 값 유지
                 ));
 
         // Response 구성

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/mypage/service/MyPageService.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/mypage/service/MyPageService.java
@@ -127,7 +127,7 @@ public class MyPageService {
         return "푸른SOL 새싹";
     }
 
-    // 나의 지난 활동 (자치회 활동 후기 최신순 3개)
+    // ===== 나의 지난 활동 (자치회 활동 후기 최신순 3개) =====
     private List<MyPageResponse.RecentCouncilReview> getRecentCouncilReviews(Long userId) {
         List<CouncilReviewParticipant> participants =
                 councilReviewParticipantRepository.findByUserIdWithPostOrderByCreatedAtDesc(userId);
@@ -142,21 +142,21 @@ public class MyPageService {
                 .limit(3)
                 .toList();
 
-        // Post ID 목록 추출
-        List<Long> postIds = topThree.stream()
-                .map(p -> p.getCouncilReviewPost().getPost().getPostId())
+        // CouncilReviewPost ID 목록 추출
+        List<Long> councilReviewPostIds = topThree.stream()
+                .map(p -> p.getCouncilReviewPost().getCouncilReviewPostId())
                 .toList();
 
         // 썸네일 이미지 배치 조회 (sortOrder=1, purpose=POST_ATTACHMENT)
         List<FileAttachment> thumbnails = fileAttachmentRepository
                 .findByFileTargetTypeAndTargetIdInAndSortOrderAndPurpose(
-                        FileTargetType.POST,
-                        postIds,
+                        FileTargetType.COUNCIL_POST,  // ← 이 부분 수정!
+                        councilReviewPostIds,  // ← postId가 아니라 councilReviewPostId
                         1,
                         AttachmentPurpose.POST_ATTACHMENT
                 );
 
-        // postId -> thumbnailUrl 맵 생성
+        // councilReviewPostId -> thumbnailUrl 맵 생성
         Map<Long, String> thumbnailMap = thumbnails.stream()
                 .collect(Collectors.toMap(
                         FileAttachment::getTargetId,
@@ -166,19 +166,19 @@ public class MyPageService {
         // Response 구성
         return topThree.stream()
                 .map(participant -> {
-                    Long postId = participant.getCouncilReviewPost().getPost().getPostId();
-                    String thumbnailUrl = thumbnailMap.get(postId);
+                    Long councilReviewPostId = participant.getCouncilReviewPost().getCouncilReviewPostId();
+                    String thumbnailUrl = thumbnailMap.get(councilReviewPostId);
 
                     return MyPageResponse.RecentCouncilReview.builder()
-                            .councilReviewPostId(participant.getCouncilReviewPost().getCouncilReviewPostId())
-                            .postId(postId)
+                            .councilReviewPostId(councilReviewPostId)
+                            .postId(participant.getCouncilReviewPost().getPost().getPostId())
                             .title(participant.getCouncilReviewPost().getPost().getPostTitle())
                             .activityDate(participant.getCouncilReviewPost().getActivityDate())
                             .thumbnailImageUrl(thumbnailUrl)
                             .createdAt(participant.getCouncilReviewPost().getCreatedAt())
                             .build();
                 })
-                .collect(Collectors.toList());
+                .toList();
     }
 
     // ===== Helper Methods =====

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/mypage/service/MyPageService.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/mypage/service/MyPageService.java
@@ -1,0 +1,144 @@
+package com.solif.backend.domain.mypage.service;
+
+import com.solif.backend.domain.auth.code.AuthErrorCode;
+import com.solif.backend.domain.councilreview.entity.CouncilReviewParticipant;
+import com.solif.backend.domain.councilreview.repository.CouncilReviewParticipantRepository;
+import com.solif.backend.domain.mission.entity.MissionCategory;
+import com.solif.backend.domain.mission.entity.MissionStatus;
+import com.solif.backend.domain.mission.repository.UserMissionRepository;
+import com.solif.backend.domain.mypage.code.MyPageErrorCode;
+import com.solif.backend.domain.mypage.dto.MyPageResponse;
+import com.solif.backend.domain.profile.entity.UserProfile;
+import com.solif.backend.domain.profile.repository.UserProfileRepository;
+import com.solif.backend.domain.user.entity.User;
+import com.solif.backend.domain.user.repository.UserRepository;
+import com.solif.backend.global.common.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MyPageService {
+
+    private final UserRepository userRepository;
+    private final UserProfileRepository userProfileRepository;
+    private final UserMissionRepository userMissionRepository;
+    private final CouncilReviewParticipantRepository councilReviewParticipantRepository;
+
+    // 마이페이지 조회
+    public MyPageResponse getMyPage(Long userId) {
+        // 사용자 조회
+        User user = findUserById(userId);
+
+        // 프로필 조회
+        UserProfile profile = userProfileRepository.findByUser_UserId(userId)
+                .orElseThrow(() -> new CustomException(MyPageErrorCode.PROFILE_NOT_FOUND));
+
+        // 활동 대시보드 구성
+        MyPageResponse.Dashboard dashboard = buildDashboard(user);
+
+        // 나의 지난 활동 (자치회 활동 후기 최신순 3개)
+        List<MyPageResponse.RecentCouncilReview> recentReviews = getRecentCouncilReviews(userId);
+
+        return MyPageResponse.of(
+                user.getName(),
+                profile.getSolidGoalName(),
+                dashboard,
+                recentReviews
+        );
+    }
+
+    // ===== 활동 대시보드 구성 =====
+    private MyPageResponse.Dashboard buildDashboard(User user) {
+        // 카테고리별 완료된 미션 개수 조회
+        Long connectCount = userMissionRepository.countByUserAndCategoryAndStatus(
+                user, MissionCategory.CONNECT, MissionStatus.COMPLETED
+        );
+        Long growCount = userMissionRepository.countByUserAndCategoryAndStatus(
+                user, MissionCategory.GROW, MissionStatus.COMPLETED
+        );
+        Long impactCount = userMissionRepository.countByUserAndCategoryAndStatus(
+                user, MissionCategory.IMPACT, MissionStatus.COMPLETED
+        );
+
+        // 점수 계산 (미션 1개 완료 = 10점)
+        int connectionScore = connectCount.intValue() * 10;
+        int growthScore = growCount.intValue() * 10;
+        int contributionScore = impactCount.intValue() * 10;
+        int totalScore = connectionScore + growthScore + contributionScore;
+
+        // 페르소나 타입 결정
+        String personaType = determinePersonaType(connectionScore, growthScore, contributionScore, totalScore);
+
+        return MyPageResponse.Dashboard.builder()
+                .connection(connectionScore)
+                .growth(growthScore)
+                .contribution(contributionScore)
+                .total(totalScore)
+                .personaType(personaType)
+                .build();
+    }
+
+    // 페르소나 타입 결정 로직
+    private String determinePersonaType(int connection, int growth, int contribution, int total) {
+        // 1순위: 전체 90점 만점
+        if (total == 90) {
+            return "푸른SOL 마스터";
+        }
+
+        // 2순위: 2개 영역 동점 (20점 이상)
+        int maxScore = Math.max(connection, Math.max(growth, contribution));
+        long countMax = 0;
+        if (connection == maxScore) countMax++;
+        if (growth == maxScore) countMax++;
+        if (contribution == maxScore) countMax++;
+
+        if (countMax >= 2 && maxScore >= 20) {
+            return "밸런스형 리더";
+        }
+
+        // 3순위: 단일 영역 최고점
+        if (connection > growth && connection > contribution) {
+            return "마당발 네트워커";
+        } else if (growth > connection && growth > contribution) {
+            return "탐구하는 학구파";
+        } else if (contribution > connection && contribution > growth) {
+            return "세상을 바꾸는 행동대장";
+        }
+
+        // 기본값 (모두 0점이거나 동점인 경우)
+        return "푸른SOL 새싹";
+    }
+
+    // 나의 지난 활동 (자치회 활동 후기 최신순 3개)
+    private List<MyPageResponse.RecentCouncilReview> getRecentCouncilReviews(Long userId) {
+        List<CouncilReviewParticipant> participants =
+                councilReviewParticipantRepository.findByUserIdWithPostOrderByCreatedAtDesc(userId);
+
+        // 최신순 3개만 가져오기
+        return participants.stream()
+                .limit(3)
+                .map(participant -> MyPageResponse.RecentCouncilReview.builder()
+                        .councilReviewPostId(participant.getCouncilReviewPost().getCouncilReviewPostId())
+                        .postId(participant.getCouncilReviewPost().getPost().getPostId())
+                        .title(participant.getCouncilReviewPost().getPost().getPostTitle())
+                        .activityDate(participant.getCouncilReviewPost().getActivityDate())
+                        .createdAt(participant.getCouncilReviewPost().getCreatedAt())
+                        .build()
+                )
+                .collect(Collectors.toList());
+    }
+
+    // ===== Helper Methods =====
+    private User findUserById(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(AuthErrorCode.USER_NOT_FOUND));
+    }
+}


### PR DESCRIPTION
## 🔍 개요
마이페이지 화면 구성을 위한 조회 API를 구현했습니다.

본 PR에서는 사용자 프로필 정보, 활동 대시보드(점수/타입명),
그리고 사용자의 최근 자치회 활동 후기를 한 번에 조회할 수 있도록
`GET /api/v1/mypage` API를 제공합니다.

## ✨ 변경 사항
### 1️⃣ 마이페이지 조회 API 구현
### 2️⃣ 상단 프로필 영역
### 3️⃣ 활동 대시보드 구현
### 4️⃣ 나의 지난 활동 조회

## 🧪 테스트
- [x] 로컬 테스트 완료
- [ ] API 테스트 완료
- [ ] 테스트 코드 작성 (해당 시)

## 📎 관련 이슈
Closes: #99 

## ⚠️ 참고 사항
- 조회 전용 API로 기존 데이터 구조 변경은 없습니다.
- 기존 API와의 의존성은 유지하며, 마이페이지 화면 요구사항에 맞춰 집계 로직만 추가했습니다.
- 상/하반기 점수 초기화 정책은 미션 초기화 로직과 연계 전제로 구현했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 마이페이지 API 추가 — 사용자 이름, 목표명, 대시보드 통계(연결/성장/기여도/총점) 및 최근 참여한 협의회 리뷰(썸네일 포함) 조회 가능
  * 페르소나 판정 로직 도입 — 활동 점수 기반으로 페르소나 유형 표시

* **버그 수정을 위한 개선**
  * 프로필 정보 미존재 시 명확한 404 오류 처리 및 성공/오류 응답 표준화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->