### PR TITLE
Feature:  안읽은 알림 목록 가져오는 기능 추가 구현

### DIFF
--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/file/entity/FileFolder.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/file/entity/FileFolder.java
@@ -8,7 +8,8 @@ import lombok.RequiredArgsConstructor;
 public enum FileFolder {
     COUNCIL_REVIEW("council-review"),   // 자치회 활동 후기
     POST("post"),                        // 게시판
-    MENTORING("mentoring");              // 멘토링
+    MENTORING("mentoring"),              // 멘토링
+    MESSAGE("message");                  // 쪽지
 
     private final String folderName;
 }

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/notification/repository/NotificationRepository.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/notification/repository/NotificationRepository.java
@@ -24,6 +24,10 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
     // 안읽은 알림 수
     long countByReceiverAndIsReadFalse(User receiver);
 
+    // 전체 안읽은 알림 목록 (카테고리 무관)
+    Slice<Notification> findByReceiverAndIsReadFalseOrderByCreatedAtDesc(
+            User receiver, Pageable pageable);
+
     // targetId로 조회 (targetId에 sender userId 저장됨)
     List<Notification> findByNotificationTypeAndTargetId(NotificationType type, Long targetId);
 }

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/notification/service/NotificationService.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/notification/service/NotificationService.java
@@ -113,9 +113,10 @@ public class NotificationService {
 
         Slice<Notification> notifications;
         if ("UNREAD".equalsIgnoreCase(filter)) {
+            // 안읽음 필터: 카테고리 무관 전체 안읽은 알림 조회
             notifications = notificationRepository
-                    .findByReceiverAndNotificationTypeInAndIsReadFalseOrderByCreatedAtDesc(
-                            receiver, types, pageable);
+                    .findByReceiverAndIsReadFalseOrderByCreatedAtDesc(
+                            receiver, pageable);
         } else {
             notifications = notificationRepository
                     .findByReceiverAndNotificationTypeInOrderByCreatedAtDesc(


### PR DESCRIPTION
## 🔍 개요
안읽은 알림 목록 가져오는 기능 추가 구현
## ✨ 변경 사항
- filefolder에 message추가
- message service 로직 추가 등

## 🧪 테스트
- [x] 로컬 테스트 완료
- [ ] API 테스트 완료
- [ ] 테스트 코드 작성 (해당 시)

## 📎 관련 이슈
Closes: #109 

## ⚠️ 참고 사항
리뷰어가 알아야 할 사항이나 논의가 필요한 부분을 작성해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 메시지 폴더 유형 지원 추가

* **개선사항**
  * 알림 조회 시 모든 미읽 알림을 카테고리 제한 없이 표시하도록 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->