### PR TITLE
feat: YouTube Data API 연동 및 역량강화 동영상 조회 기능 구현

### DIFF
--- a/.github/workflows/deploy-stg.yml
+++ b/.github/workflows/deploy-stg.yml
@@ -75,6 +75,8 @@ jobs:
             REDIS_PORT=${{ secrets.REDIS_PORT }}
             S3_ACCESS_KEY=${{secrets.S3_ACCESS_KEY}}
             S3_SECRET_KEY=${{secrets.S3_SECRET_KEY}}
+            YOUTUBE_API_KEY=${{secrets.YOUTUBE_API_KEY}}
+            YOUTUBE_CHANNEL_ID=${{secrets.YOUTUBE_CHANNEL_ID}}
             GOOGLE_APPLICATION_CREDENTIALS=/app/secrets/gcp-vision.json
             EOF
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -75,6 +75,8 @@ jobs:
             REDIS_PORT=${{ secrets.REDIS_PORT }}
             S3_ACCESS_KEY=${{secrets.S3_ACCESS_KEY}}
             S3_SECRET_KEY=${{secrets.S3_SECRET_KEY}}
+            YOUTUBE_API_KEY=${{secrets.YOUTUBE_API_KEY}}
+            YOUTUBE_CHANNEL_ID=${{secrets.YOUTUBE_CHANNEL_ID}}
             GOOGLE_APPLICATION_CREDENTIALS=/app/secrets/gcp-vision.json
             EOF
 

--- a/blue-sol-backend/build.gradle
+++ b/blue-sol-backend/build.gradle
@@ -48,6 +48,15 @@ dependencies {
 	// Google Cloud Vision API
 	implementation 'com.google.cloud:google-cloud-vision:3.20.0'
 
+	// YouTube Data API
+	implementation 'com.google.api-client:google-api-client:2.2.0'
+	implementation 'com.google.apis:google-api-services-youtube:v3-rev20230502-2.0.0'
+	implementation 'com.google.http-client:google-http-client-jackson2:1.43.3'
+
+	// Caffeine Cache
+	implementation 'org.springframework.boot:spring-boot-starter-cache'
+	implementation 'com.github.ben-manes.caffeine:caffeine:3.1.8'
+
 	runtimeOnly 'com.h2database:h2'
 }
 

