### PR TITLE
fix: 솔방울 추억 회상 API memoryDetail null 반환 문제 수정

### DIFF
--- a/blue-sol-backend/src/main/java/com/solif/backend/domain/mission/service/MissionService.java
+++ b/blue-sol-backend/src/main/java/com/solif/backend/domain/mission/service/MissionService.java
@@ -569,15 +569,16 @@ public class MissionService {
             }
             case MESSAGE_THREAD -> {
                 // 경험나누기로 연결된 첫 쪽지
-                // targetId에 내(sender) userId가 들어있음
+                // 나에게 온 HELP 알림 조회
                 List<Notification> helpNotifications = notificationRepository
-                        .findByNotificationTypeAndTargetId(NotificationType.HELP, user.getUserId());
+                        .findByReceiverAndNotificationType(user, NotificationType.HELP);
 
                 for (Notification notification : helpNotifications) {
-                    Long receiverId = notification.getReceiver().getUserId();
+                    Long senderId = notification.getTargetId();  // 도움 요청한 사람
 
+                    // 내가 그 사람에게 보낸 첫 쪽지 찾기
                     Message message = messageRepository.findFirstBySender_UserIdAndReceiver_UserIdOrderByCreatedAtAsc(
-                            user.getUserId(), receiverId
+                            user.getUserId(), senderId
                     ).orElse(null);
 
                     if (message != null) {


### PR DESCRIPTION
## 🔍 개요
솔방울 추억 회상 API에서 완료된 미션의 `memoryDetail`이 전부 `null`로 반환되던 문제를 수정했습니다.

솔방울(=완료 미션 3개 기반) 보유 사용자에 대해
`hasMemoryDetail=true` 및 `memoryDetail` 객체가 정상적으로 내려오도록
조회/매핑 로직을 보완했습니다.

## ✨ 변경 사항
- PineconeMemory 조회 로직 개선

## 🧪 테스트
- [x] 로컬 테스트 완료
- [ ] API 테스트 완료
- [ ] 테스트 코드 작성 (해당 시)

## 📎 관련 이슈
Closes: #120 

## ⚠️ 참고 사항
- 기존 응답 필드 구조는 유지하고, 누락되던 memoryDetail만 정상 세팅되도록 수정했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정

* **메시지 스레드 메모리 출처 결정 로직 개선** - HELP 알림 처리 방식을 개선하여 발신자 식별 정확도를 향상시켰습니다. 사용자가 수신한 알림을 바탕으로 올바른 메시지를 더 정확하게 연결합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->