### PR TITLE
feat: 교류망 상세조회 api 추가

### DIFF
--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/network/code/NetworkSuccessCode.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/network/code/NetworkSuccessCode.java
@@ -14,7 +14,8 @@ public enum NetworkSuccessCode implements SuccessCode {
     NETWORK_INTERACTION_SUCCESS(HttpStatus.CREATED, "NETWORK_003", "상호작용 발송에 성공했습니다."),
     NETWORK_RECOMMENDATION_SUCCESS(HttpStatus.OK, "NETWORK_004", "교류망 추천 조회에 성공했습니다."),
     NETWORK_SEARCH_SUCCESS(HttpStatus.OK, "NETWORK_005", "교류망 검색에 성공했습니다."),
-    NETWORK_QR_ADD_SUCCESS(HttpStatus.CREATED, "NETWORK_006", "QR 코드로 교류망 추가에 성공했습니다.");
+    NETWORK_QR_ADD_SUCCESS(HttpStatus.CREATED, "NETWORK_006", "QR 코드로 교류망 추가에 성공했습니다."),
+    NETWORK_USER_CARD_SUCCESS(HttpStatus.OK, "NETWORK_007", "사용자 카드 조회에 성공했습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/network/controller/NetworkController.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/network/controller/NetworkController.java
@@ -106,4 +106,17 @@ public class NetworkController {
         NetworkSearchResponse response = networkService.searchNetworks(userId, keyword);
         return ResponseFactory.success(NetworkSuccessCode.NETWORK_SEARCH_SUCCESS, response);
     }
+
+    @Operation(
+            summary = "교류망 사용자 카드 조회",
+            description = "특정 사용자의 SOLID 카드 정보를 조회합니다. (NFC/QR 연동용)",
+            security = @SecurityRequirement(name = "Bearer Authentication")
+    )
+    @GetMapping("/users/{userId}/card")
+    public ResponseEntity<SuccessResponse<NetworkUserCardResponse>> getUserCard(
+            @PathVariable Long userId
+    ) {
+        NetworkUserCardResponse response = networkService.getUserCard(userId);
+        return ResponseFactory.success(NetworkSuccessCode.NETWORK_USER_CARD_SUCCESS, response);
+    }
 }

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/network/dto/NetworkUserCardResponse.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/network/dto/NetworkUserCardResponse.java
@@ -1,0 +1,40 @@
+package com.solif.backend.domain.network.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+@Schema(description = "교류망 사용자 카드 조회 응답")
+public class NetworkUserCardResponse {
+
+    @Schema(description = "사용자 ID")
+    private Long userId;
+
+    @Schema(description = "사용자 이름")
+    private String userName;
+
+    @Schema(description = "캐릭터")
+    private String userCharacter;
+
+    @Schema(description = "캐릭터 이미지 URL")
+    private String characterImageUrl;
+
+    @Schema(description = "배경 패턴")
+    private String backgroundPattern;
+
+    @Schema(description = "배경 이미지 URL")
+    private String backgroundImageUrl;
+
+    @Schema(description = "SOLID 목표 이름")
+    private String solidGoalName;
+
+    @Schema(description = "관심사 목록")
+    private List<String> interests;
+
+    @Schema(description = "가입 연도", example = "2026")
+    private Integer joinYear;
+}

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/network/service/NetworkService.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/network/service/NetworkService.java
@@ -556,4 +556,24 @@ public class NetworkService {
             return List.of();
         }
     }
+
+    // 교류망 사용자 카드 조회
+    public NetworkUserCardResponse getUserCard(Long targetUserId) {
+        User targetUser = findUserById(targetUserId);
+        UserProfile profile = userProfileRepository.findByUser_UserId(targetUserId).orElse(null);
+        List<String> interests = getInterestsByUser(targetUser);
+        Integer joinYear = getJoinYear(targetUser);
+
+        return NetworkUserCardResponse.builder()
+                .userId(targetUser.getUserId())
+                .userName(targetUser.getName())
+                .userCharacter(profile != null ? profile.getUserCharacter() : null)
+                .characterImageUrl(buildS3Url(profile != null ? profile.getUserCharacter() : null))
+                .backgroundPattern(profile != null ? profile.getBackgroundPattern() : null)
+                .backgroundImageUrl(buildS3Url(profile != null ? profile.getBackgroundPattern() : null))
+                .solidGoalName(profile != null ? profile.getSolidGoalName() : null)
+                .interests(interests)
+                .joinYear(joinYear)
+                .build();
+    }
 }


### PR DESCRIPTION
## 🔍 개요
교류망 추천 리스트에서 사용자 클릭 시,
해당 사용자의 SOLID 카드 정보를 조회하는 API를 추가했습니다.

GET /api/v1/networks/users/{userId}/card

NFC / QR 접속 시에도 동일 API를 사용합니다.

## ✨ 변경 사항
- NetworkController에 SOLID 카드 상세 조회 API 추가
- NetworkService에 카드 정보 조회 로직 구현
- CardDetailResponse DTO 추가

## 🧪 테스트
- [x] 로컬 테스트 완료
- [ ] API 테스트 완료
- [ ] 테스트 코드 작성 (해당 시)

## 📎 관련 이슈
Closes: #114 

## ⚠️ 참고 사항
- 추후 카드 공개 범위 정책 변경 시 Service 단에서 제어 가능하도록 구현했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 사용자 카드 조회 기능이 추가되었습니다. 교류망에서 특정 사용자의 프로필, 캐릭터, 배경 이미지, 관심사, 참여 연도 등을 포함한 SOLID 카드 정보를 조회할 수 있는 새로운 API 엔드포인트가 제공됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->