--- a/blue-sol-backend/build.gradle
+++ b/blue-sol-backend/build.gradle
@@ -49,9 +49,9 @@ dependencies {
 	implementation 'com.google.cloud:google-cloud-vision:3.20.0'
 
 	// YouTube Data API
-	implementation 'com.google.api-client:google-api-client:2.2.0'
-	implementation 'com.google.apis:google-api-services-youtube:v3-rev20230502-2.0.0'
-	implementation 'com.google.http-client:google-http-client-jackson2:1.43.3'
+	implementation 'com.google.api-client:google-api-client:2.8.1'
+	implementation 'com.google.apis:google-api-services-youtube:v3-rev20251217-2.0.0'
+	implementation 'com.google.http-client:google-http-client-jackson2:2.1.0'
 
 	// Caffeine Cache
 	implementation 'org.springframework.boot:spring-boot-starter-cache'

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/mission/dto/MissionProgressResponse.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/mission/dto/MissionProgressResponse.java
@@ -28,6 +28,9 @@ public class MissionProgressResponse {
     @Schema(description = "이번주 미션 리스트 (최대 3개)")
     private List<WeeklyMissionCard> weeklyMissions;
 
+    @Schema(description = "푸른 SOL 역량강화 동영상 목록 (최대 20개)")
+    private List<SkillDevelopmentVideo> skillDevelopmentVideos;
+
     @Schema(description = "장학 프로그램 최신 3개")
     private List<ScholarshipProgramCard> scholarshipPrograms;
 
@@ -87,6 +90,29 @@ public class MissionProgressResponse {
 
         @Schema(description = "완료 여부")
         private Boolean isCompleted;
+    }
+
+    @Getter
+    @Builder
+    @Schema(description = "역량강화 동영상 카드")
+    public static class SkillDevelopmentVideo {
+        @Schema(description = "동영상 ID")
+        private String videoId;
+
+        @Schema(description = "제목")
+        private String title;
+
+        @Schema(description = "썸네일 URL")
+        private String thumbnailUrl;
+
+        @Schema(description = "카테고리 (인성/사회/과학/창업/취업)")
+        private String category;
+
+        @Schema(description = "강연자")
+        private String speaker;
+
+        @Schema(description = "동영상 URL")
+        private String videoUrl;
     }
 
     @Getter

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/mission/service/MissionService.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/mission/service/MissionService.java
@@ -30,6 +30,8 @@ import com.solif.backend.domain.scholarshipprogrampost.entity.ScholarshipProgram
 import com.solif.backend.domain.scholarshipprogrampost.repository.ScholarshipProgramPostRepository;
 import com.solif.backend.domain.user.entity.User;
 import com.solif.backend.domain.user.repository.UserRepository;
+import com.solif.backend.domain.youtube.dto.VideoDto;
+import com.solif.backend.domain.youtube.service.YouTubeService;
 import com.solif.backend.global.common.exception.CustomException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -63,7 +65,7 @@ public class MissionService {
     private final CommentRepository commentRepository;
 
     // YouTube API 연동
-    private final com.solif.backend.domain.youtube.service.YouTubeService youtubeService;
+    private final YouTubeService youtubeService;
     private final ScholarshipProgramPostRepository scholarshipProgramPostRepository;
     private final FileAttachmentRepository fileAttachmentRepository;
 
@@ -674,8 +676,7 @@ public class MissionService {
     private List<MissionProgressResponse.SkillDevelopmentVideo> buildSkillDevelopmentVideos() {
         try {
             // YouTube API를 통해 최신 동영상 20개 조회
-            List<com.solif.backend.domain.youtube.dto.VideoDto> youtubeVideos =
-                youtubeService.getLatestVideos(20);
+            List<VideoDto> youtubeVideos = youtubeService.getLatestVideos(20);
 
             // DTO 변환
             return youtubeVideos.stream()

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/mission/service/MissionService.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/mission/service/MissionService.java
@@ -61,6 +61,9 @@ public class MissionService {
     private final MessageRepository messageRepository;
     private final PostRepository postRepository;
     private final CommentRepository commentRepository;
+
+    // YouTube API 연동
+    private final com.solif.backend.domain.youtube.service.YouTubeService youtubeService;
     private final ScholarshipProgramPostRepository scholarshipProgramPostRepository;
     private final FileAttachmentRepository fileAttachmentRepository;
 
@@ -87,6 +90,9 @@ public class MissionService {
         // 이번주 미션 리스트 (각 카테고리의 현재 진행 중인 미션)
         List<MissionProgressResponse.WeeklyMissionCard> weeklyMissions = buildWeeklyMissions(userMissions);
 
+        // 푸른 SOL 역량강화 동영상 조회 (YouTube API)
+        List<MissionProgressResponse.SkillDevelopmentVideo> skillDevelopmentVideos = buildSkillDevelopmentVideos();
+
         // 장학 프로그램 최신 3개
         List<MissionProgressResponse.ScholarshipProgramCard> scholarshipPrograms = buildScholarshipPrograms();
 
@@ -96,6 +102,7 @@ public class MissionService {
                 .daysUntilSeasonEnd(daysUntilEnd)
                 .categoryProgress(categoryProgress)
                 .weeklyMissions(weeklyMissions)
+                .skillDevelopmentVideos(skillDevelopmentVideos)
                 .scholarshipPrograms(scholarshipPrograms)
                 .build();
     }
@@ -208,7 +215,6 @@ public class MissionService {
                     }
                 }
             }
-
 
             completedMissions.add(
                     PineconeMemoryResponse.CompletedMission.builder()
@@ -663,6 +669,31 @@ public class MissionService {
 //            case MENTORING -> MissionConditionType.MENTORING_COMPLETE;
 //        };
 //    }
+
+    // 푸른 SOL 역량강화 동영상 조회 (YouTube API)
+    private List<MissionProgressResponse.SkillDevelopmentVideo> buildSkillDevelopmentVideos() {
+        try {
+            // YouTube API를 통해 최신 동영상 20개 조회
+            List<com.solif.backend.domain.youtube.dto.VideoDto> youtubeVideos =
+                youtubeService.getLatestVideos(20);
+
+            // DTO 변환
+            return youtubeVideos.stream()
+                .map(video -> MissionProgressResponse.SkillDevelopmentVideo.builder()
+                    .videoId(video.getVideoId())
+                    .title(video.getTitle())
+                    .thumbnailUrl(video.getThumbnailUrl())
+                    .category(video.getCategory())
+                    .speaker(video.getSpeaker())
+                    .videoUrl(video.getVideoUrl())
+                    .build())
+                .collect(Collectors.toList());
+        } catch (Exception e) {
+            log.error("YouTube 동영상 조회 실패", e);
+            // 에러 발생 시 빈 리스트 반환
+            return new ArrayList<>();
+        }
+    }
 
     // 회원가입 완료 후 미션 초기화
     @Transactional

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/youtube/controller/YouTubeController.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/youtube/controller/YouTubeController.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -38,6 +39,9 @@ public class YouTubeController {
         log.info("동영상 목록 조회 요청: maxResults={}", maxResults);
         
         // 최대값 제한
+        if (maxResults < 1) {
+            maxResults = 1;
+        }
         if (maxResults > 50) {
             maxResults = 50;
         }
@@ -78,6 +82,7 @@ public class YouTubeController {
      * POST /api/youtube/refresh
      */
     @PostMapping("/refresh")
+    @PreAuthorize("hasRole('ADMIN')")
     @Operation(summary = "캐시 수동 갱신", description = "YouTube 동영상 캐시를 수동으로 갱신합니다. (관리자용)")
     public ResponseEntity<String> refreshCache() {
         log.info("YouTube 캐시 수동 갱신 요청");

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/youtube/controller/YouTubeController.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/youtube/controller/YouTubeController.java
@@ -67,6 +67,9 @@ public class YouTubeController {
         log.info("카테고리별 동영상 조회: category={}, maxResults={}", category, maxResults);
         
         // 최대값 제한
+        if (maxResults < 1) {
+            maxResults = 1;
+        }
         if (maxResults > 50) {
             maxResults = 50;
         }

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/youtube/controller/YouTubeController.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/youtube/controller/YouTubeController.java
@@ -1,0 +1,89 @@
+package com.solif.backend.domain.youtube.controller;
+
+import com.solif.backend.domain.youtube.dto.VideoDto;
+import com.solif.backend.domain.youtube.service.YouTubeService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+/**
+ * YouTube 동영상 조회 API
+ */
+@Slf4j
+@RestController
+@RequestMapping("/api/youtube")
+@RequiredArgsConstructor
+@Tag(name = "YouTube", description = "YouTube 동영상 조회 API")
+public class YouTubeController {
+    
+    private final YouTubeService youtubeService;
+    
+    /**
+     * 최신 동영상 목록 조회
+     * 
+     * GET /api/youtube/videos?maxResults=20
+     */
+    @GetMapping("/videos")
+    @Operation(summary = "최신 동영상 목록 조회", description = "채널의 최신 동영상을 조회합니다.")
+    public ResponseEntity<List<VideoDto>> getVideos(
+        @Parameter(description = "최대 결과 개수 (1-50)", example = "20")
+        @RequestParam(defaultValue = "20") Integer maxResults
+    ) {
+        log.info("동영상 목록 조회 요청: maxResults={}", maxResults);
+        
+        // 최대값 제한
+        if (maxResults > 50) {
+            maxResults = 50;
+        }
+        
+        List<VideoDto> videos = youtubeService.getLatestVideos(maxResults);
+        
+        return ResponseEntity.ok(videos);
+    }
+    
+    /**
+     * 카테고리별 동영상 조회
+     * 
+     * GET /api/youtube/videos/category?category=인성&maxResults=10
+     */
+    @GetMapping("/videos/category")
+    @Operation(summary = "카테고리별 동영상 조회", description = "특정 카테고리의 동영상을 조회합니다.")
+    public ResponseEntity<List<VideoDto>> getVideosByCategory(
+        @Parameter(description = "카테고리 (전체, 인성, 사회, 과학, 창업, 취업)", example = "인성")
+        @RequestParam(required = false, defaultValue = "전체") String category,
+        @Parameter(description = "최대 결과 개수 (1-50)", example = "20")
+        @RequestParam(defaultValue = "20") Integer maxResults
+    ) {
+        log.info("카테고리별 동영상 조회: category={}, maxResults={}", category, maxResults);
+        
+        // 최대값 제한
+        if (maxResults > 50) {
+            maxResults = 50;
+        }
+        
+        List<VideoDto> videos = youtubeService.getVideosByCategory(category, maxResults);
+        
+        return ResponseEntity.ok(videos);
+    }
+    
+    /**
+     * 캐시 수동 갱신 (관리자용)
+     * 
+     * POST /api/youtube/refresh
+     */
+    @PostMapping("/refresh")
+    @Operation(summary = "캐시 수동 갱신", description = "YouTube 동영상 캐시를 수동으로 갱신합니다. (관리자용)")
+    public ResponseEntity<String> refreshCache() {
+        log.info("YouTube 캐시 수동 갱신 요청");
+        
+        youtubeService.refreshCache();
+        
+        return ResponseEntity.ok("캐시가 갱신되었습니다.");
+    }
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/youtube/dto/VideoDto.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/youtube/dto/VideoDto.java
@@ -1,0 +1,76 @@
+package com.solif.backend.domain.youtube.dto;
+
+import com.google.api.services.youtube.model.SearchResult;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
+/**
+ * YouTube 동영상 정보 DTO
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class VideoDto {
+    
+    private String videoId;           // 유튜브 동영상 ID
+    private String title;              // 제목
+    private String description;        // 설명
+    private String thumbnailUrl;       // 썸네일 URL (고화질)
+    private String channelTitle;       // 채널명
+    private LocalDateTime publishedAt; // 게시일
+    private String videoUrl;           // 전체 URL
+    
+    // 커스텀 필드
+    private String category;           // 카테고리 (인성, 사회, 과학, 창업, 취업)
+    private String speaker;            // 강연자 이름
+    
+    /**
+     * YouTube 검색 결과를 DTO로 변환
+     */
+    public static VideoDto fromSearchResult(SearchResult searchResult) {
+        if (searchResult.getId() == null || searchResult.getId().getVideoId() == null) {
+            return null;
+        }
+        
+        String videoId = searchResult.getId().getVideoId();
+        var snippet = searchResult.getSnippet();
+        
+        // publishedAt을 LocalDateTime으로 변환
+        LocalDateTime publishedAt = null;
+        if (snippet.getPublishedAt() != null) {
+            publishedAt = LocalDateTime.ofInstant(
+                Instant.ofEpochMilli(snippet.getPublishedAt().getValue()),
+                ZoneId.systemDefault()
+            );
+        }
+        
+        // 썸네일 URL 추출 (고화질 우선, 없으면 기본)
+        String thumbnailUrl = null;
+        if (snippet.getThumbnails() != null) {
+            if (snippet.getThumbnails().getHigh() != null) {
+                thumbnailUrl = snippet.getThumbnails().getHigh().getUrl();
+            } else if (snippet.getThumbnails().getMedium() != null) {
+                thumbnailUrl = snippet.getThumbnails().getMedium().getUrl();
+            } else if (snippet.getThumbnails().getDefault() != null) {
+                thumbnailUrl = snippet.getThumbnails().getDefault().getUrl();
+            }
+        }
+        
+        return VideoDto.builder()
+            .videoId(videoId)
+            .title(snippet.getTitle())
+            .description(snippet.getDescription())
+            .thumbnailUrl(thumbnailUrl)
+            .channelTitle(snippet.getChannelTitle())
+            .publishedAt(publishedAt)
+            .videoUrl("https://www.youtube.com/watch?v=" + videoId)
+            .build();
+    }
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/youtube/dto/VideoDto.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/youtube/dto/VideoDto.java
@@ -38,16 +38,20 @@ public class VideoDto {
         if (searchResult.getId() == null || searchResult.getId().getVideoId() == null) {
             return null;
         }
-        
-        String videoId = searchResult.getId().getVideoId();
+
         var snippet = searchResult.getSnippet();
+        if (snippet == null){
+            return null;
+        }
+
+        String videoId = searchResult.getId().getVideoId();
         
         // publishedAt을 LocalDateTime으로 변환
         LocalDateTime publishedAt = null;
         if (snippet.getPublishedAt() != null) {
             publishedAt = LocalDateTime.ofInstant(
                 Instant.ofEpochMilli(snippet.getPublishedAt().getValue()),
-                ZoneId.systemDefault()
+                ZoneId.of("Asia/Seoul")
             );
         }
         
@@ -64,13 +68,13 @@ public class VideoDto {
         }
         
         return VideoDto.builder()
-            .videoId(videoId)
-            .title(snippet.getTitle())
-            .description(snippet.getDescription())
-            .thumbnailUrl(thumbnailUrl)
-            .channelTitle(snippet.getChannelTitle())
-            .publishedAt(publishedAt)
-            .videoUrl("https://www.youtube.com/watch?v=" + videoId)
-            .build();
+                .videoId(videoId)
+                .title(snippet.getTitle() != null ? snippet.getTitle() : "")  // ← null-safe
+                .description(snippet.getDescription() != null ? snippet.getDescription() : "")
+                .thumbnailUrl(thumbnailUrl)
+                .channelTitle(snippet.getChannelTitle() != null ? snippet.getChannelTitle() : "")
+                .publishedAt(publishedAt)
+                .videoUrl("https://www.youtube.com/watch?v=" + videoId)
+                .build();
     }
 }

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/youtube/service/YouTubeApiCacheService.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/youtube/service/YouTubeApiCacheService.java
@@ -1,0 +1,101 @@
+package com.solif.backend.domain.youtube.service;
+
+import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
+import com.google.api.client.json.gson.GsonFactory;
+import com.google.api.services.youtube.YouTube;
+import com.google.api.services.youtube.model.SearchListResponse;
+import com.google.api.services.youtube.model.SearchResult;
+import com.solif.backend.domain.youtube.dto.VideoDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * YouTube API 캐시 전용 서비스
+ * Spring AOP 프록시가 정상 동작하도록 별도 클래스로 분리
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class YouTubeApiCacheService {
+    
+    @Value("${youtube.api.key}")
+    private String apiKey;
+    
+    @Value("${youtube.api.channel-id}")
+    private String channelId;
+    
+    /**
+     * YouTube API 클라이언트 생성
+     */
+    private YouTube getYouTubeService() throws GeneralSecurityException, IOException {
+        return new YouTube.Builder(
+            GoogleNetHttpTransport.newTrustedTransport(),
+            GsonFactory.getDefaultInstance(),
+            null
+        )
+        .setApplicationName("blue-sol-backend")
+        .build();
+    }
+    
+    /**
+     * 채널의 전체 동영상 조회 (캐싱 적용)
+     * 최대 50개를 가져와서 캐싱
+     * 
+     * @return 동영상 목록 (최대 50개)
+     */
+    @Cacheable(value = "youtubeVideos", key = "'all'")
+    public List<VideoDto> getAllVideos() {
+        try {
+            log.info("YouTube API 호출: 전체 동영상 조회 (maxResults=50)");
+            
+            YouTube youtube = getYouTubeService();
+            
+            // 검색 요청 생성
+            YouTube.Search.List search = youtube.search()
+                .list(java.util.Arrays.asList("id", "snippet"))
+                .setChannelId(channelId)
+                .setKey(apiKey)
+                .setMaxResults(50L)  // 최대 50개 가져오기
+                .setOrder("date")  // 최신순
+                .setType(java.util.Arrays.asList("video")); // 동영상만
+            
+            // API 호출
+            SearchListResponse response = search.execute();
+            List<SearchResult> searchResults = response.getItems();
+            if (searchResults == null) {
+                return List.of();
+            }
+            
+            // DTO 변환
+            List<VideoDto> videos = searchResults.stream()
+                .map(VideoDto::fromSearchResult)
+                .filter(video -> video != null)  // null 제외
+                .collect(Collectors.toList());
+            
+            log.info("YouTube API 응답: {} 개의 동영상 조회됨", videos.size());
+            
+            return videos;
+            
+        } catch (Exception e) {
+            log.error("YouTube API 호출 실패", e);
+            throw new RuntimeException("YouTube 동영상 조회 실패: " + e.getMessage(), e);
+        }
+    }
+    
+    /**
+     * 캐시 삭제 (캐시 갱신 시 사용)
+     */
+    @CacheEvict(value = "youtubeVideos", allEntries = true)
+    public void evictCache() {
+        log.info("YouTube 동영상 캐시 삭제 완료");
+    }
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/youtube/service/YouTubeService.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/youtube/service/YouTubeService.java
@@ -1,0 +1,182 @@
+package com.solif.backend.domain.youtube.service;
+
+import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
+import com.google.api.client.json.gson.GsonFactory;
+import com.google.api.services.youtube.YouTube;
+import com.google.api.services.youtube.model.SearchListResponse;
+import com.google.api.services.youtube.model.SearchResult;
+import com.solif.backend.domain.youtube.dto.VideoDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * YouTube Data API 연동 서비스
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class YouTubeService {
+    
+    @Value("${youtube.api.key}")
+    private String apiKey;
+    
+    @Value("${youtube.api.channel-id}")
+    private String channelId;
+    
+    /**
+     * YouTube API 클라이언트 생성
+     */
+    private YouTube getYouTubeService() throws GeneralSecurityException, IOException {
+        return new YouTube.Builder(
+            GoogleNetHttpTransport.newTrustedTransport(),
+            GsonFactory.getDefaultInstance(),
+            null
+        )
+        .setApplicationName("blue-sol-backend")
+        .build();
+    }
+    
+    /**
+     * 채널의 최신 동영상 조회 (캐싱 적용)
+     * 
+     * @param maxResults 최대 결과 개수 (기본 20개)
+     * @return 동영상 목록
+     */
+    @Cacheable(value = "youtubeVideos", key = "#maxResults")
+    public List<VideoDto> getLatestVideos(Integer maxResults) {
+        try {
+            log.info("YouTube API 호출: 채널 동영상 조회 (maxResults={})", maxResults);
+            
+            YouTube youtube = getYouTubeService();
+            
+            // 검색 요청 생성
+            YouTube.Search.List search = youtube.search()
+                .list(java.util.Arrays.asList("id", "snippet"))
+                .setChannelId(channelId)
+                .setKey(apiKey)
+                .setMaxResults(maxResults.longValue())
+                .setOrder("date")  // 최신순
+                .setType(java.util.Arrays.asList("video")); // 동영상만
+            
+            // API 호출
+            SearchListResponse response = search.execute();
+            List<SearchResult> searchResults = response.getItems();
+            
+            // DTO 변환
+            List<VideoDto> videos = searchResults.stream()
+                .map(VideoDto::fromSearchResult)
+                .filter(video -> video != null)  // null 제외
+                .collect(Collectors.toList());
+            
+            log.info("YouTube API 응답: {} 개의 동영상 조회됨", videos.size());
+            
+            // 카테고리 분류 적용
+            videos.forEach(this::assignCategory);
+            
+            return videos;
+            
+        } catch (Exception e) {
+            log.error("YouTube API 호출 실패", e);
+            throw new RuntimeException("YouTube 동영상 조회 실패: " + e.getMessage(), e);
+        }
+    }
+    
+    /**
+     * 카테고리별 동영상 필터링
+     */
+    public List<VideoDto> getVideosByCategory(String category, Integer maxResults) {
+        List<VideoDto> allVideos = getLatestVideos(maxResults);
+        
+        if (category == null || category.equals("전체")) {
+            return allVideos;
+        }
+        
+        return allVideos.stream()
+            .filter(video -> category.equals(video.getCategory()))
+            .collect(Collectors.toList());
+    }
+    
+    /**
+     * 동영상 제목 기반 카테고리 자동 분류
+     * 
+     * 규칙:
+     * 1. 제목에 [인성], [사회] 등 태그가 있으면 해당 카테고리
+     * 2. 키워드 기반 분류
+     */
+    private void assignCategory(VideoDto video) {
+        String title = video.getTitle().toLowerCase();
+        
+        // 1. 태그 기반 분류 (우선순위)
+        if (title.contains("[인성]") || title.contains("[人性]")) {
+            video.setCategory("인성");
+        } else if (title.contains("[사회]") || title.contains("[社會]")) {
+            video.setCategory("사회");
+        } else if (title.contains("[과학]") || title.contains("[科學]")) {
+            video.setCategory("과학");
+        } else if (title.contains("[창업]") || title.contains("[創業]")) {
+            video.setCategory("창업");
+        } else if (title.contains("[취업]") || title.contains("[就業]")) {
+            video.setCategory("취업");
+        }
+        // 2. 키워드 기반 분류
+        else if (title.contains("인성") || title.contains("도덕") || title.contains("윤리")) {
+            video.setCategory("인성");
+        } else if (title.contains("사회") || title.contains("경제") || title.contains("정치")) {
+            video.setCategory("사회");
+        } else if (title.contains("과학") || title.contains("기술") || title.contains("ai") || 
+                   title.contains("인공지능") || title.contains("우라만이")) {
+            video.setCategory("과학");
+        } else if (title.contains("창업") || title.contains("스타트업") || title.contains("기업가")) {
+            video.setCategory("창업");
+        } else if (title.contains("취업") || title.contains("면접") || title.contains("이력서") || 
+                   title.contains("글로벌 금융")) {
+            video.setCategory("취업");
+        }
+        // 기본값
+        else {
+            video.setCategory("전체");
+        }
+        
+        // 강연자 추출
+        extractSpeaker(video);
+    }
+    
+    /**
+     * 제목에서 강연자 이름 추출
+     * 예: "어떤 삶을 살고 싶나요? 나를 아십니까? - 포이샤스 원종희 대표님"
+     */
+    private void extractSpeaker(VideoDto video) {
+        String title = video.getTitle();
+        
+        // 패턴: "- XXX 대표님", "| XXX 교수님" 등
+        String[] patterns = {" - ", " | ", " / "};
+        
+        for (String pattern : patterns) {
+            if (title.contains(pattern)) {
+                String[] parts = title.split(pattern);
+                if (parts.length > 1) {
+                    String speakerPart = parts[parts.length - 1].trim();
+                    video.setSpeaker(speakerPart);
+                    break;
+                }
+            }
+        }
+    }
+    
+    /**
+     * 캐시 수동 갱신용 메서드
+     */
+    public void refreshCache() {
+        log.info("YouTube 동영상 캐시 갱신 시작");
+        getLatestVideos(50);  // 캐시 갱신
+        log.info("YouTube 동영상 캐시 갱신 완료");
+    }
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/youtube/service/YouTubeService.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/youtube/service/YouTubeService.java
@@ -1,20 +1,10 @@
 package com.solif.backend.domain.youtube.service;
 
-import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
-import com.google.api.client.json.gson.GsonFactory;
-import com.google.api.services.youtube.YouTube;
-import com.google.api.services.youtube.model.SearchListResponse;
-import com.google.api.services.youtube.model.SearchResult;
 import com.solif.backend.domain.youtube.dto.VideoDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.cache.annotation.CacheEvict;
-import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
-import java.io.IOException;
-import java.security.GeneralSecurityException;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -26,70 +16,7 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class YouTubeService {
     
-    @Value("${youtube.api.key}")
-    private String apiKey;
-    
-    @Value("${youtube.api.channel-id}")
-    private String channelId;
-    
-    /**
-     * YouTube API 클라이언트 생성
-     */
-    private YouTube getYouTubeService() throws GeneralSecurityException, IOException {
-        return new YouTube.Builder(
-            GoogleNetHttpTransport.newTrustedTransport(),
-            GsonFactory.getDefaultInstance(),
-            null
-        )
-        .setApplicationName("blue-sol-backend")
-        .build();
-    }
-    
-    /**
-     * 채널의 전체 동영상 조회 (캐싱 적용 - 고정 키)
-     * 최대 50개를 가져와서 캐싱하고, getLatestVideos에서 필요한 만큼만 반환
-     */
-    @Cacheable(value = "youtubeVideos", key = "'all'")
-    private List<VideoDto> getAllVideos() {
-        try {
-            log.info("YouTube API 호출: 전체 동영상 조회 (maxResults=50)");
-            
-            YouTube youtube = getYouTubeService();
-            
-            // 검색 요청 생성
-            YouTube.Search.List search = youtube.search()
-                .list(java.util.Arrays.asList("id", "snippet"))
-                .setChannelId(channelId)
-                .setKey(apiKey)
-                .setMaxResults(50L)  // 최대 50개 가져오기
-                .setOrder("date")  // 최신순
-                .setType(java.util.Arrays.asList("video")); // 동영상만
-            
-            // API 호출
-            SearchListResponse response = search.execute();
-            List<SearchResult> searchResults = response.getItems();
-            if (searchResults == null) {
-                return List.of();
-            }
-            
-            // DTO 변환
-            List<VideoDto> videos = searchResults.stream()
-                .map(VideoDto::fromSearchResult)
-                .filter(video -> video != null)  // null 제외
-                .collect(Collectors.toList());
-            
-            log.info("YouTube API 응답: {} 개의 동영상 조회됨", videos.size());
-            
-            // 카테고리 분류 적용
-            videos.forEach(this::assignCategory);
-            
-            return videos;
-            
-        } catch (Exception e) {
-            log.error("YouTube API 호출 실패", e);
-            throw new RuntimeException("YouTube 동영상 조회 실패: " + e.getMessage(), e);
-        }
-    }
+    private final YouTubeApiCacheService cacheService;
     
     /**
      * 채널의 최신 동영상 조회 (캐시된 전체 목록에서 필요한 만큼만 반환)
@@ -98,7 +25,10 @@ public class YouTubeService {
      * @return 동영상 목록
      */
     public List<VideoDto> getLatestVideos(Integer maxResults) {
-        List<VideoDto> allVideos = getAllVideos();  // 캐시에서 가져옴 (key='all')
+        List<VideoDto> allVideos = cacheService.getAllVideos();  // 캐시 서비스에서 가져옴
+        
+        // 카테고리 분류 적용 (캐시된 데이터에는 아직 적용 안됨)
+        allVideos.forEach(this::assignCategory);
         
         // maxResults만큼만 자르기
         return allVideos.stream()
@@ -108,16 +38,26 @@ public class YouTubeService {
     
     /**
      * 카테고리별 동영상 필터링
+     * 전체 동영상 목록에서 카테고리 필터링 후 maxResults만큼 반환
      */
     public List<VideoDto> getVideosByCategory(String category, Integer maxResults) {
-        List<VideoDto> allVideos = getLatestVideos(maxResults);
+        // 전체 동영상 조회 (캐시에서 최대 50개)
+        List<VideoDto> allVideos = cacheService.getAllVideos();
         
+        // 카테고리 분류 적용
+        allVideos.forEach(this::assignCategory);
+        
+        // "전체" 카테고리면 바로 maxResults만큼 반환
         if (category == null || category.equals("전체")) {
-            return allVideos;
+            return allVideos.stream()
+                .limit(maxResults)
+                .collect(Collectors.toList());
         }
         
+        // 카테고리 필터링 먼저 → 그 다음 limit 적용
         return allVideos.stream()
             .filter(video -> category.equals(video.getCategory()))
+            .limit(maxResults)  // ← 필터링 후 limit!
             .collect(Collectors.toList());
     }
     
@@ -192,11 +132,11 @@ public class YouTubeService {
      * 캐시 수동 갱신용 메서드
      * 기존 캐시를 모두 지우고 새로 조회하여 캐시 갱신
      */
-    @CacheEvict(value = "youtubeVideos", allEntries = true)
     public void refreshCache() {
         log.info("YouTube 동영상 캐시 갱신 시작");
         // 캐시를 지운 후 즉시 새로 조회하여 캐시 채우기
-        getAllVideos();
+        cacheService.evictCache();
+        cacheService.getAllVideos();
         log.info("YouTube 동영상 캐시 갱신 완료");
     }
 }

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/youtube/service/YouTubeService.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/youtube/service/YouTubeService.java
@@ -9,6 +9,7 @@ import com.solif.backend.domain.youtube.dto.VideoDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
@@ -45,15 +46,13 @@ public class YouTubeService {
     }
     
     /**
-     * 채널의 최신 동영상 조회 (캐싱 적용)
-     * 
-     * @param maxResults 최대 결과 개수 (기본 20개)
-     * @return 동영상 목록
+     * 채널의 전체 동영상 조회 (캐싱 적용 - 고정 키)
+     * 최대 50개를 가져와서 캐싱하고, getLatestVideos에서 필요한 만큼만 반환
      */
-    @Cacheable(value = "youtubeVideos", key = "#maxResults")
-    public List<VideoDto> getLatestVideos(Integer maxResults) {
+    @Cacheable(value = "youtubeVideos", key = "'all'")
+    private List<VideoDto> getAllVideos() {
         try {
-            log.info("YouTube API 호출: 채널 동영상 조회 (maxResults={})", maxResults);
+            log.info("YouTube API 호출: 전체 동영상 조회 (maxResults=50)");
             
             YouTube youtube = getYouTubeService();
             
@@ -62,13 +61,16 @@ public class YouTubeService {
                 .list(java.util.Arrays.asList("id", "snippet"))
                 .setChannelId(channelId)
                 .setKey(apiKey)
-                .setMaxResults(maxResults.longValue())
+                .setMaxResults(50L)  // 최대 50개 가져오기
                 .setOrder("date")  // 최신순
                 .setType(java.util.Arrays.asList("video")); // 동영상만
             
             // API 호출
             SearchListResponse response = search.execute();
             List<SearchResult> searchResults = response.getItems();
+            if (searchResults == null) {
+                return List.of();
+            }
             
             // DTO 변환
             List<VideoDto> videos = searchResults.stream()
@@ -87,6 +89,21 @@ public class YouTubeService {
             log.error("YouTube API 호출 실패", e);
             throw new RuntimeException("YouTube 동영상 조회 실패: " + e.getMessage(), e);
         }
+    }
+    
+    /**
+     * 채널의 최신 동영상 조회 (캐시된 전체 목록에서 필요한 만큼만 반환)
+     * 
+     * @param maxResults 최대 결과 개수 (1-50)
+     * @return 동영상 목록
+     */
+    public List<VideoDto> getLatestVideos(Integer maxResults) {
+        List<VideoDto> allVideos = getAllVideos();  // 캐시에서 가져옴 (key='all')
+        
+        // maxResults만큼만 자르기
+        return allVideos.stream()
+            .limit(maxResults)
+            .collect(Collectors.toList());
     }
     
     /**
@@ -161,7 +178,7 @@ public class YouTubeService {
         
         for (String pattern : patterns) {
             if (title.contains(pattern)) {
-                String[] parts = title.split(pattern);
+                String[] parts = title.split(java.util.regex.Pattern.quote(pattern));
                 if (parts.length > 1) {
                     String speakerPart = parts[parts.length - 1].trim();
                     video.setSpeaker(speakerPart);
@@ -173,10 +190,13 @@ public class YouTubeService {
     
     /**
      * 캐시 수동 갱신용 메서드
+     * 기존 캐시를 모두 지우고 새로 조회하여 캐시 갱신
      */
+    @CacheEvict(value = "youtubeVideos", allEntries = true)
     public void refreshCache() {
         log.info("YouTube 동영상 캐시 갱신 시작");
-        getLatestVideos(50);  // 캐시 갱신
+        // 캐시를 지운 후 즉시 새로 조회하여 캐시 채우기
+        getAllVideos();
         log.info("YouTube 동영상 캐시 갱신 완료");
     }
 }

--- a/blue-sol-backend/src/main/java/com/solif/backend/global/config/CacheConfig.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/global/config/CacheConfig.java
@@ -1,6 +1,8 @@
 package com.solif.backend.global.config;
 
 import com.github.benmanes.caffeine.cache.Caffeine;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.cache.caffeine.CaffeineCacheManager;
@@ -15,16 +17,20 @@ import java.util.concurrent.TimeUnit;
  */
 @Configuration
 @EnableCaching
+@RequiredArgsConstructor
 public class CacheConfig {
-    
+
+    @Value("${youtube.cache.ttl:3600}")
+    private long cacheTtlSeconds;
+
     @Bean
     public CacheManager cacheManager() {
         CaffeineCacheManager cacheManager = new CaffeineCacheManager("youtubeVideos");
         cacheManager.setCaffeine(Caffeine.newBuilder()
-            .maximumSize(100)                        // 최대 100개 항목 저장
-            .expireAfterWrite(1, TimeUnit.HOURS)     // 1시간 후 만료
-            .recordStats());                         // 통계 기록
-        
+                .maximumSize(10)                         // 최대 10개 항목 저장 (키가 'all' 하나만 사용)
+                .expireAfterWrite(cacheTtlSeconds, TimeUnit.SECONDS)    // 설정된 시간 후 만료 (기본 1시간)
+                .recordStats());                         // 통계 기록
+
         return cacheManager;
     }
 }

--- a/blue-sol-backend/src/main/java/com/solif/backend/global/config/CacheConfig.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/global/config/CacheConfig.java
@@ -1,0 +1,30 @@
+package com.solif.backend.global.config;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.caffeine.CaffeineCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Caffeine 캐시 설정
+ * YouTube API 호출 결과를 캐싱하여 API 할당량을 절약
+ */
+@Configuration
+@EnableCaching
+public class CacheConfig {
+    
+    @Bean
+    public CacheManager cacheManager() {
+        CaffeineCacheManager cacheManager = new CaffeineCacheManager("youtubeVideos");
+        cacheManager.setCaffeine(Caffeine.newBuilder()
+            .maximumSize(100)                        // 최대 100개 항목 저장
+            .expireAfterWrite(1, TimeUnit.HOURS)     // 1시간 후 만료
+            .recordStats());                         // 통계 기록
+        
+        return cacheManager;
+    }
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/global/scheduler/YouTubeScheduler.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/global/scheduler/YouTubeScheduler.java
@@ -1,0 +1,35 @@
+package com.solif.backend.global.scheduler;
+
+import com.solif.backend.domain.youtube.service.YouTubeService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/**
+ * YouTube 관련 스케줄 작업
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class YouTubeScheduler {
+    
+    private final YouTubeService youtubeService;
+    
+    /**
+     * 1시간마다 자동으로 캐시 갱신
+     * YouTube API 할당량을 고려하여 1시간 간격으로 설정
+     * 
+     * TODO: API 키 설정 후 주석 해제
+     */
+    // @Scheduled(fixedRate = 3600000)  // 1시간 = 3,600,000ms
+    public void refreshYouTubeCache() {
+        log.info("스케줄러: YouTube 캐시 자동 갱신 시작");
+        try {
+            youtubeService.refreshCache();
+            log.info("스케줄러: YouTube 캐시 자동 갱신 완료");
+        } catch (Exception e) {
+            log.error("스케줄러: YouTube 캐시 갱신 실패", e);
+        }
+    }
+}

--- a/blue-sol-backend/src/main/resources/application-prod.yml
+++ b/blue-sol-backend/src/main/resources/application-prod.yml
@@ -30,7 +30,7 @@ logging:
 
 jwt:
   secret: ${JWT_SECRET}
-  access-token-expiration: 3600000
+  access-token-expiration: 10800000
   refresh-token-expiration: 604800000
 
 cloud:

--- a/blue-sol-backend/src/main/resources/application-prod.yml
+++ b/blue-sol-backend/src/main/resources/application-prod.yml
@@ -43,3 +43,9 @@ cloud:
       access-key: ${S3_ACCESS_KEY}
       secret-key: ${S3_SECRET_KEY}
 
+youtube:
+  api:
+    key: ${YOUTUBE_API_KEY}
+    channel-id: ${YOUTUBE_CHANNEL_ID}
+  cache:
+    ttl: 3600

--- a/blue-sol-backend/src/main/resources/application-prod.yml
+++ b/blue-sol-backend/src/main/resources/application-prod.yml
@@ -47,5 +47,3 @@ youtube:
   api:
     key: ${YOUTUBE_API_KEY}
     channel-id: ${YOUTUBE_CHANNEL_ID}
-  cache:
-    ttl: 3600

--- a/blue-sol-backend/src/main/resources/application-stg.yml
+++ b/blue-sol-backend/src/main/resources/application-stg.yml
@@ -30,7 +30,7 @@ logging:
 
 jwt:
   secret: ${JWT_SECRET}
-  access-token-expiration: 3600000
+  access-token-expiration: 10800000
   refresh-token-expiration: 604800000
 
 cloud:

--- a/blue-sol-backend/src/main/resources/application-stg.yml
+++ b/blue-sol-backend/src/main/resources/application-stg.yml
@@ -42,3 +42,10 @@ cloud:
     credentials:
       access-key: ${S3_ACCESS_KEY}
       secret-key: ${S3_SECRET_KEY}
+
+youtube:
+  api:
+    key: ${YOUTUBE_API_KEY}
+    channel-id: ${YOUTUBE_CHANNEL_ID}
+  cache:
+    ttl: 3600


### PR DESCRIPTION
## 🔍 개요
홈 화면 "푸른 SOL 역량강화" 섹션에 YouTube 채널(@SHFG1226)의 동영상을 자동으로 표시하기 위한 백엔드 API 구현

## ✨ 변경 사항
- YouTube Data API v3 연동
- REST API 엔드포인트 추가
- 자동 카테고리 분류

## 🧪 테스트
- [x] 로컬 테스트 완료
- [ ] API 테스트 완료
- [ ] 테스트 코드 작성 (해당 시)

## 📎 관련 이슈
Closes: #107 

## ⚠️ 참고 사항
리뷰어가 알아야 할 사항이나 논의가 필요한 부분을 작성해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 유튜브 동영상 통합: 미션 진행에 추천 기술 동영상 추가 및 동영상 조회 API(전체/카테고리별) 제공
  * 관리자용 수동 캐시 갱신 엔드포인트 추가

* **개선사항**
  * 동영상 캐시 도입으로 응답 성능 개선 및 수동/예약 갱신 지원 준비
  * 배포 환경에 유튜브 API 설정 항목(스테이징/프로덕션) 추가
  * 액세스 토큰 만료시간 연장 (3시간) 

* **종속성**
  * 유튜브 연동 및 캐시 라이브러리 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->