### PR TITLE
feat: 성장 미션 완료 시 팝업 알림 발송 기능 추가

### DIFF
--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/mission/dto/MissionPopupResponse.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/mission/dto/MissionPopupResponse.java
@@ -1,0 +1,23 @@
+package com.solif.backend.domain.mission.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@Schema(description = "미션 팝업 알림 응답 (SSE 전용, DB 저장 안 함)")
+public class MissionPopupResponse {
+
+    @Schema(description = "팝업 타입 (CATEGORY_COMPLETE: 카테고리 완료, PINECONE_EARNED: 솔방울 획득)")
+    private String popupType;
+
+    @Schema(description = "카테고리명 (연결/성장/기여)")
+    private String category;
+
+    @Schema(description = "팝업 메시지")
+    private String message;
+
+    @Schema(description = "남은 솔방울 개수 (솔방울 획득 시에만 사용)")
+    private Integer remainingCount;
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/mission/service/MissionService.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/mission/service/MissionService.java
@@ -10,6 +10,7 @@ import com.solif.backend.domain.file.repository.FileAttachmentRepository;
 import com.solif.backend.domain.message.entity.Message;
 import com.solif.backend.domain.message.repository.MessageRepository;
 import com.solif.backend.domain.mission.code.MissionErrorCode;
+import com.solif.backend.domain.mission.dto.MissionPopupResponse;
 import com.solif.backend.domain.mission.dto.MissionProgressResponse;
 import com.solif.backend.domain.mission.dto.PineconeEarnResponse;
 import com.solif.backend.domain.mission.dto.PineconeMemoryResponse;
@@ -21,6 +22,7 @@ import com.solif.backend.domain.mission.repository.UserPineconeRepository;
 import com.solif.backend.domain.notification.entity.Notification;
 import com.solif.backend.domain.notification.entity.NotificationType;
 import com.solif.backend.domain.notification.repository.NotificationRepository;
+import com.solif.backend.domain.notification.service.NotificationService;
 import com.solif.backend.domain.post.entity.Post;
 import com.solif.backend.domain.post.entity.PostCategory;
 import com.solif.backend.domain.post.repository.PostRepository;
@@ -63,6 +65,7 @@ public class MissionService {
     private final MessageRepository messageRepository;
     private final PostRepository postRepository;
     private final CommentRepository commentRepository;
+    private final NotificationService notificationService;
 
     // YouTube API 연동
     private final YouTubeService youtubeService;
@@ -149,10 +152,11 @@ public class MissionService {
             savePineconeMemory(pinecone, userMission);
         }
 
-        // TODO: 알림 발송
-        // notificationService.send(userId, ...);
-
         log.info("솔방울 획득 - userId: {}, category: {}, season: {}", userId, category, currentSeason);
+
+        // 🆕 솔방울 획득 팝업 발송
+        Long totalEarnedCount = userPineconeRepository.countByUserAndSeasonKey(user, currentSeason);
+        sendPineconeEarnedPopup(userId, category, totalEarnedCount.intValue());
 
         return PineconeEarnResponse.builder()
                 .pineconeId(pinecone.getUserPineconeId())
@@ -269,6 +273,9 @@ public class MissionService {
         if (shouldComplete) {
             userMission.complete();
             log.info("미션 완료 - userId: {}, missionId: {}, conditionType: {}", userId, mission.getMissionId(), conditionType);
+
+            // 카테고리 미션 3개 완료 체크 후 팝업 발송
+            checkAndSendCategoryCompletePopup(userId, mission.getMissionCategory());
         }
     }
 
@@ -301,6 +308,9 @@ public class MissionService {
             userMission.complete();
             log.info("미션 완료 (카운트 달성) - userId: {}, missionId: {}, count: {}/{}",
                     userId, mission.getMissionId(), userMission.getProgressCount(), targetCount);
+
+            // 카테고리 미션 3개 완료 체크 후 팝업 발송
+            checkAndSendCategoryCompletePopup(userId, mission.getMissionCategory());
         }
     }
 
@@ -758,5 +768,49 @@ public class MissionService {
                             .build();
                 })
                 .toList();
