### PR TITLE
feat: 성장-미션 Phase 2 자동 연동 구현

### DIFF
--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/comment/service/CommentService.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/comment/service/CommentService.java
@@ -10,6 +10,8 @@ import com.solif.backend.domain.comment.repository.CommentRepository;
 import com.solif.backend.domain.council.repository.CouncilMemberRepository;
 import com.solif.backend.domain.councilreview.entity.CouncilReviewPost;
 import com.solif.backend.domain.councilreview.repository.CouncilReviewPostRepository;
+import com.solif.backend.domain.mission.entity.MissionConditionType;
+import com.solif.backend.domain.mission.service.MissionService;
 import com.solif.backend.domain.notification.entity.NotificationType;
 import com.solif.backend.domain.notification.entity.NotificationTargetType;
 import com.solif.backend.domain.notification.event.NotificationEvent;
@@ -39,6 +41,7 @@ public class CommentService {
     private final ApplicationEventPublisher eventPublisher;
     private final CouncilMemberRepository councilMemberRepository;
     private final CouncilReviewPostRepository councilReviewPostRepository;
+    private final MissionService missionService;
 
     // 댓글 목록 조회
     public List<CommentResponse> getComments(Long postId) {
@@ -89,6 +92,11 @@ public class CommentService {
 
         // 저장
         Comment savedComment = commentRepository.save(comment);
+
+        // 미션 체크: 타인의 게시글에 댓글 작성 (post_id를 sourceId로 전달)
+        if (!post.getAuthor().getUserId().equals(userId)) {
+            missionService.checkAndCompleteMission(userId, MissionConditionType.COMMENT_CREATE, postId);
+        }
 
         // 알림 발송
         publishCommentNotification(userId, post, savedComment);

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/comment/service/CommentService.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/comment/service/CommentService.java
@@ -11,7 +11,7 @@ import com.solif.backend.domain.council.repository.CouncilMemberRepository;
 import com.solif.backend.domain.councilreview.entity.CouncilReviewPost;
 import com.solif.backend.domain.councilreview.repository.CouncilReviewPostRepository;
 import com.solif.backend.domain.mission.entity.MissionConditionType;
-import com.solif.backend.domain.mission.service.MissionService;
+import com.solif.backend.domain.mission.event.MissionEvent;
 import com.solif.backend.domain.notification.entity.NotificationType;
 import com.solif.backend.domain.notification.entity.NotificationTargetType;
 import com.solif.backend.domain.notification.event.NotificationEvent;
@@ -41,7 +41,6 @@ public class CommentService {
     private final ApplicationEventPublisher eventPublisher;
     private final CouncilMemberRepository councilMemberRepository;
     private final CouncilReviewPostRepository councilReviewPostRepository;
-    private final MissionService missionService;
 
     // 댓글 목록 조회
     public List<CommentResponse> getComments(Long postId) {
@@ -93,9 +92,13 @@ public class CommentService {
         // 저장
         Comment savedComment = commentRepository.save(comment);
 
-        // 미션 체크: 타인의 게시글에 댓글 작성 (post_id를 sourceId로 전달)
+        // 미션 체크: 타인의 게시글에 댓글 작성 (트랜잭션 커밋 후 비동기 처리)
         if (!post.getAuthor().getUserId().equals(userId)) {
-            missionService.checkAndCompleteMission(userId, MissionConditionType.COMMENT_CREATE, postId);
+            eventPublisher.publishEvent(new MissionEvent(
+                    userId,
+                    MissionConditionType.COMMENT_CREATE,
+                    postId
+            ));
         }
 
         // 알림 발송

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/message/service/MessageService.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/message/service/MessageService.java
@@ -73,8 +73,11 @@ public class MessageService {
 
         Message savedMessage = messageRepository.save(message);
 
-        // 미션 - 첫 쪽지 발송 (message_id를 sourceId로 전달)
+        // 미션 체크: 미션 #3 (첫 쪽지 발송)
         missionService.checkAndCompleteMission(senderId, MissionConditionType.MESSAGE, savedMessage.getMessageId());
+
+        // 미션 체크: 미션 #5 (경험나누기 → 쪽지 소통)
+        missionService.checkAndCompleteMission(senderId, MissionConditionType.MESSAGE_THREAD, savedMessage.getMessageId());
 
         // 파일 확정 (fileIds가 있으면)
         if (request.getFileIds() != null && !request.getFileIds().isEmpty()) {

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/message/service/MessageService.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/message/service/MessageService.java
@@ -5,6 +5,8 @@ import com.solif.backend.domain.file.entity.FileAttachment;
 import com.solif.backend.domain.file.entity.FileTargetType;
 import com.solif.backend.domain.file.repository.FileAttachmentRepository;
 import com.solif.backend.domain.file.service.FileService;
+import com.solif.backend.domain.mission.entity.MissionConditionType;
+import com.solif.backend.domain.mission.service.MissionService;
 import com.solif.backend.domain.notification.entity.NotificationType;
 import com.solif.backend.domain.notification.entity.TargetType;
 import com.solif.backend.domain.notification.event.NotificationEvent;
@@ -38,6 +40,7 @@ public class MessageService {
     private final ApplicationEventPublisher eventPublisher;
     private final FileService fileService;
     private final FileAttachmentRepository fileAttachmentRepository;
+    private final MissionService missionService;
 
     @Value("${cloud.aws.region.static}")
     private String region;
@@ -69,6 +72,9 @@ public class MessageService {
                 .build();
 
         Message savedMessage = messageRepository.save(message);
+
+        // 미션 - 첫 쪽지 발송 (message_id를 sourceId로 전달)
+        missionService.checkAndCompleteMission(senderId, MissionConditionType.MESSAGE, savedMessage.getMessageId());
 
         // 파일 확정 (fileIds가 있으면)
         if (request.getFileIds() != null && !request.getFileIds().isEmpty()) {

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/message/service/MessageService.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/message/service/MessageService.java
@@ -6,7 +6,7 @@ import com.solif.backend.domain.file.entity.FileTargetType;
 import com.solif.backend.domain.file.repository.FileAttachmentRepository;
 import com.solif.backend.domain.file.service.FileService;
 import com.solif.backend.domain.mission.entity.MissionConditionType;
-import com.solif.backend.domain.mission.service.MissionService;
+import com.solif.backend.domain.mission.event.MissionEvent;
 import com.solif.backend.domain.notification.entity.NotificationType;
 import com.solif.backend.domain.notification.entity.NotificationTargetType;
 import com.solif.backend.domain.notification.event.NotificationEvent;
@@ -45,7 +45,6 @@ public class MessageService {
     private final FileService fileService;
     private final FileAttachmentRepository fileAttachmentRepository;
     private final UserProfileRepository userProfileRepository;
-    private final MissionService missionService;
 
     @Value("${cloud.aws.s3.bucket}")
     private String bucket;
@@ -117,11 +116,19 @@ public class MessageService {
 
         Message savedMessage = messageRepository.save(message);
 
-        // 미션 체크: 미션 #3 (첫 쪽지 발송)
-        missionService.checkAndCompleteMission(senderId, MissionConditionType.MESSAGE, savedMessage.getMessageId());
+        // 미션 체크: 미션 #3 (첫 쪽지 발송) (트랜잭션 커밋 후 비동기 처리)
+        eventPublisher.publishEvent(new MissionEvent(
+                senderId,
+                MissionConditionType.MESSAGE,
+                savedMessage.getMessageId()
+        ));
 
-        // 미션 체크: 미션 #5 (경험나누기 → 쪽지 소통)
-        missionService.checkAndCompleteMission(senderId, MissionConditionType.MESSAGE_THREAD, savedMessage.getMessageId());
+        // 미션 체크: 미션 #5 (경험나누기 → 쪽지 소통) (트랜잭션 커밋 후 비동기 처리)
+        eventPublisher.publishEvent(new MissionEvent(
+                senderId,
+                MissionConditionType.MESSAGE_THREAD,
+                savedMessage.getMessageId()
+        ));
 
         // 파일 확정 (fileIds가 있으면)
         if (request.getFileIds() != null && !request.getFileIds().isEmpty()) {

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/mission/dto/MissionProgressResponse.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/mission/dto/MissionProgressResponse.java
@@ -28,6 +28,9 @@ public class MissionProgressResponse {
     @Schema(description = "이번주 미션 리스트 (최대 3개)")
     private List<WeeklyMissionCard> weeklyMissions;
 
+    @Schema(description = "장학 프로그램 최신 3개")
+    private List<ScholarshipProgramCard> scholarshipPrograms;
+
     @Getter
     @Builder
     @Schema(description = "카테고리별 솔방울 획득 상태")
@@ -84,5 +87,28 @@ public class MissionProgressResponse {
 
         @Schema(description = "완료 여부")
         private Boolean isCompleted;
+    }
+
+    @Getter
+    @Builder
+    @Schema(description = "장학 프로그램 카드")
+    public static class ScholarshipProgramCard {
+        @Schema(description = "게시글 ID")
+        private Long postId;
+
+        @Schema(description = "카테고리 (REQUIRED/OPTIONAL)")
+        private String category;
+
+        @Schema(description = "카테고리명 (필수 프로그램/선택 프로그램)")
+        private String categoryName;
+
+        @Schema(description = "프로그램 제목")
+        private String title;
+
+        @Schema(description = "썸네일 이미지 URL")
+        private String thumbnailUrl;
+
+        @Schema(description = "작성 일시")
+        private String createdAt;
     }
 }

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/mission/dto/PineconeMemoryResponse.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/mission/dto/PineconeMemoryResponse.java
@@ -45,6 +45,9 @@ public class PineconeMemoryResponse {
         @Schema(description = "추억 타입 (MESSAGE/POST/COMMENT/MENTORING)")
         private String memoryType;
 
+        @Schema(description = "추억 ID (messageId 또는 postId)")
+        private Long sourceId;
+
         @Schema(description = "추억 제목/내용")
         private String memoryContent;
 

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/mission/event/MissionEvent.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/mission/event/MissionEvent.java
@@ -1,0 +1,15 @@
+package com.solif.backend.domain.mission.event;
+
+import com.solif.backend.domain.mission.entity.MissionConditionType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+// 미션 체크 이벤트 : 트랜잭션 커밋 이후에 리스너가 수신하여 미션을 체크/완료 처리합니다.
+@Getter
+@AllArgsConstructor
+public class MissionEvent {
+
+    private final Long userId;
+    private final MissionConditionType conditionType;
+    private final Long sourceId;
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/mission/event/MissionEventListener.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/mission/event/MissionEventListener.java
@@ -35,8 +35,8 @@ public class MissionEventListener {
                 );
             }
         } catch (Exception e) {
-            log.warn("미션 체크 실패 - userId: {}, conditionType: {}, sourceId: {}, error: {}",
-                    event.getUserId(), event.getConditionType(), event.getSourceId(), e.getMessage());
+            log.warn("미션 체크 실패 - userId: {}, conditionType: {}, sourceId: {}",
+                    +event.getUserId(), event.getConditionType(), event.getSourceId(), e);
         }
     }
 }

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/mission/event/MissionEventListener.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/mission/event/MissionEventListener.java
@@ -1,0 +1,42 @@
+package com.solif.backend.domain.mission.event;
+
+import com.solif.backend.domain.mission.entity.MissionConditionType;
+import com.solif.backend.domain.mission.service.MissionService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+// 미션 이벤트 리스너 : 트랜잭션 커밋 후 미션 체크 로직을 실행합니다.
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class MissionEventListener {
+
+    private final MissionService missionService;
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleMissionEvent(MissionEvent event) {
+        log.info(">>> 미션 이벤트 수신됨 - userId: {}, conditionType: {}, sourceId: {}",
+                event.getUserId(), event.getConditionType(), event.getSourceId());
+        try {
+            // POST_VIEW는 incrementMissionProgress 사용
+            if (event.getConditionType() == MissionConditionType.POST_VIEW) {
+                missionService.incrementMissionProgress(event.getUserId(), event.getConditionType());
+            } else {
+                // 나머지는 checkAndCompleteMission 사용
+                missionService.checkAndCompleteMission(
+                        event.getUserId(),
+                        event.getConditionType(),
+                        event.getSourceId()
+                );
+            }
+        } catch (Exception e) {
+            log.warn("미션 체크 실패 - userId: {}, conditionType: {}, sourceId: {}, error: {}",
+                    event.getUserId(), event.getConditionType(), event.getSourceId(), e.getMessage());
+        }
+    }
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/mission/event/MissionEventListener.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/mission/event/MissionEventListener.java
@@ -36,7 +36,7 @@ public class MissionEventListener {
             }
         } catch (Exception e) {
             log.warn("미션 체크 실패 - userId: {}, conditionType: {}, sourceId: {}",
-                    +event.getUserId(), event.getConditionType(), event.getSourceId(), e);
+                    event.getUserId(), event.getConditionType(), event.getSourceId(), e);
         }
     }
 }

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/mission/service/MissionService.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/mission/service/MissionService.java
@@ -146,26 +146,51 @@ public class MissionService {
                 user, category, currentSeason
         ).orElseThrow(() -> new CustomException(MissionErrorCode.PINECONE_NOT_FOUND));
 
+        // 완료된 미션 3개 조회 (UserMission 기준 - sequenceOrder 순)
+        List<UserMission> completedUserMissions = userMissionRepository
+                .findByUserAndMission_MissionCategory(user, category)
+                .stream()
+                .filter(UserMission::isCompleted)
+                .sorted((um1, um2) -> Integer.compare(
+                        um1.getMission().getSequenceOrder(),
+                        um2.getMission().getSequenceOrder()
+                ))
+                .limit(3)
+                .toList();
+
         // 추억 조회
         List<PineconeMemory> memories = pineconeMemoryRepository.findByUserPineconeOrderByCreatedAtAsc(pinecone);
+
+        // conditionType 기준으로 Map 생성 (빠른 조회용)
+        Map<MissionConditionType, PineconeMemory> memoryMap = memories.stream()
+                .collect(Collectors.toMap(PineconeMemory::getConditionType, m -> m, (m1, m2) -> m1));
 
         // 완료한 미션 3개 구성
         List<PineconeMemoryResponse.CompletedMission> completedMissions = new ArrayList<>();
 
-        for (PineconeMemory memory : memories) {
-            MissionConditionType conditionType = memory.getConditionType();
-            String missionTitle = getMissionTitleByConditionType(conditionType);
+        for (UserMission userMission : completedUserMissions) {
+            Mission mission = userMission.getMission();
+            MissionConditionType conditionType = mission.getConditionType();
+            String missionTitle = mission.getMissionTitle();
 
-            boolean hasMemoryDetail = hasMemoryDetail(memory.getSourceType());
+            // 해당 미션의 PineconeMemory가 있는지 확인
+            PineconeMemory memory = memoryMap.get(conditionType);
+
+            boolean hasMemoryDetail = false;
             PineconeMemoryResponse.MemoryDetail memoryDetail = null;
 
-            if (hasMemoryDetail) {
-                memoryDetail = buildMemoryDetail(memory);
-                // null인 경우 hasMemoryDetail을 false로 변경
-                if (memoryDetail == null) {
-                    hasMemoryDetail = false;
+            if (memory != null) {
+                hasMemoryDetail = hasMemoryDetail(memory.getSourceType());
+
+                if (hasMemoryDetail) {
+                    memoryDetail = buildMemoryDetail(memory);
+                    // null인 경우 hasMemoryDetail을 false로 변경
+                    if (memoryDetail == null) {
+                        hasMemoryDetail = false;
+                    }
                 }
             }
+
 
             completedMissions.add(
                     PineconeMemoryResponse.CompletedMission.builder()
@@ -556,6 +581,7 @@ public class MissionService {
                 }
                 yield PineconeMemoryResponse.MemoryDetail.builder()
                         .memoryType("MESSAGE")
+                        .sourceId(memory.getSourceId())
                         .memoryContent(message.getMessageTitle())
                         .relatedUserName(message.getReceiver().getName())
                         .createdAt(message.getCreatedAt().toString())
@@ -568,6 +594,7 @@ public class MissionService {
                 }
                 yield PineconeMemoryResponse.MemoryDetail.builder()
                         .memoryType("POST")
+                        .sourceId(memory.getSourceId())
                         .memoryContent(post.getPostTitle())
                         .relatedUserName(null)
                         .createdAt(post.getCreatedAt().toString())
@@ -581,6 +608,7 @@ public class MissionService {
                 }
                 yield PineconeMemoryResponse.MemoryDetail.builder()
                         .memoryType("COMMENT")
+                        .sourceId(memory.getSourceId())
                         .memoryContent(post.getPostTitle())
                         .relatedUserName(post.getAuthor().getName())
                         .createdAt(post.getCreatedAt().toString())

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/mission/service/MissionService.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/mission/service/MissionService.java
@@ -445,24 +445,22 @@ public class MissionService {
 
     // 경험 나누기 → 쪽지 소통 조건 체크
     private boolean checkMessageThreadCondition(User user) {
-        // HELP 알림 조회: 내가 보낸 HELP 알림
-        // targetId에 sender(나)의 userId가 저장되어 있음
+        // HELP 알림 조회: 나에게 온 HELP 알림 (내가 receiver인 경우)
         List<Notification> helpNotifications = notificationRepository
-                .findByNotificationTypeAndTargetId(NotificationType.HELP, user.getUserId());
+                .findByReceiverAndNotificationType(user, NotificationType.HELP);
 
         if (helpNotifications.isEmpty()) {
             return false;
         }
 
-        // 해당 사람들(receiver)과 쪽지를 주고받았는지 확인
+        // 나에게 HELP를 보낸 사람들(sender)에게 쪽지를 보냈는지 확인
         for (Notification notification : helpNotifications) {
-            Long receiverId = notification.getReceiver().getUserId();
+            Long senderId = notification.getTargetId();  // HELP를 보낸 사람의 userId
 
-            // 쪽지 확인 (양방향)
-            boolean hasMessage = messageRepository.existsBySender_UserIdAndReceiver_UserId(user.getUserId(), receiverId) ||
-                    messageRepository.existsBySender_UserIdAndReceiver_UserId(receiverId, user.getUserId());
+            // 내가 그 사람에게 쪽지를 보냈는지 확인
+            boolean sentMessage = messageRepository.existsBySender_UserIdAndReceiver_UserId(user.getUserId(), senderId);
 
-            if (hasMessage) {
+            if (sentMessage) {
                 return true;
             }
         }

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/mission/service/MissionService.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/mission/service/MissionService.java
@@ -218,9 +218,6 @@ public class MissionService {
         if (shouldComplete) {
             userMission.complete();
             log.info("미션 완료 - userId: {}, missionId: {}, conditionType: {}", userId, mission.getMissionId(), conditionType);
-
-            // TODO: 알림 발송
-            // notificationService.send(userId, NotificationType.MISSION_COMPLETED, ...);
         }
     }
 
@@ -253,8 +250,6 @@ public class MissionService {
             userMission.complete();
             log.info("미션 완료 (카운트 달성) - userId: {}, missionId: {}, count: {}/{}",
                     userId, mission.getMissionId(), userMission.getProgressCount(), targetCount);
-
-            // TODO: 알림 발송
         }
     }
 

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/mission/service/MissionService.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/mission/service/MissionService.java
@@ -537,10 +537,10 @@ public class MissionService {
                 yield post != null ? post.getPostId() : null;
             }
             case COMMENT_CREATE -> {
-                // 첫 번째 작성한 댓글
+                // 첫 번째 작성한 댓글이 달린 게시글
                 Comment comment = commentRepository.findFirstByUser_UserIdOrderByCreatedAtAsc(user.getUserId())
                         .orElse(null);
-                yield comment != null ? comment.getCommentId() : null;
+                yield comment != null ? comment.getPost().getPostId() : null;
             }
             case MENTORING_COMPLETE -> {
                 // TODO: 멘토링 도메인 구현 후 추가
@@ -578,15 +578,16 @@ public class MissionService {
                         .build();
             }
             case COMMENT -> {
-                Comment comment = commentRepository.findById(memory.getSourceId()).orElse(null);
-                if (comment == null) {
+                // sourceId는 post_id (댓글이 달린 게시글)
+                Post post = postRepository.findById(memory.getSourceId()).orElse(null);
+                if (post == null) {
                     yield null;
                 }
                 yield PineconeMemoryResponse.MemoryDetail.builder()
                         .memoryType("COMMENT")
-                        .memoryContent(comment.getCommentContent())
-                        .relatedUserName(comment.getPost().getAuthor().getName())
-                        .createdAt(comment.getCreatedAt().toString())
+                        .memoryContent(post.getPostTitle())
+                        .relatedUserName(post.getAuthor().getName())
+                        .createdAt(post.getCreatedAt().toString())
                         .build();
             }
             case MENTORING -> {

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/mission/service/MissionService.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/mission/service/MissionService.java
@@ -532,7 +532,8 @@ public class MissionService {
             }
             case POST_CREATE -> {
                 // 첫 번째 작성한 게시글
-                Post post = postRepository.findFirstByAuthor_UserIdOrderByCreatedAtAsc(user.getUserId())
+                Post post = postRepository
+                        .findTop1ByAuthor_UserIdAndDeletedAtIsNullOrderByCreatedAtAsc(user.getUserId())
                         .orElse(null);
                 yield post != null ? post.getPostId() : null;
             }

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/mission/service/MissionService.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/mission/service/MissionService.java
@@ -3,6 +3,10 @@ package com.solif.backend.domain.mission.service;
 import com.solif.backend.domain.auth.code.AuthErrorCode;
 import com.solif.backend.domain.comment.entity.Comment;
 import com.solif.backend.domain.comment.repository.CommentRepository;
+import com.solif.backend.domain.file.entity.AttachmentPurpose;
+import com.solif.backend.domain.file.entity.FileAttachment;
+import com.solif.backend.domain.file.entity.FileTargetType;
+import com.solif.backend.domain.file.repository.FileAttachmentRepository;
 import com.solif.backend.domain.message.entity.Message;
 import com.solif.backend.domain.message.repository.MessageRepository;
 import com.solif.backend.domain.mission.code.MissionErrorCode;
@@ -18,14 +22,19 @@ import com.solif.backend.domain.notification.entity.Notification;
 import com.solif.backend.domain.notification.entity.NotificationType;
 import com.solif.backend.domain.notification.repository.NotificationRepository;
 import com.solif.backend.domain.post.entity.Post;
+import com.solif.backend.domain.post.entity.PostCategory;
 import com.solif.backend.domain.post.repository.PostRepository;
 import com.solif.backend.domain.profile.entity.UserProfile;
 import com.solif.backend.domain.profile.repository.UserProfileRepository;
+import com.solif.backend.domain.scholarshipprogrampost.entity.ScholarshipProgramPost;
+import com.solif.backend.domain.scholarshipprogrampost.repository.ScholarshipProgramPostRepository;
 import com.solif.backend.domain.user.entity.User;
 import com.solif.backend.domain.user.repository.UserRepository;
 import com.solif.backend.global.common.exception.CustomException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -52,6 +61,11 @@ public class MissionService {
     private final MessageRepository messageRepository;
     private final PostRepository postRepository;
     private final CommentRepository commentRepository;
+    private final ScholarshipProgramPostRepository scholarshipProgramPostRepository;
+    private final FileAttachmentRepository fileAttachmentRepository;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
 
     // ===== 미션 진행 상황 조회 =====
     public MissionProgressResponse getMissionProgress(Long userId) {
@@ -73,12 +87,16 @@ public class MissionService {
         // 이번주 미션 리스트 (각 카테고리의 현재 진행 중인 미션)
         List<MissionProgressResponse.WeeklyMissionCard> weeklyMissions = buildWeeklyMissions(userMissions);
 
+        // 장학 프로그램 최신 3개
+        List<MissionProgressResponse.ScholarshipProgramCard> scholarshipPrograms = buildScholarshipPrograms();
+
         return MissionProgressResponse.builder()
                 .currentSeason(currentSeason)
                 .earnedPineconeCount(earnedPineconeCount.intValue())
                 .daysUntilSeasonEnd(daysUntilEnd)
                 .categoryProgress(categoryProgress)
                 .weeklyMissions(weeklyMissions)
+                .scholarshipPrograms(scholarshipPrograms)
                 .build();
     }
 
@@ -660,5 +678,53 @@ public class MissionService {
         }
 
         log.info("사용자 미션 초기화 완료 - userId: {}, 미션 개수: {}", user.getUserId(), allMissions.size());
+    }
+
+    // 장학 프로그램 최신 3개 구성
+    private List<MissionProgressResponse.ScholarshipProgramCard> buildScholarshipPrograms() {
+        // 최신 3개 조회
+        List<ScholarshipProgramPost> posts = scholarshipProgramPostRepository
+                .findTop3WithPostAndAuthor(PageRequest.of(0, 3));
+
+        if (posts.isEmpty()) {
+            return List.of();
+        }
+
+        // postId 수집 (썸네일 이미지 조회용)
+        List<Long> postIds = posts.stream()
+                .map(spp -> spp.getPost().getPostId())
+                .toList();
+
+        // N+1 해결: 썸네일 이미지 배치 조회
+        Map<Long, String> thumbnailUrlMap = fileAttachmentRepository
+                .findByFileTargetTypeAndFileTargetIdInAndSortOrderAndPurpose(
+                        FileTargetType.POST,
+                        postIds,
+                        1,
+                        AttachmentPurpose.POST_ATTACHMENT
+                )
+                .stream()
+                .collect(Collectors.toMap(
+                        FileAttachment::getFileTargetId,
+                        attachment -> attachment.getFile().getUrl(region),
+                        (existing, replacement) -> existing
+                ));
+
+        // ScholarshipProgramCard 생성
+        return posts.stream()
+                .map(spp -> {
+                    Post post = spp.getPost();
+                    PostCategory category = post.getPostCategory();
+
+                    return MissionProgressResponse.ScholarshipProgramCard.builder()
+                            .postId(post.getPostId())
+                            .category(category != null ? category.name() : null)
+                            .categoryName(category != null ? category.getDescription() : null)
+                            .title(post.getPostTitle())
+                            .thumbnailUrl(thumbnailUrlMap.get(post.getPostId()))
+                            .createdAt(post.getCreatedAt().toString())
+                            .build();
+                })
+                .toList();
     }
 }

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/network/service/NetworkService.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/network/service/NetworkService.java
@@ -10,6 +10,8 @@ import com.solif.backend.domain.interest.repository.UserInterestRepository;
 import com.solif.backend.domain.mentoring.entity.MentoringInteraction;
 import com.solif.backend.domain.mentoring.entity.MentoringInteractionType;
 import com.solif.backend.domain.mentoring.repository.MentoringInteractionRepository;
+import com.solif.backend.domain.mission.entity.MissionConditionType;
+import com.solif.backend.domain.mission.service.MissionService;
 import com.solif.backend.domain.network.dto.*;
 import com.solif.backend.domain.network.entity.Connection;
 import com.solif.backend.domain.network.entity.ConnectionStatus;
@@ -70,6 +72,7 @@ public class NetworkService {
     private final CouncilMemberRepository councilMemberRepository;
     private final ObjectMapper objectMapper;
     private final MentoringInteractionRepository mentoringInteractionRepository;
+    private final MissionService missionService;
 
     // Connection에서 상대방 가져오기 (내가 register면 target을, 내가 target이면 register를 반환)
     private User getOtherUser(Connection conn, User me) {
@@ -262,6 +265,9 @@ public class NetworkService {
                 .interactionType(interactionType)
                 .build();
         mentoringInteractionRepository.save(interaction);
+
+        // 미션 체크: 응원/경험나누기 카운트 증가 (CHEER/HELP 구분 없이)
+        missionService.incrementMissionProgress(userId, MissionConditionType.CONNECTION_ACTION);
 
         // 알림 메시지 설정
         if (notificationType == NotificationType.CHEER) {
@@ -457,7 +463,7 @@ public class NetworkService {
                 .filter(u -> !u.getUserId().equals(user.getUserId()))
                 .distinct()
                 .limit(10)
-                .collect(Collectors.toList());
+                .toList();
 
         // 자치회 정보 배치 조회 (N+1 방지)
         List<Long> userIds = users.stream()
@@ -493,7 +499,7 @@ public class NetworkService {
         List<User> users = userRepository.findAll().stream()
                 .filter(u -> !u.getUserId().equals(user.getUserId()))
                 .limit(20)
-                .collect(Collectors.toList());
+                .toList();
 
         // 자치회 정보 배치 조회 (N+1 방지)
         List<Long> userIds = users.stream()

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/notification/repository/NotificationRepository.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/notification/repository/NotificationRepository.java
@@ -6,8 +6,6 @@ import com.solif.backend.domain.user.entity.User;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
@@ -26,4 +24,7 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
 
     // targetId로 조회 (targetId에 sender userId 저장됨)
     List<Notification> findByNotificationTypeAndTargetId(NotificationType type, Long targetId);
+
+    // 수신자와 알림 타입으로 조회 (미션 #5용)
+    List<Notification> findByReceiverAndNotificationType(User receiver, NotificationType type);
 }

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/post/repository/PostRepository.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/post/repository/PostRepository.java
@@ -53,9 +53,5 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     );
 
     // 사용자가 첫 번째 작성한 게시글 (삭제되지 않은 것만)
-    @Query("SELECT p FROM Post p " +
-            "WHERE p.author.userId = :authorUserId " +
-            "AND p.deletedAt IS NULL " +
-            "ORDER BY p.createdAt ASC")
-    Optional<Post> findFirstByAuthor_UserIdOrderByCreatedAtAsc(@Param("authorUserId") Long authorUserId);
+    Optional<Post> findTop1ByAuthor_UserIdAndDeletedAtIsNullOrderByCreatedAtAsc(Long userId);
 }

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/post/service/PostService.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/post/service/PostService.java
@@ -4,6 +4,8 @@ import com.solif.backend.domain.mentoringpost.entity.MentoringPost;
 import com.solif.backend.domain.mentoringpost.repository.MentoringPostRepository;
 import com.solif.backend.domain.counselingpost.entity.CounselingPost;
 import com.solif.backend.domain.counselingpost.repository.CounselingPostRepository;
+import com.solif.backend.domain.mission.entity.MissionConditionType;
+import com.solif.backend.domain.mission.service.MissionService;
 import com.solif.backend.domain.noticepost.entity.NoticePost;
 import com.solif.backend.domain.noticepost.repository.NoticePostRepository;
 import com.solif.backend.domain.auth.code.AuthErrorCode;
@@ -59,6 +61,7 @@ public class PostService {
     private final MentoringPostRepository mentoringPostRepository;
     private final CounselingPostRepository counselingPostRepository;
     private final NoticePostRepository noticePostRepository;
+    private final MissionService missionService;
 
     @Value("${cloud.aws.region.static}")
     private String region;
@@ -214,6 +217,12 @@ public class PostService {
 
         // 조회수 증가
         post.increaseViewCount();
+
+        // 미션 체크: 재단 소식(공지사항) 확인
+        // boardId = 4 (재단소식) AND category = NOTICE (공지사항)
+        if (post.getBoard().getBoardId() == 4L && post.getPostCategory() == PostCategory.NOTICE) {
+            missionService.incrementMissionProgress(userId, MissionConditionType.POST_VIEW);
+        }
 
         // 익명 여부 판단 (boardId=3만 익명)
         boolean isAnonymous = (post.getBoard().getBoardId() == 3L);

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/post/service/PostService.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/post/service/PostService.java
@@ -5,7 +5,7 @@ import com.solif.backend.domain.mentoringpost.repository.MentoringPostRepository
 import com.solif.backend.domain.counselingpost.entity.CounselingPost;
 import com.solif.backend.domain.counselingpost.repository.CounselingPostRepository;
 import com.solif.backend.domain.mission.entity.MissionConditionType;
-import com.solif.backend.domain.mission.service.MissionService;
+import com.solif.backend.domain.mission.event.MissionEvent;
 import com.solif.backend.domain.noticepost.entity.NoticePost;
 import com.solif.backend.domain.noticepost.repository.NoticePostRepository;
 import com.solif.backend.domain.auth.code.AuthErrorCode;
@@ -33,6 +33,7 @@ import com.solif.backend.global.common.exception.CustomException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
@@ -61,7 +62,7 @@ public class PostService {
     private final MentoringPostRepository mentoringPostRepository;
     private final CounselingPostRepository counselingPostRepository;
     private final NoticePostRepository noticePostRepository;
-    private final MissionService missionService;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Value("${cloud.aws.region.static}")
     private String region;
@@ -218,10 +219,14 @@ public class PostService {
         // 조회수 증가
         post.increaseViewCount();
 
-        // 미션 체크: 재단 소식(공지사항) 확인
+        // 미션 체크: 재단 소식(공지사항) 확인 (트랜잭션 커밋 후 비동기 처리)
         // boardId = 4 (재단소식) AND category = NOTICE (공지사항)
         if (post.getBoard().getBoardId() == 4L && post.getPostCategory() == PostCategory.NOTICE) {
-            missionService.incrementMissionProgress(userId, MissionConditionType.POST_VIEW);
+            eventPublisher.publishEvent(new MissionEvent(
+                    userId,
+                    MissionConditionType.POST_VIEW,
+                    post.getPostId()
+            ));
         }
 
         // 익명 여부 판단 (boardId=3만 익명)
@@ -294,8 +299,12 @@ public class PostService {
             counselingPostRepository.save(counselingPost);
             log.info("고민상담 생성 - counselingPostId: {}", counselingPost.getCounselingPostId());
 
-            // 미션 체크: 고민상담 게시글 작성 (post_id를 sourceId로 전달)
-            missionService.checkAndCompleteMission(userId, MissionConditionType.POST_CREATE, savedPost.getPostId());
+            // 미션 체크: 고민상담 게시글 작성 (트랜잭션 커밋 후 비동기 처리)
+            eventPublisher.publishEvent(new MissionEvent(
+                    userId,
+                    MissionConditionType.POST_CREATE,
+                    savedPost.getPostId()
+            ));
         } else if (request.getBoardId() == 4L) {
             // 재단소식
             NoticePost noticePost = NoticePost.builder()

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/post/service/PostService.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/post/service/PostService.java
@@ -293,6 +293,9 @@ public class PostService {
                     .build();
             counselingPostRepository.save(counselingPost);
             log.info("고민상담 생성 - counselingPostId: {}", counselingPost.getCounselingPostId());
+
+            // 미션 체크: 고민상담 게시글 작성 (post_id를 sourceId로 전달)
+            missionService.checkAndCompleteMission(userId, MissionConditionType.POST_CREATE, savedPost.getPostId());
         } else if (request.getBoardId() == 4L) {
             // 재단소식
             NoticePost noticePost = NoticePost.builder()

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/profile/service/ProfileService.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/profile/service/ProfileService.java
@@ -5,6 +5,8 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.solif.backend.domain.interest.entity.UserInterest;
 import com.solif.backend.domain.interest.repository.UserInterestRepository;
+import com.solif.backend.domain.mission.entity.MissionConditionType;
+import com.solif.backend.domain.mission.service.MissionService;
 import com.solif.backend.domain.profile.dto.*;
 import com.solif.backend.domain.profile.entity.UserProfile;
 import com.solif.backend.domain.profile.exception.ProfileErrorCode;
@@ -38,6 +40,7 @@ public class ProfileService {
     private final QrCodeService qrCodeService;
     private final ObjectMapper objectMapper;
     private final S3Service s3Service;
+    private final MissionService missionService;
 
     // 프로필 생성
     @Transactional
@@ -69,6 +72,10 @@ public class ProfileService {
                 .build();
 
         userProfileRepository.save(profile);
+
+        // 미션 체크: 프로필 100% 완성 (온보딩 완료)
+        missionService.checkAndCompleteMission(userId, MissionConditionType.PROFILE_COMPLETE, null);
+
 
         return ProfileCreateResponse.of(profile.getProfileId(), qrResult.imageUrl());
     }

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/scholarshipprogrampost/repository/ScholarshipProgramPostRepository.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/scholarshipprogrampost/repository/ScholarshipProgramPostRepository.java
@@ -2,6 +2,7 @@ package com.solif.backend.domain.scholarshipprogrampost.repository;
 
 import com.solif.backend.domain.post.entity.PostCategory;
 import com.solif.backend.domain.scholarshipprogrampost.entity.ScholarshipProgramPost;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -25,4 +26,17 @@ public interface ScholarshipProgramPostRepository extends JpaRepository<Scholars
     List<ScholarshipProgramPost> findByPostCategoryWithPostAndAuthor(
             @Param("postCategory") PostCategory postCategory
     );
+
+    /**
+     * 장학 프로그램 최신 3개 조회 (카테고리 구분 없이)
+     * - N+1 문제 해결을 위한 fetch join
+     * - 삭제되지 않은 게시글만 조회
+     * - 최신순 정렬
+     */
+    @Query("SELECT spp FROM ScholarshipProgramPost spp " +
+            "JOIN FETCH spp.post p " +
+            "JOIN FETCH p.author " +
+            "WHERE p.deletedAt IS NULL " +
+            "ORDER BY p.createdAt DESC")
+    List<ScholarshipProgramPost> findTop3WithPostAndAuthor(Pageable pageable);
 }


### PR DESCRIPTION
## 🔍 개요
성장-미션 시스템 Phase 2로,
사용자의 실제 행동(프로필 조회/쪽지/게시글/댓글/멘토링 등)에 따라
미션이 자동으로 진행/완료되도록 각 도메인 서비스에 연동 로직을 추가했습니다.

## ✨ 변경 사항
- ### 1️⃣ 미션 자동 연동
- ### 2️⃣ MissionService 연동 보완

## 🧪 테스트
- [x] 로컬 테스트 완료
- [ ] API 테스트 완료
- [ ] 테스트 코드 작성 (해당 시)

## 📎 관련 이슈
Closes: #101 

## ⚠️ 참고 사항
- 트랜잭션 범위를 고려하여 도메인 로직과 미션 로직의 결합을 최소화했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 미션 자동 반영 확대: 댓글 작성, 메시지 전송(첫 메시지/스레드), 네트워크 상호작용, 게시물 보기/작성, 프로필 완성 등에서 미션 이벤트가 발행되어 진행이 자동 처리됩니다.
  * 미션 이벤트 및 비동기 리스너 도입으로 미션 검증/완료 로직이 트랜잭션 후 처리됩니다.

* **New Data**
  * 메모리 응답에 sourceId 추가로 활동 출처(게시물/메시지) 추적 강화.
  * 미션 진행 응답에 장학 프로그램 카드(scholarshipPrograms) 추가.

* **Refactor**
  * 관련 조회·메모리 조립·리포지토리 조회 로직 개선 및 성능 최적화.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->