### PR TITLE
feat: 자치회 활동 멤버 상세 조회 API에 캐릭터/배경 이미지 필드 추가

### DIFF
--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/council/dto/CouncilMemberResponse.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/council/dto/CouncilMemberResponse.java
@@ -2,11 +2,13 @@ package com.solif.backend.domain.council.dto;
 
 import com.solif.backend.domain.council.entity.CouncilMember;
 import com.solif.backend.domain.council.entity.CouncilMemberRole;
+import com.solif.backend.domain.profile.entity.UserProfile;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
+import java.util.function.Function;
 
 @Getter
 @Builder
@@ -31,7 +33,23 @@ public class CouncilMemberResponse {
     @Schema(description = "학교명", example = "제주대학교")
     private String schoolName;
 
-    public static CouncilMemberResponse from(CouncilMember member) {
+    @Schema(description = "캐릭터", example = "character1.png")
+    private String userCharacter;
+
+    @Schema(description = "캐릭터 이미지 URL", example = "https://bucket.s3.region.amazonaws.com/character1.png")
+    private String characterImageUrl;
+
+    @Schema(description = "배경 패턴", example = "pattern1.png")
+    private String backgroundPattern;
+
+    @Schema(description = "배경 이미지 URL", example = "https://bucket.s3.region.amazonaws.com/pattern1.png")
+    private String backgroundImageUrl;
+
+    public static CouncilMemberResponse from(
+            CouncilMember member,
+            UserProfile profile,
+            Function<String, String> buildS3Url
+    ) {
         return CouncilMemberResponse.builder()
                 .userId(member.getUser().getUserId())
                 .name(member.getUser().getName())
@@ -39,6 +57,10 @@ public class CouncilMemberResponse {
                 .joinedAt(member.getJoinedAt())
                 .region(member.getUser().getRegion())
                 .schoolName(member.getUser().getSchoolName())
+                .userCharacter(profile != null ? profile.getUserCharacter() : null)
+                .characterImageUrl(buildS3Url.apply(profile != null ? profile.getUserCharacter() : null))
+                .backgroundPattern(profile != null ? profile.getBackgroundPattern() : null)
+                .backgroundImageUrl(buildS3Url.apply(profile != null ? profile.getBackgroundPattern() : null))
                 .build();
     }
 }

--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/council/service/CouncilMemberService.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/council/service/CouncilMemberService.java
@@ -13,16 +13,20 @@ import com.solif.backend.domain.council.repository.CouncilRepository;
 import com.solif.backend.domain.notification.entity.NotificationType;
 import com.solif.backend.domain.notification.entity.NotificationTargetType;
 import com.solif.backend.domain.notification.event.NotificationEvent;
+import com.solif.backend.domain.profile.entity.UserProfile;
+import com.solif.backend.domain.profile.repository.UserProfileRepository;
 import com.solif.backend.domain.user.entity.User;
 import com.solif.backend.domain.user.repository.UserRepository;
 import com.solif.backend.global.common.exception.CustomException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -35,7 +39,19 @@ public class CouncilMemberService {
     private final CouncilRepository councilRepository;
     private final CouncilMemberRepository councilMemberRepository;
     private final UserRepository userRepository;
+    private final UserProfileRepository userProfileRepository;
     private final ApplicationEventPublisher eventPublisher;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    private String buildS3Url(String key) {
+        if (key == null || key.isBlank()) return null;
+        return String.format("https://%s.s3.%s.amazonaws.com/%s", bucket, region, key);
+    }
 
     // 자치회 멤버 목록 조회
     public MemberListResponse getMembers(Long councilId) {
@@ -49,9 +65,23 @@ public class CouncilMemberService {
         List<CouncilMember> members = councilMemberRepository
                 .findByCouncilOrderByRoleDescJoinedAtAsc(council);
 
+        // UserProfile 배치 조회 (N+1 방지)
+        List<Long> userIds = members.stream()
+                .map(member -> member.getUser().getUserId())
+                .collect(Collectors.toList());
+
+        Map<Long, UserProfile> profileMap = userProfileRepository.findByUser_UserIdIn(userIds).stream()
+                .collect(Collectors.toMap(
+                        profile -> profile.getUser().getUserId(),
+                        profile -> profile
+                ));
+
         // DTO 변환
         List<CouncilMemberResponse> memberResponses = members.stream()
-                .map(CouncilMemberResponse::from)
+                .map(member -> {
+                    UserProfile profile = profileMap.get(member.getUser().getUserId());
+                    return CouncilMemberResponse.from(member, profile, this::buildS3Url);
+                })
                 .collect(Collectors.toList());
 
         return MemberListResponse.of(councilId, memberResponses);


### PR DESCRIPTION
## 🔍 개요
자치회 활동 멤버 상세 조회 API 응답에
멤버의 캐릭터(userCharacter)와 배경 이미지(backgroundPattern) 정보를 추가했습니다.

## ✨ 변경 사항
- CouncilMemberResponse DTO에 필드 추가

## 🧪 테스트
- [x] 로컬 테스트 완료
- [ ] API 테스트 완료
- [ ] 테스트 코드 작성 (해당 시)

## 📎 관련 이슈
Closes: #116 

## ⚠️ 참고 사항
- 기존 필드에는 변경이 없으며, 응답 필드만 확장되었습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * Council 멤버 응답에 프로필 기반 UI 필드 추가: 사용자 캐릭터, 캐릭터 이미지 URL, 배경 패턴, 배경 이미지 URL
  * UserProfile 데이터를 활용한 멤버 정보 표시 개선
  * 배치 프로필 조회를 통한 성능 최적화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->