+    }
+
+    // 카테고리 미션 3개 완료 체크 후 팝업 발송
+    private void checkAndSendCategoryCompletePopup(Long userId, MissionCategory category) {
+        User user = findUserById(userId);
+        String currentSeason = getCurrentSeasonKey();
+
+        // 해당 카테고리 완료된 미션 개수 확인
+        Long completedCount = userMissionRepository.countByUserAndCategoryAndStatus(
+                user, category, MissionStatus.COMPLETED
+        );
+
+        // 3개 모두 완료 && 아직 솔방울 미획득인 경우에만 팝업
+        if (completedCount == 3) {
+            boolean alreadyEarned = userPineconeRepository.existsByUserAndPineconeCategoryAndSeasonKey(
+                    user, category, currentSeason
+            );
+
+            if (!alreadyEarned) {
+                MissionPopupResponse popup = MissionPopupResponse.builder()
+                        .popupType("CATEGORY_COMPLETE")
+                        .category(getCategoryName(category))
+                        .message("미션 완료! " + getCategoryName(category) + " 솔방울 받으러 가기")
+                        .build();
+
+                notificationService.sendPopup(userId, "mission_popup", popup);
+                log.info("카테고리 완료 팝업 발송 - userId: {}, category: {}", userId, category);
+            }
+        }
+    }
+
+    // 솔방울 획득 팝업 발송
+    private void sendPineconeEarnedPopup(Long userId, MissionCategory category, Integer totalEarnedCount) {
+        Integer remainingCount = 3 - totalEarnedCount;
+
+        MissionPopupResponse popup = MissionPopupResponse.builder()
+                .popupType("PINECONE_EARNED")
+                .category(getCategoryName(category))
+                .message(getCategoryName(category) + " 솔방울을 획득했어요! 명함 받기 보상까지 " + remainingCount + "번 남았어요.")
+                .remainingCount(remainingCount)
+                .build();
+
+        notificationService.sendPopup(userId, "mission_popup", popup);
+        log.info("솔방울 획득 팝업 발송 - userId: {}, category: {}, remaining: {}", userId, category, remainingCount);
     }
 }

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/notification/service/NotificationService.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/notification/service/NotificationService.java
@@ -8,7 +8,6 @@ import com.solif.backend.domain.notification.dto.*;
 import com.solif.backend.domain.notification.entity.*;
 import com.solif.backend.domain.notification.repository.NotificationRepository;
 import com.solif.backend.domain.notification.repository.SseEmitterRepository;
-import com.solif.backend.domain.profile.entity.UserProfile;
 import com.solif.backend.domain.profile.repository.UserProfileRepository;
 import com.solif.backend.domain.user.entity.User;
 import com.solif.backend.domain.user.repository.UserRepository;
@@ -300,5 +299,19 @@ public class NotificationService {
         if (!notification.getReceiver().getUserId().equals(userId)) {
             throw new CustomException(NotificationErrorCode.UNAUTHORIZED_NOTIFICATION_ACCESS);
         }
+    }
+
+    /**
+     * 팝업 알림 전송 (DB 저장 없음)
+     * 미션 완료, 솔방울 획득 등 일회성 팝업에 사용
+     */
+    public void sendPopup(Long receiverUserId, String eventName, Object data) {
+        Map<String, SseEmitter> emitters = sseEmitterRepository.findAllByUserId(receiverUserId);
+
+        emitters.forEach((emitterId, emitter) -> {
+            sendToEmitter(emitter, emitterId, eventName, data);
+        });
+
+        log.info("팝업 알림 전송 - userId: {}, eventName: {}", receiverUserId, eventName);
     }
 }


### PR DESCRIPTION
## 🔍 개요
성장-미션 시스템에서 미션 완료 시
사용자에게 팝업 알림을 전송하는 기능을 추가했습니다.

## ✨ 변경 사항
- ### 1️⃣ 미션 완료 알림 기능 추가
- ### 2️⃣ MissionService 로직 확장

## 🧪 테스트
- [X] 로컬 테스트 완료
- [ ] API 테스트 완료
- [ ] 테스트 코드 작성 (해당 시)

## 📎 관련 이슈
Closes: #112 

## ⚠️ 참고 사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 미션 이벤트 팝업 알림 기능 추가
    * 솔콘 획득 시 즉시 팝업으로 획득량과 잔량 정보 제공
    * 각 카테고리별 미션 3개 완료 시 완료 알림 팝업 제공

<!-- end of auto-generated comment: release notes by coderabbit.ai -->